### PR TITLE
chore: upgrade Go from 1.21 to 1.24

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Build x64 DLL
         run: |
-          docker run --rm -v "${{ github.workspace }}:/go/work" -w /go/work x1unix/go-mingw:1.20 \
+          docker run --rm -v "${{ github.workspace }}:/go/work" -w /go/work x1unix/go-mingw:1.24 \
             go build -buildvcs=false -o dist/ocap_recorder_x64.dll -buildmode=c-shared ./cmd/ocap_recorder
 
       - name: Upload build artifacts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,13 +10,13 @@ Go native DLL extension for ArmA 3 that records gameplay/mission replay data to 
 
 ```bash
 # Pull Docker image
-docker pull x1unix/go-mingw:1.20
+docker pull x1unix/go-mingw:1.24
 
 # Build x64 Windows DLL
-docker run --rm -v ${PWD}:/go/work -w /go/work x1unix/go-mingw:1.20 go build -o dist/ocap_recorder_x64.dll -buildmode=c-shared ./cmd/ocap_recorder
+docker run --rm -v ${PWD}:/go/work -w /go/work x1unix/go-mingw:1.24 go build -o dist/ocap_recorder_x64.dll -buildmode=c-shared ./cmd/ocap_recorder
 
 # Build x86 Windows DLL
-docker run --rm -v ${PWD}:/go/work -w /go/work -e GOARCH=386 x1unix/go-mingw:1.20 go build -o dist/ocap_recorder.dll -buildmode=c-shared ./cmd/ocap_recorder
+docker run --rm -v ${PWD}:/go/work -w /go/work -e GOARCH=386 x1unix/go-mingw:1.24 go build -o dist/ocap_recorder.dll -buildmode=c-shared ./cmd/ocap_recorder
 ```
 
 **Output:** `dist/ocap_recorder_x64.dll` or `dist/ocap_recorder.dll`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build Golang app for Linux
-FROM golang:1.20
+FROM golang:1.24
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/OCAP2/extension
 
-go 1.21
+go 1.24
 
 require (
 	github.com/Graylog2/go-gelf v0.0.0-20170811154226-7ebf4f536d8f


### PR DESCRIPTION
## Summary

- Upgrade Go version from 1.21 to 1.24
- Update Docker build images to use `x1unix/go-mingw:1.24`
- Update Dockerfile base image to `golang:1.24`

## Research: Go Version Compatibility

### Windows Version Support by Go Version

| Go Version | Windows Support | Notes |
|------------|-----------------|-------|
| **Go 1.20** | Windows 7+ / Server 2008 R2+ | Last version supporting Windows 7 |
| **Go 1.21-1.24** | Windows 10+ / Server 2016+ | Current stable range |
| **Go 1.25** | Windows 10+ / Server 2016+ | Requires binutils 2.37+ for CGo |

### ArmA 3 Compatibility

ArmA 3 officially supports **Windows 7 SP1 (64-bit)** as minimum. However:
- Windows 7 reached end-of-life in January 2020
- Windows 7/8 market share is negligible in 2025
- The previous Go 1.21 version already dropped Windows 7/8 support

### Linux Considerations

| Component | Requirement |
|-----------|-------------|
| **Kernel** | Go 1.24+ requires Linux 3.2+ (Ubuntu 12.04+) |
| **glibc** (CGo) | Build on oldest target system for portability |
| **gcc** (CGo) | 4.6+ (Go 1.25 will need binutils 2.37+) |

The `x1unix/go-mingw:1.24` image uses Alpine with binutils 2.43, which also meets future Go 1.25 requirements.

### Why Go 1.24?

1. **Already dropped Windows 7/8** - Project was at Go 1.21 which already requires Windows 10+
2. **Stable release** - Go 1.24 is the current stable version (released Feb 2025)
3. **Future-proof toolchain** - The go-mingw image includes binutils 2.43, ready for Go 1.25
4. **Performance improvements** - Go 1.24 includes runtime and toolchain optimizations

### Sources

- [Go Minimum Requirements](https://go.dev/wiki/MinimumRequirements)
- [Go 1.24 Release Notes](https://go.dev/doc/go1.24)
- [Windows 7 support removal (Go 1.21)](https://github.com/golang/go/issues/57003)
- [x1unix/docker-go-mingw releases](https://github.com/x1unix/docker-go-mingw/releases)
- [ArmA 3 System Requirements](https://arma3.com/requirements)

## Changes

- `go.mod`: 1.21 → 1.24
- `Dockerfile`: golang:1.20 → golang:1.24
- `CLAUDE.md`: x1unix/go-mingw:1.20 → x1unix/go-mingw:1.24
- `.github/workflows/go.yml`: x1unix/go-mingw:1.20 → x1unix/go-mingw:1.24

## Test plan

- [x] CI build passes with new Go version
- [x] DLL builds successfully with x1unix/go-mingw:1.24
- [ ] Extension loads correctly in ArmA 3