### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,9 +21,9 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -35,14 +35,14 @@ jobs:
         run: go test -coverprofile=cover.out -coverpkg=./internal/... ./internal/...
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: code-coverage
           path: cover.out
 
       - name: Download artifact (main.breakdown)
         id: download-main-breakdown
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         if: github.event_name == 'pull_request'
         with:
           branch: main
@@ -52,7 +52,7 @@ jobs:
 
       - name: Check test coverage
         id: coverage
-        uses: vladopajic/go-test-coverage/action/source@v2
+        uses: vladopajic/go-test-coverage/action/source@679e6807f68f2440a4c43d386442a1d0041838a9 # v2
         with:
           profile: cover.out
           git-token: ${{ github.ref_name == 'main' && secrets.GITHUB_TOKEN || '' }}
@@ -61,7 +61,7 @@ jobs:
           diff-base-breakdown-file-name: ${{ steps.download-main-breakdown.outputs.found_artifact == 'true' && 'main.breakdown' || '' }}
 
       - name: Upload artifact (main.breakdown)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: github.ref_name == 'main'
         with:
           name: main.breakdown
@@ -73,7 +73,7 @@ jobs:
     if: github.event_name != 'pull_request' || (!github.event.pull_request.draft && !contains(github.event.pull_request.title, 'WIP'))
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build x64 DLL
         run: |
@@ -81,7 +81,7 @@ jobs:
             go build -buildvcs=false -o dist/ocap_recorder_x64.dll -buildmode=c-shared ./cmd/ocap_recorder
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dll-artifacts
           path: dist/ocap_recorder_x64.dll
@@ -98,7 +98,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: fgrosse/go-coverage-report@v1.2.0
+      - uses: fgrosse/go-coverage-report@5226a7eae769f316df554bead7a716fcfd78130f # v1.2.0
         with:
           coverage-artifact-name: "code-coverage"
           coverage-file-name: "cover.out"


### PR DESCRIPTION
## Summary

Pin all GitHub Actions to their full commit SHA for improved security and reproducibility.

## Actions Pinned

| Action | Version | SHA |
|--------|---------|-----|
| actions/checkout | v4 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| actions/setup-go | v5 | `40f1582b2485089dde7abd97c1529aa768e1baff` |
| actions/upload-artifact | v4 | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| dawidd6/action-download-artifact | v6 | `bf251b5aa9c2f7eeb574a96ee720e24f801b7c11` |
| vladopajic/go-test-coverage | v2 | `679e6807f68f2440a4c43d386442a1d0041838a9` |
| fgrosse/go-coverage-report | v1.2.0 | `5226a7eae769f316df554bead7a716fcfd78130f` |

## Why

- Prevents supply chain attacks via compromised action tags
- Ensures reproducible builds
- Dependabot will still create PRs to update these SHAs