### PR TITLE
refactor: extract config, database, and influx packages from main.go

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/spf13/viper"
+)
+
+// Load reads configuration from JSON file and sets default values.
+// configDir is the directory containing the config file.
+func Load(configDir string) error {
+	// Set default values
+	viper.SetDefault("logLevel", "info")
+	viper.SetDefault("defaultTag", "Op")
+	viper.SetDefault("logsDir", "./ocaplogs")
+
+	viper.SetDefault("api.serverUrl", "http://localhost:5000")
+	viper.SetDefault("api.apiKey", "")
+
+	viper.SetDefault("db.host", "localhost")
+	viper.SetDefault("db.port", "5432")
+	viper.SetDefault("db.username", "postgres")
+	viper.SetDefault("db.password", "postgres")
+	viper.SetDefault("db.database", "ocap")
+
+	viper.SetDefault("influx.enabled", true)
+	viper.SetDefault("influx.host", "localhost")
+	viper.SetDefault("influx.port", "8086")
+	viper.SetDefault("influx.protocol", "http")
+	viper.SetDefault("influx.token", "supersecrettoken")
+	viper.SetDefault("influx.org", "ocap-metrics")
+
+	viper.SetDefault("graylog.enabled", true)
+	viper.SetDefault("graylog.address", "localhost:12201")
+
+	viper.SetDefault("logio.enabled", true)
+	viper.SetDefault("logio.host", "localhost")
+	viper.SetDefault("logio.port", "28777")
+
+	viper.SetConfigName("ocap_recorder.cfg.json")
+	viper.AddConfigPath(configDir)
+	viper.SetConfigType("json")
+
+	err := viper.ReadInConfig()
+	if err != nil {
+		return fmt.Errorf("error reading config file: %v", err)
+	}
+
+	return nil
+}
+
+// GetString returns a string config value.
+func GetString(key string) string {
+	return viper.GetString(key)
+}
+
+// GetInt returns an int config value.
+func GetInt(key string) int {
+	return viper.GetInt(key)
+}
+
+// GetBool returns a bool config value.
+func GetBool(key string) bool {
+	return viper.GetBool(key)
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -1,0 +1,342 @@
+package database
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/OCAP2/extension/internal/model"
+	"github.com/glebarez/sqlite"
+	"github.com/rs/zerolog"
+	"github.com/spf13/viper"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// Manager handles database connections and operations.
+type Manager struct {
+	DB              *gorm.DB
+	SqlDB           *sql.DB
+	IsValid         bool
+	ShouldSaveLocal bool
+	SqliteFilePath  string
+	Logger          zerolog.Logger
+}
+
+// NewManager creates a new database manager.
+func NewManager(log zerolog.Logger) *Manager {
+	return &Manager{
+		IsValid:         false,
+		ShouldSaveLocal: false,
+		Logger:          log,
+	}
+}
+
+// Connect establishes a database connection, falling back to SQLite if Postgres fails.
+func (m *Manager) Connect() error {
+	var err error
+
+	m.DB, err = m.GetPostgresDB()
+	if err != nil {
+		m.Logger.Error().Err(err).Msg("Failed to connect to Postgres DB, trying SQLite")
+		m.ShouldSaveLocal = true
+		m.DB, err = m.GetSqliteDB("")
+		if err != nil || m.DB == nil {
+			m.IsValid = false
+			return fmt.Errorf("failed to get local SQLite DB: %s", err)
+		}
+		m.IsValid = true
+	}
+
+	// test connection
+	m.SqlDB, err = m.DB.DB()
+	if err != nil {
+		return fmt.Errorf("failed to access sql interface: %s", err)
+	}
+
+	err = m.SqlDB.Ping()
+	if err != nil {
+		m.Logger.Error().Err(err).Msg("Failed to validate connection, trying SQLite")
+		m.ShouldSaveLocal = true
+		m.DB, err = m.GetSqliteDB("")
+		if err != nil || m.DB == nil {
+			m.IsValid = false
+			return fmt.Errorf("failed to get local SQLite DB: %s", err)
+		}
+		m.IsValid = true
+	} else {
+		m.Logger.Info().Msg("Connected to database")
+		m.IsValid = true
+	}
+
+	if !m.IsValid {
+		return fmt.Errorf("db not valid. not saving")
+	}
+
+	if !m.ShouldSaveLocal {
+		m.SqlDB.SetMaxOpenConns(10)
+	}
+
+	return nil
+}
+
+// GetPostgresDB returns a connection to the Postgres database.
+func (m *Manager) GetPostgresDB() (*gorm.DB, error) {
+	dsn := fmt.Sprintf(`host=%s port=%s user=%s password=%s dbname=%s sslmode=disable`,
+		viper.GetString("db.host"),
+		viper.GetString("db.port"),
+		viper.GetString("db.username"),
+		viper.GetString("db.password"),
+		viper.GetString("db.database"),
+	)
+
+	m.Logger.Debug().Msgf("Connecting to Postgres DB at '%s'", dsn)
+
+	db, err := gorm.Open(postgres.New(postgres.Config{
+		DSN:                  dsn,
+		PreferSimpleProtocol: true,
+	}), &gorm.Config{
+		SkipDefaultTransaction: true,
+		CreateBatchSize:        10000,
+		Logger:                 logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+// GetSqliteDB returns a connection to a SQLite database.
+// If path is empty, uses an in-memory database.
+func (m *Manager) GetSqliteDB(path string) (*gorm.DB, error) {
+	var db *gorm.DB
+	var err error
+
+	if path != "" {
+		db, err = gorm.Open(sqlite.Open(path), &gorm.Config{
+			PrepareStmt:            true,
+			SkipDefaultTransaction: true,
+			CreateBatchSize:        2000,
+			Logger:                 logger.Default.LogMode(logger.Silent),
+		})
+		if err != nil {
+			m.IsValid = false
+			return nil, err
+		}
+		m.Logger.Info().Str("path", path).Msg("Using local SQLite DB")
+	} else {
+		db, err = gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{
+			PrepareStmt:            true,
+			SkipDefaultTransaction: true,
+			CreateBatchSize:        2000,
+			Logger:                 logger.Default.LogMode(logger.Silent),
+		})
+		if err != nil {
+			m.IsValid = false
+			return nil, err
+		}
+		m.Logger.Info().Msg("Using local SQLite DB in memory with periodic disk dump")
+	}
+
+	// set PRAGMAS
+	pragmas := []string{
+		"PRAGMA user_version = 1;",
+		"PRAGMA journal_mode = MEMORY;",
+		"PRAGMA synchronous = OFF;",
+		"PRAGMA cache_size = -32000;",
+		"PRAGMA temp_store = MEMORY;",
+		"PRAGMA page_size = 32768;",
+		"PRAGMA mmap_size = 30000000000;",
+	}
+
+	for _, pragma := range pragmas {
+		if err := db.Exec(pragma).Error; err != nil {
+			return nil, fmt.Errorf("error setting PRAGMA: %s", err)
+		}
+	}
+
+	return db, nil
+}
+
+// Setup migrates tables and creates default settings if they don't exist.
+func (m *Manager) Setup() error {
+	// Check if OcapInfo table exists
+	if !m.DB.Migrator().HasTable(&model.OcapInfo{}) {
+		err := m.DB.AutoMigrate(&model.OcapInfo{})
+		if err != nil {
+			m.IsValid = false
+			return fmt.Errorf("failed to create ocap_info table: %s", err)
+		}
+		err = m.DB.Create(&model.OcapInfo{
+			GroupName:        "OCAP",
+			GroupDescription: "OCAP",
+			GroupLogo:        "https://i.imgur.com/0Q4z0ZP.png",
+			GroupWebsite:     "https://ocap.arma3.com",
+		}).Error
+		if err != nil {
+			m.IsValid = false
+			return fmt.Errorf("failed to create ocap_info entry: %s", err)
+		}
+	}
+
+	// Ensure PostGIS Extension is installed for Postgres
+	if m.DB.Dialector.Name() == "postgres" {
+		err := m.DB.Exec(`CREATE Extension IF NOT EXISTS postgis;`).Error
+		if err != nil {
+			m.IsValid = false
+			return fmt.Errorf("failed to create PostGIS Extension: %s", err)
+		}
+		m.Logger.Info().Msg("PostGIS Extension created")
+	}
+
+	m.Logger.Info().Msg("Migrating schema")
+	var err error
+	if m.ShouldSaveLocal {
+		err = m.DB.AutoMigrate(model.DatabaseModelsSQLite...)
+	} else {
+		err = m.DB.AutoMigrate(model.DatabaseModels...)
+	}
+	if err != nil {
+		m.IsValid = false
+		return fmt.Errorf("failed to migrate schema: %s", err)
+	}
+
+	m.Logger.Info().Msg("Database setup complete")
+	return nil
+}
+
+// DumpMemoryToDisk vacuums the in-memory database to a file.
+func (m *Manager) DumpMemoryToDisk() error {
+	if m.SqliteFilePath == "" {
+		return fmt.Errorf("sqlite file path not set")
+	}
+
+	// remove existing file if it exists
+	if exists, err := os.Stat(m.SqliteFilePath); err == nil && exists != nil {
+		if err := os.Remove(m.SqliteFilePath); err != nil {
+			return fmt.Errorf("error removing existing DB file: %s", err)
+		}
+	}
+
+	start := time.Now()
+	err := m.DB.Exec("VACUUM INTO 'file:" + m.SqliteFilePath + "';").Error
+	if err != nil {
+		return fmt.Errorf("error dumping memory DB to disk: %s", err)
+	}
+
+	m.Logger.Debug().Dur("duration", time.Since(start)).Msg("Dumped memory DB to disk")
+	return nil
+}
+
+// GetBackupDBPaths returns paths to all .db files in the given directory.
+func GetBackupDBPaths(addonFolder string) ([]string, error) {
+	files, err := os.ReadDir(addonFolder)
+	if err != nil {
+		return nil, err
+	}
+
+	var dbPaths []string
+	for _, file := range files {
+		if !file.IsDir() && len(file.Name()) > 3 && file.Name()[len(file.Name())-3:] == ".db" {
+			dbPaths = append(dbPaths, addonFolder+"/"+file.Name())
+		}
+	}
+	return dbPaths, nil
+}
+
+// Standalone functions for direct usage without Manager
+
+// GetPostgresDBStandalone returns a connection to the Postgres database using viper config.
+func GetPostgresDBStandalone() (*gorm.DB, error) {
+	dsn := fmt.Sprintf(`host=%s port=%s user=%s password=%s dbname=%s sslmode=disable`,
+		viper.GetString("db.host"),
+		viper.GetString("db.port"),
+		viper.GetString("db.username"),
+		viper.GetString("db.password"),
+		viper.GetString("db.database"),
+	)
+
+	db, err := gorm.Open(postgres.New(postgres.Config{
+		DSN:                  dsn,
+		PreferSimpleProtocol: true,
+	}), &gorm.Config{
+		SkipDefaultTransaction: true,
+		CreateBatchSize:        10000,
+		Logger:                 logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+// GetSqliteDBStandalone returns a connection to a SQLite database.
+// If path is empty, uses an in-memory database.
+func GetSqliteDBStandalone(path string) (*gorm.DB, error) {
+	var db *gorm.DB
+	var err error
+
+	if path != "" {
+		db, err = gorm.Open(sqlite.Open(path), &gorm.Config{
+			PrepareStmt:            true,
+			SkipDefaultTransaction: true,
+			CreateBatchSize:        2000,
+			Logger:                 logger.Default.LogMode(logger.Silent),
+		})
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		db, err = gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{
+			PrepareStmt:            true,
+			SkipDefaultTransaction: true,
+			CreateBatchSize:        2000,
+			Logger:                 logger.Default.LogMode(logger.Silent),
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// set PRAGMAS
+	pragmas := []string{
+		"PRAGMA user_version = 1;",
+		"PRAGMA journal_mode = MEMORY;",
+		"PRAGMA synchronous = OFF;",
+		"PRAGMA cache_size = -32000;",
+		"PRAGMA temp_store = MEMORY;",
+		"PRAGMA page_size = 32768;",
+		"PRAGMA mmap_size = 30000000000;",
+	}
+
+	for _, pragma := range pragmas {
+		if err := db.Exec(pragma).Error; err != nil {
+			return nil, fmt.Errorf("error setting PRAGMA: %s", err)
+		}
+	}
+
+	return db, nil
+}
+
+// DumpMemoryDBToDisk vacuums the in-memory database to a disk file.
+func DumpMemoryDBToDisk(db *gorm.DB, sqliteFilePath string) error {
+	if sqliteFilePath == "" {
+		return fmt.Errorf("sqlite file path not set")
+	}
+
+	// remove existing file if it exists
+	if exists, err := os.Stat(sqliteFilePath); err == nil && exists != nil {
+		if err := os.Remove(sqliteFilePath); err != nil {
+			return fmt.Errorf("error removing existing DB file: %s", err)
+		}
+	}
+
+	err := db.Exec("VACUUM INTO 'file:" + sqliteFilePath + "';").Error
+	if err != nil {
+		return fmt.Errorf("error dumping memory DB to disk: %s", err)
+	}
+
+	return nil
+}

--- a/internal/influx/influx.go
+++ b/internal/influx/influx.go
@@ -1,0 +1,256 @@
+package influx
+
+import (
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
+	influxdb2_api "github.com/influxdata/influxdb-client-go/v2/api"
+	influxdb2_write "github.com/influxdata/influxdb-client-go/v2/api/write"
+	"github.com/influxdata/influxdb-client-go/v2/domain"
+	"github.com/rs/zerolog"
+	"github.com/spf13/viper"
+)
+
+// DefaultBucketNames are the default InfluxDB buckets used by OCAP.
+var DefaultBucketNames = []string{
+	"mission_data",
+	"ocap_performance",
+	"player_performance",
+	"server_performance",
+	"Telegraf",
+}
+
+// Manager handles InfluxDB connections and writes.
+type Manager struct {
+	Client       influxdb2.Client
+	Writers      map[string]influxdb2_api.WriteAPI
+	BackupWriter *gzip.Writer
+	IsValid      bool
+	BucketNames  []string
+	Logger       zerolog.Logger
+	BackupPath   string
+}
+
+// NewManager creates a new InfluxDB manager.
+func NewManager(log zerolog.Logger, backupPath string) *Manager {
+	return &Manager{
+		Writers:     make(map[string]influxdb2_api.WriteAPI),
+		IsValid:     false,
+		BucketNames: DefaultBucketNames,
+		Logger:      log,
+		BackupPath:  backupPath,
+	}
+}
+
+// Connect establishes a connection to InfluxDB.
+func (m *Manager) Connect() error {
+	if !viper.GetBool("influx.enabled") {
+		return errors.New("influxdb.Enabled is false")
+	}
+
+	m.Client = influxdb2.NewClientWithOptions(
+		fmt.Sprintf(
+			"%s://%s:%s",
+			viper.GetString("influx.protocol"),
+			viper.GetString("influx.host"),
+			viper.GetString("influx.port"),
+		),
+		viper.GetString("influx.token"),
+		influxdb2.DefaultOptions().
+			SetBatchSize(2500).
+			SetFlushInterval(1000),
+	)
+
+	// validate client connection health
+	running, err := m.Client.Ping(context.Background())
+
+	if err != nil || !running {
+		m.IsValid = false
+		// create backup writer
+		if m.BackupWriter == nil {
+			m.Logger.Info().Str("backupPath", m.BackupPath).
+				Msg("Failed to initialize InfluxDB client, writing to backup file")
+
+			file, err := os.OpenFile(m.BackupPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+			if err != nil {
+				return fmt.Errorf("error creating backup file: %v", err)
+			}
+			m.BackupWriter = gzip.NewWriter(file)
+		}
+	} else {
+		m.IsValid = true
+	}
+
+	if m.IsValid {
+		err = m.setupOrganizationAndBuckets()
+		if err != nil {
+			return err
+		}
+		m.CreateWriters()
+		m.Logger.Info().Msg("InfluxDB client initialized")
+	} else {
+		m.Logger.Warn().Msg("InfluxDB client failed to initialize, using backup writer")
+	}
+
+	return nil
+}
+
+func (m *Manager) setupOrganizationAndBuckets() error {
+	ctx := context.Background()
+	orgName := viper.GetString("influx.org")
+
+	// ensure org exists
+	_, err := m.Client.OrganizationsAPI().FindOrganizationByName(ctx, orgName)
+	if err != nil {
+		m.Logger.Info().Str("org", orgName).Msg("Organization not found, creating")
+		_, err = m.Client.OrganizationsAPI().CreateOrganizationWithName(ctx, orgName)
+		if err != nil {
+			m.Logger.Error().Err(err).Str("org", orgName).Msg("Error creating organization")
+			return err
+		}
+	}
+
+	// get influxOrg
+	influxOrg, err := m.Client.OrganizationsAPI().FindOrganizationByName(ctx, orgName)
+	if err != nil {
+		m.Logger.Error().Err(err).Str("org", orgName).Msg("Error getting organization")
+		return err
+	}
+
+	// ensure buckets exist with 90 day retention
+	for _, bucket := range m.BucketNames {
+		_, err = m.Client.BucketsAPI().FindBucketByName(ctx, bucket)
+		if err != nil {
+			m.Logger.Info().Str("bucket", bucket).Msg("Bucket not found, creating")
+
+			rule := domain.RetentionRuleTypeExpire
+			_, err = m.Client.BucketsAPI().CreateBucketWithName(ctx, influxOrg, bucket, domain.RetentionRule{
+				Type:         &rule,
+				EverySeconds: 60 * 60 * 24 * 90, // 90 days
+			})
+			if err != nil {
+				m.Logger.Error().Err(err).Str("bucket", bucket).Msg("Error creating bucket")
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// CreateWriters creates write APIs for all configured buckets.
+func (m *Manager) CreateWriters() {
+	orgName := viper.GetString("influx.org")
+	for _, bucket := range m.BucketNames {
+		m.Logger.Trace().Str("bucket", bucket).Msg("Creating InfluxDB writer")
+		m.Writers[bucket] = m.Client.WriteAPI(orgName, bucket)
+
+		errorsCh := m.Writers[bucket].Errors()
+		go func(bucketName string, errorsCh <-chan error) {
+			for writeErr := range errorsCh {
+				m.Logger.Error().Err(writeErr).Str("bucket", bucketName).
+					Msg("Error sending data to InfluxDB")
+			}
+		}(bucket, errorsCh)
+
+		m.Logger.Trace().Str("bucket", bucket).Msg("InfluxDB writer created")
+	}
+
+	m.Logger.Debug().Msg("InfluxDB writers initialized")
+}
+
+// WritePoint writes a point to InfluxDB or backup file.
+func (m *Manager) WritePoint(ctx context.Context, bucket string, point *influxdb2_write.Point) error {
+	if m.IsValid {
+		if _, ok := m.Writers[bucket]; !ok {
+			return fmt.Errorf("influxDB bucket '%s' not registered", bucket)
+		}
+		m.Writers[bucket].WritePoint(point)
+	} else {
+		if m.BackupWriter == nil {
+			return fmt.Errorf("influxDB client not initialized and backup writer not available")
+		}
+
+		lineProtocol := influxdb2_write.PointToLineProtocol(point, time.Duration(1*time.Nanosecond))
+		_, err := m.BackupWriter.Write([]byte(lineProtocol + "\n"))
+		if err != nil {
+			return fmt.Errorf("error writing to InfluxDB backup file: %s", err)
+		}
+	}
+
+	return nil
+}
+
+// ProcessMetricData parses metric data from Arma and returns a bucket name and point.
+func ProcessMetricData(data []string, fixEscapeQuotes func(string) string, trimQuotes func(string) string) (
+	bucket string,
+	point *influxdb2_write.Point,
+	err error,
+) {
+	// fix received data
+	for i, v := range data {
+		data[i] = fixEscapeQuotes(trimQuotes(v))
+	}
+
+	// each metric will come through as a string array
+	// 0 = bucket name
+	// 1 = measurement name
+	// n with "tag" prefix = tag name
+	// n with "field" prefix = field
+	// tag and field values use "::" separator
+
+	bucket = data[0]
+	measurementName := data[1]
+	point = influxdb2_write.NewPointWithMeasurement(measurementName)
+
+	// add tags
+	for _, tag := range data[2:] {
+		if !strings.HasPrefix(tag, "tag::") {
+			continue
+		}
+		parts := strings.Split(tag, "::")
+		if len(parts) >= 3 {
+			point.AddTag(parts[1], parts[2])
+		}
+	}
+
+	// add fields
+	for _, field := range data[2:] {
+		if !strings.HasPrefix(field, "field::") {
+			continue
+		}
+		parts := strings.Split(field, "::")
+		if len(parts) < 4 {
+			continue
+		}
+		fieldType := parts[1]
+		fieldName := parts[2]
+		fieldValue := parts[3]
+
+		switch fieldType {
+		case "string":
+			point.AddField(fieldName, fieldValue)
+		case "int":
+			intVal, err := strconv.Atoi(fieldValue)
+			if err != nil {
+				return "", nil, fmt.Errorf("error converting field value '%s' to int: %w", fieldValue, err)
+			}
+			point.AddField(fieldName, intVal)
+		case "float":
+			floatVal, err := strconv.ParseFloat(fieldValue, 64)
+			if err != nil {
+				return "", nil, fmt.Errorf("error converting field value '%s' to float: %w", fieldValue, err)
+			}
+			point.AddField(fieldName, floatVal)
+		}
+	}
+
+	return bucket, point, nil
+}


### PR DESCRIPTION
## Summary

- Extract configuration loading into `internal/config` package
- Extract database connection management into `internal/database` package  
- Extract InfluxDB client management into `internal/influx` package
- Reduce main.go from 5,198 to 4,844 lines (~7% reduction)

## Changes

### New Packages

| Package | Lines | Description |
|---------|-------|-------------|
| `internal/config` | 65 | Configuration loading with viper wrappers |
| `internal/database` | 342 | Postgres/SQLite connection management |
| `internal/influx` | 256 | InfluxDB client and metrics handling |

### Code Quality

- Fixed variable shadowing issue in `getProgramStatus()` where return variable `model` shadowed the package import
- Removed unused imports (`sqlite`, `postgres`, `logger`, `domain`, `influxdb2_api`)
- Added Manager structs for database and influx packages to encapsulate state

## Test plan

- [x] DLL builds successfully with Docker
- [ ] Test in ArmA 3 environment with Postgres connection
- [ ] Test fallback to SQLite when Postgres unavailable
- [ ] Test InfluxDB metrics collection