### PR TITLE
Fixed [json.exception.type_error.302] type must be string, but is array

### DIFF
--- a/OcapReplaySaver2/OcapReplaySaver2.cpp
+++ b/OcapReplaySaver2/OcapReplaySaver2.cpp
@@ -1144,7 +1144,7 @@ void commandSave(const vector<string>& args) {
     j["endFrame"] = JSON_INT_FROM_ARG(4);
     if (args.size() > 5) {
         j["tags"] = JSON_STR_FROM_ARG(5);
-        config.newServerGameType = (json {JSON_STR_FROM_ARG(5)}).get<std::string>();
+        config.newServerGameType = JSON_STR_FROM_ARG(5);
     }
 
     prepareMarkerFrames(j["endFrame"]);


### PR DESCRIPTION
Error by trying to save with tag

```
2021-07-10 01:54:58,8609 140083735859136 [OcapReplaySaver2.cpp:1307:int RVExtensionArgs(char*, int, const char*, const char**, int)] TRACE :SAVE: 6:["vt7"::"opt_v41"::"Lord, form, eXcalibur, Fank, maxSzone, TeTeT"::1::180::"Test"] 
2021-07-10 01:54:58,8610 140083735859136 [OcapReplaySaver2.cpp:1307:int RVExtensionArgs(char*, int, const char*, const char**, int)] TRACE :LOG: 4:["Saved recording of mission"::"opt_v41"::"with tag"::"Test"] 
2021-07-10 01:54:58,8610 140081026402048 [OcapReplaySaver2.cpp:290:void perform_command(std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&)] TRACE :EVENT: 3:[180::"endMission"::["EAST","OPFOR triumphed over their enemy!"]] 
2021-07-10 01:54:58,8611 140081026402048 [OcapReplaySaver2.cpp:290:void perform_command(std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&)] TRACE :SAVE: 6:["vt7"::"opt_v41"::"Lord, form, eXcalibur, Fank, maxSzone, TeTeT"::1::180::"Test"] 
2021-07-10 01:54:58,8611 140081026402048 [OcapReplaySaver2.cpp:1142:void commandSave(const std::vector<std::__cxx11::basic_string<char> >&)] INFO "vt7" "opt_v41" "Lord, form, eXcalibur, Fank, maxSzone, TeTeT" 1 180 
2021-07-10 01:54:58,8612 140081026402048 [OcapReplaySaver2.cpp:305:void perform_command(std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&)] ERROR Exception:  [json.exception.type_error.302] type must be string, but is array 
2021-07-10 01:54:58,8612 140081026402048 [OcapReplaySaver2.cpp:322:void perform_command(std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&)] ERROR Return, parameters were: :SAVE: 6:["vt7"::"opt_v41"::"Lord, form, eXcalibur, Fank, maxSzone, TeTeT"::1::180::"Test"] 
2021-07-10 01:54:58,8613 140081026402048 [OcapReplaySaver2.cpp:290:void perform_command(std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&)] TRACE :LOG: 4:["Saved recording of mission"::"opt_v41"::"with tag"::"Test"] 
2021-07-10 01:54:58,8618 140083735859136 [OcapReplaySaver2.cpp:1307:int RVExtensionArgs(char*, int, const char*, const char**, int)] TRACE :LOG: 6:["fnc_exportData.sqf: RealyTime ="::180.146::" OcapTime ="::180::" delta ="::0.146011] 
2021-07-10 01:54:58,8619 140081026402048 [OcapReplaySaver2.cpp:290:void perform_command(std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&)] TRACE :LOG: 6:["fnc_exportData.sqf: RealyTime ="::180.146::" OcapTime ="::180::" delta ="::0.146011] 
```