### PR TITLE
refactor: extract internal packages from main.go

### DIFF
--- a/cmd/ocap_recorder/main.go
+++ b/cmd/ocap_recorder/main.go
@@ -12,15 +12,12 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math"
 	"math/rand"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -30,19 +27,18 @@ import (
 	"github.com/OCAP2/extension/internal/cache"
 	"github.com/OCAP2/extension/internal/config"
 	"github.com/OCAP2/extension/internal/database"
-	"github.com/OCAP2/extension/internal/geo"
+	"github.com/OCAP2/extension/internal/handlers"
 	"github.com/OCAP2/extension/internal/influx"
+	"github.com/OCAP2/extension/internal/logging"
 	"github.com/OCAP2/extension/internal/model"
-	"github.com/OCAP2/extension/internal/queue"
+	"github.com/OCAP2/extension/internal/monitor"
 	"github.com/OCAP2/extension/internal/util"
+	"github.com/OCAP2/extension/internal/worker"
 	"github.com/OCAP2/extension/pkg/a3interface"
 
-	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 	influxdb2_write "github.com/influxdata/influxdb-client-go/v2/api/write"
 	"github.com/spf13/viper"
 
-	"github.com/Graylog2/go-gelf/gelf"
-	geom "github.com/peterstace/simplefeatures/geom"
 	"github.com/rs/zerolog"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -84,7 +80,6 @@ var (
 
 // global variables
 var (
-
 	// DB is the GORM DB interface
 	DB *gorm.DB
 
@@ -100,18 +95,12 @@ var (
 	// InfluxManager handles InfluxDB connections
 	InfluxManager *influx.Manager
 
-	// LogIoConn is the connection to the log.io service
-	LogIoConn net.Conn
-	// NullByte is a byte slice containing a single null byte
-	NullByte byte = 0x00
+	// LogManager handles all logging
+	LogManager *logging.Manager
 
-	// GraylogWriter is the GELF writer
-	GraylogWriter *gelf.Writer
-
-	// Logger writes to console and file in line format
+	// Logger writes to console and file in line format (convenience reference)
 	Logger zerolog.Logger
-	// TraceSample will write sampled DB status errors in case of connection issues
-	TraceSample zerolog.Logger
+
 	// JSONLogger is hooked from Logger and writes to JSONL file
 	JSONLogger zerolog.Logger
 
@@ -125,270 +114,20 @@ var (
 	EntityCache *cache.EntityCache = cache.NewEntityCache()
 
 	// MarkerCache maps marker names to their database IDs for the current mission
-	MarkerCache     = make(map[string]uint)
-	MarkerCacheLock sync.RWMutex
+	MarkerCache *cache.MarkerCache = cache.NewMarkerCache()
 
-	SessionStartTime       time.Time = time.Now()
-	LastDBWriteDuration    time.Duration
-	IsStatusProcessRunning bool = false
+	SessionStartTime time.Time = time.Now()
 
 	addonVersion string = "unknown"
+
+	// Services
+	handlerService *handlers.Service
+	workerManager  *worker.Manager
+	monitorService *monitor.Service
+	queues         *worker.Queues
 )
 
 // channels
-var (
-	// caches of processed models pending DB write
-	soldiersToWrite              = queue.SoldiersQueue{}
-	soldierStatesToWrite         = queue.SoldierStatesQueue{}
-	vehiclesToWrite              = queue.VehiclesQueue{}
-	vehicleStatesToWrite         = queue.VehicleStatesQueue{}
-	firedEventsToWrite           = queue.FiredEventsQueue{}
-	projectileEventsToWrite      = queue.ProjectileEventsQueue{}
-	generalEventsToWrite         = queue.GeneralEventsQueue{}
-	hitEventsToWrite             = queue.HitEventsQueue{}
-	killEventsToWrite            = queue.KillEventsQueue{}
-	chatEventsToWrite            = queue.ChatEventsQueue{}
-	radioEventsToWrite           = queue.RadioEventsQueue{}
-	fpsEventsToWrite             = queue.FpsEventsQueue{}
-	ace3DeathEventsToWrite       = queue.Ace3DeathEventsQueue{}
-	ace3UnconsciousEventsToWrite = queue.Ace3UnconsciousEventsQueue{}
-	markersToWrite               = queue.MarkersQueue{}
-	markerStatesToWrite          = queue.MarkerStatesQueue{}
-
-)
-
-// init is run automatically when the module is loaded
-func init() {
-	var err error
-
-	ArmaDir, err = a3interface.GetArmaDir()
-	if err != nil {
-		panic(err)
-	}
-
-	ModulePath = a3interface.GetModulePath()
-	ModuleFolder = filepath.Dir(ModulePath)
-
-	// if the module dir is not the a3 root, we want to assume the addon folder has been renamed and adjust it accordingly
-	AddonFolder = filepath.Dir(ModulePath)
-
-	if AddonFolder == ArmaDir {
-		AddonFolder = filepath.Join(ArmaDir, "@"+Addon)
-	}
-
-	// check if parent folder exists
-	// if it doesn't, create it
-	if _, err := os.Stat(AddonFolder); os.IsNotExist(err) {
-		os.Mkdir(AddonFolder, 0755)
-	}
-
-	InitLogFilePath = filepath.Join(AddonFolder, "init.log")
-
-	InitLogFile, err = os.Create(InitLogFilePath)
-	if err != nil {
-		defer Logger.Warn().Err(err).Str("path", InitLogFilePath).
-			Msg("Failed to create/open log file!")
-	}
-	setupLogging(InitLogFile)
-
-	// load config
-	err = loadConfig()
-	if err != nil {
-		Logger.Warn().Err(err).Msg("Failed to load config, using defaults!")
-	} else {
-		Logger.Info().Msg("Loaded config")
-	}
-
-	// resolve path set in config
-	// create logs dir if it doesn't exist
-	if _, err := os.Stat(viper.GetString("logsDir")); os.IsNotExist(err) {
-		os.Mkdir(viper.GetString("logsDir"), 0755)
-	}
-
-	OcapLogFilePath = fmt.Sprintf(
-		`%s\%s.%s.log`,
-		viper.GetString("logsDir"),
-		ExtensionName,
-		SessionStartTime.Format("20060102_150405"),
-	)
-
-	// check if OcapLogFilePath exists
-	// if it does, move it to OcapLogFilePath.old
-	// if it doesn't, create it
-	if _, err := os.Stat(OcapLogFilePath); err == nil {
-		os.Rename(OcapLogFilePath, OcapLogFilePath+".old")
-	}
-
-	OcapLogFile, err = os.OpenFile(OcapLogFilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-	if err != nil {
-		Logger.Error().Err(err).Str("path", OcapLogFilePath).
-			Msg("Failed to create/open log file!")
-	}
-
-	Logger.Info().Str("path", OcapLogFilePath).Msg("Begin logging in logs directory")
-
-	// set up logging
-	setupLogging(OcapLogFile)
-	Logger.Info().Str("path", OcapLogFilePath).Msg("Logging to file")
-
-	SqliteDBFilePath = fmt.Sprintf(`%s\%s_%s.db`, AddonFolder, ExtensionName, SessionStartTime.Format("20060102_150405"))
-	InfluxBackupFilePath = AddonFolder + "\\influx_backup.log.gzip"
-	// set up a3interfaces
-	Logger.Info().Msg("Setting up a3interface...")
-	err = setupA3Interface()
-	if err != nil {
-		Logger.Fatal().Err(err).Msg("Failed to set up a3interfaces!")
-	} else {
-		Logger.Info().Msg("Set up a3interfaces")
-	}
-
-	// get count of cpus available
-	// set GOMAXPROCS to n - 2, minimum 2
-	// this is to ensure we're using all available cores
-
-	// get number of CPUs
-	numCPUs := runtime.NumCPU()
-	Logger.Debug().Int("numCPUs", numCPUs).Msg("Number of CPUs")
-
-	// set GOMAXPROCS
-	runtime.GOMAXPROCS(int(math.Max(float64(numCPUs-2), 1)))
-
-	go func() {
-		startGoroutines()
-
-		// log frontend status
-		checkServerStatus()
-	}()
-}
-
-func initExtension() {
-	// send ready callback to Arma
-	a3interface.WriteArmaCallback(ExtensionName, ":EXT:READY:")
-	// send extension version
-	a3interface.WriteArmaCallback(ExtensionName, ":VERSION:", CurrentExtensionVersion)
-}
-
-func setupLogging(file *os.File) {
-
-	// get log level
-	var logLevelActual zerolog.Level
-	switch strings.ToUpper(viper.GetString("logLevel")) {
-	case "DEBUG":
-		logLevelActual = zerolog.DebugLevel
-	case "INFO":
-		logLevelActual = zerolog.InfoLevel
-	case "WARN":
-		logLevelActual = zerolog.WarnLevel
-	case "ERROR":
-		logLevelActual = zerolog.ErrorLevel
-	case "TRACE":
-		logLevelActual = zerolog.TraceLevel
-	default:
-		logLevelActual = zerolog.InfoLevel
-	}
-
-	// remove old logs (older than 7 days)
-	// removeOldLogs(viper.GetString("logsDir"), 7)
-
-	// set up logging
-	zerolog.SetGlobalLevel(logLevelActual)
-	zerolog.TimestampFunc = func() time.Time {
-		return time.Now().UTC()
-	}
-
-	// set up multi-level writer
-	mlw := zerolog.MultiLevelWriter(
-		// write console format with colors to console
-		zerolog.ConsoleWriter{
-			Out:        os.Stdout,
-			TimeFormat: time.RFC3339,
-		},
-		// write console format without colors to file
-		zerolog.ConsoleWriter{
-			Out:        file,
-			TimeFormat: time.RFC3339,
-			NoColor:    true,
-		},
-	)
-
-	Logger = zerolog.New(mlw).With().Timestamp().Logger().
-		Hook(
-			zerolog.HookFunc(
-				func(e *zerolog.Event, level zerolog.Level, msg string) {
-					// add current mission
-					// add runtime info
-					e.Bool("usingLocalDB", ShouldSaveLocal).
-						Str("currentMission", CurrentMission.MissionName).
-						Uint("currentMissionID", CurrentMission.ID).
-						Bool("statusMonitorActive", IsStatusProcessRunning)
-				}))
-
-	TraceSample = Logger.With().
-		Bool("asmpled", true).Logger().Sample(&zerolog.BurstSampler{
-		// allow max 5 entries per 10 seconds
-		// once reached, sample 1 in 100
-		Burst:       5,
-		Period:      10 * time.Second,
-		NextSampler: &zerolog.BasicSampler{N: 100},
-	})
-
-	Logger.Info().Str("loglevel", Logger.GetLevel().String()).Msg("Logging set up")
-}
-
-func writeToLogIo(level zerolog.Level, msg string) {
-	if LogIoConn == nil {
-		return
-	}
-	data := make([]byte, 0)
-	message := fmt.Sprintf(
-		`%s %s %s`,
-		time.Now().UTC().Format(time.RFC3339),
-		level.String(),
-		msg,
-	)
-	data = append(data, []byte(
-		"+msg|ocap2|ocap_recorder|"+message,
-	)...)
-	data = append(data, NullByte)
-
-	_, err := LogIoConn.Write(data)
-	if err != nil {
-		Logger.Debug().Err(err).Msg("Failed to send log to log.io")
-	}
-}
-
-// removeOldLogs will remove all .log and .jsonl files older than daysDelta days
-func removeOldLogs(path string, daysDelta int) {
-	files, err := os.ReadDir(path)
-	if err != nil {
-		Logger.Warn().Err(err).Msg("Failed to read logs dir")
-		return
-	}
-
-	for _, f := range files {
-		if f.IsDir() {
-			continue
-		}
-		// get file info
-		r, err := f.Info()
-		if err != nil {
-			Logger.Warn().Err(err).Msg("Failed to get file info")
-			continue
-		}
-		// check if file is a log file and if it's older than daysDelta days
-		if filepath.Ext(f.Name()) == ".log" || filepath.Ext(f.Name()) == ".jsonl" {
-			if time.Since(r.ModTime()).Hours() > float64(daysDelta*24) {
-				os.Remove(path + "\\" + f.Name())
-			}
-		}
-	}
-}
-
-// //////////////////////
-// A3Interface Section //
-// //////////////////////
-// A3Interface is the interface for interacting with Arma 3
-// These variables are used to communicate with it
 var (
 	// RVExtArgsDataChannels is a map of channels for receiving data from RVExtensionArgs
 	RVExtArgsDataChannels = map[string]chan []string{
@@ -431,6 +170,143 @@ var (
 	a3ErrorChan = make(chan []string, 50)
 )
 
+// init is run automatically when the module is loaded
+func init() {
+	var err error
+
+	ArmaDir, err = a3interface.GetArmaDir()
+	if err != nil {
+		panic(err)
+	}
+
+	ModulePath = a3interface.GetModulePath()
+	ModuleFolder = filepath.Dir(ModulePath)
+
+	// if the module dir is not the a3 root, we want to assume the addon folder has been renamed and adjust it accordingly
+	AddonFolder = filepath.Dir(ModulePath)
+
+	if AddonFolder == ArmaDir {
+		AddonFolder = filepath.Join(ArmaDir, "@"+Addon)
+	}
+
+	// check if parent folder exists
+	// if it doesn't, create it
+	if _, err := os.Stat(AddonFolder); os.IsNotExist(err) {
+		os.Mkdir(AddonFolder, 0755)
+	}
+
+	InitLogFilePath = filepath.Join(AddonFolder, "init.log")
+
+	InitLogFile, err = os.Create(InitLogFilePath)
+	if err != nil {
+		defer LogManager.Logger.Warn().Err(err).Str("path", InitLogFilePath).
+			Msg("Failed to create/open log file!")
+	}
+
+	// Initialize logging manager
+	LogManager = logging.NewManager()
+	LogManager.Setup(InitLogFile, viper.GetString("logLevel"))
+	Logger = LogManager.Logger
+
+	// load config
+	err = loadConfig()
+	if err != nil {
+		Logger.Warn().Err(err).Msg("Failed to load config, using defaults!")
+	} else {
+		Logger.Info().Msg("Loaded config")
+	}
+
+	// resolve path set in config
+	// create logs dir if it doesn't exist
+	if _, err := os.Stat(viper.GetString("logsDir")); os.IsNotExist(err) {
+		os.Mkdir(viper.GetString("logsDir"), 0755)
+	}
+
+	OcapLogFilePath = fmt.Sprintf(
+		`%s\%s.%s.log`,
+		viper.GetString("logsDir"),
+		ExtensionName,
+		SessionStartTime.Format("20060102_150405"),
+	)
+
+	// check if OcapLogFilePath exists
+	// if it does, move it to OcapLogFilePath.old
+	// if it doesn't, create it
+	if _, err := os.Stat(OcapLogFilePath); err == nil {
+		os.Rename(OcapLogFilePath, OcapLogFilePath+".old")
+	}
+
+	OcapLogFile, err = os.OpenFile(OcapLogFilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	if err != nil {
+		Logger.Error().Err(err).Str("path", OcapLogFilePath).
+			Msg("Failed to create/open log file!")
+	}
+
+	Logger.Info().Str("path", OcapLogFilePath).Msg("Begin logging in logs directory")
+
+	// set up logging
+	LogManager.Setup(OcapLogFile, viper.GetString("logLevel"))
+	Logger = LogManager.Logger
+	Logger.Info().Str("path", OcapLogFilePath).Msg("Logging to file")
+
+	// Set up dynamic state callbacks for logging
+	LogManager.GetMissionName = func() string {
+		if handlerService != nil {
+			return handlerService.GetMissionContext().GetMission().MissionName
+		}
+		return ""
+	}
+	LogManager.GetMissionID = func() uint {
+		if handlerService != nil {
+			return handlerService.GetMissionContext().GetMission().ID
+		}
+		return 0
+	}
+	LogManager.IsUsingLocalDB = func() bool { return ShouldSaveLocal }
+	LogManager.IsStatusRunning = func() bool {
+		if monitorService != nil {
+			return monitorService.IsRunning()
+		}
+		return false
+	}
+
+	SqliteDBFilePath = fmt.Sprintf(`%s\%s_%s.db`, AddonFolder, ExtensionName, SessionStartTime.Format("20060102_150405"))
+	InfluxBackupFilePath = AddonFolder + "\\influx_backup.log.gzip"
+	// set up a3interfaces
+	Logger.Info().Msg("Setting up a3interface...")
+	err = setupA3Interface()
+	if err != nil {
+		Logger.Fatal().Err(err).Msg("Failed to set up a3interfaces!")
+	} else {
+		Logger.Info().Msg("Set up a3interfaces")
+	}
+
+	// get count of cpus available
+	// set GOMAXPROCS to n - 2, minimum 2
+	// this is to ensure we're using all available cores
+
+	// get number of CPUs
+	numCPUs := runtime.NumCPU()
+	Logger.Debug().Int("numCPUs", numCPUs).Msg("Number of CPUs")
+
+	// set GOMAXPROCS
+	runtime.GOMAXPROCS(int(math.Max(float64(numCPUs-2), 1)))
+
+	go func() {
+		startGoroutines()
+
+		// log frontend status
+		checkServerStatus()
+	}()
+}
+
+func initExtension() {
+	// send ready callback to Arma
+	a3interface.WriteArmaCallback(ExtensionName, ":EXT:READY:")
+	// send extension version
+	a3interface.WriteArmaCallback(ExtensionName, ":VERSION:", CurrentExtensionVersion)
+}
+
 func initDB() (err error) {
 	Logger.Trace().Msg("Received :INIT:DB: call")
 	loadConfig()
@@ -438,17 +314,13 @@ func initDB() (err error) {
 	DB, err = getDB()
 	if err != nil || DB == nil {
 		// if we couldn't connect to the database, send a callback to the addon to let it know
-		writeLog(functionName, fmt.Sprintf(`Error connecting to database: %v`, err), "ERROR")
+		LogManager.WriteLog(functionName, fmt.Sprintf(`Error connecting to database: %v`, err), "ERROR")
 		a3interface.WriteArmaCallback(ExtensionName, ":DB:ERROR:", err.Error())
 	} else {
 		go func() {
-			// err = setupDB(DB)
-			// if err != nil {
-			// 	writeLog(functionName, fmt.Sprintf(`Error setting up database: %v`, err), "ERROR")
-			// }
 			err = connectToInflux()
 			if err != nil {
-				writeLog(functionName, fmt.Sprintf(`Error connecting to InfluxDB: %v`, err), "ERROR")
+				LogManager.WriteLog(functionName, fmt.Sprintf(`Error connecting to InfluxDB: %v`, err), "ERROR")
 			}
 			// only if everything worked should we send a callback letting the addon know we're ready to receive the mission data
 			a3interface.WriteArmaCallback(ExtensionName, ":DB:OK:", DB.Dialector.Name())
@@ -493,7 +365,11 @@ func setupA3Interface() (err error) {
 				addonVersion = util.FixEscapeQuotes(util.TrimQuotes(data[0]))
 				Logger.Info().Str("version", addonVersion).Msg("Addon version")
 			case data := <-RVExtArgsDataChannels[":NEW:MISSION:"]:
-				go logNewMission(data)
+				go func() {
+					if handlerService != nil {
+						handlerService.LogNewMission(data)
+					}
+				}()
 			}
 		}
 	}()
@@ -516,86 +392,6 @@ func checkServerStatus() {
 	} else {
 		Logger.Info().Msg("OCAP Frontend is online")
 	}
-}
-
-func getProgramStatus(
-	rawBuffers bool,
-	writeQueues bool,
-	lastWrite bool,
-) (output []string, perfModel model.OcapPerformance) {
-	// returns a slice of strings indicating raw arrays pending processing as rawBuffers
-	// returns a slice of strings indicating pending data to write to DB as writeQueues
-	// returns a string indicating the last write duration in ms as lastWrite
-
-	buffersObj := model.BufferLengths{
-		Soldiers:              uint16(len(RVExtArgsDataChannels[":NEW:SOLDIER:"])),
-		Vehicles:              uint16(len(RVExtArgsDataChannels[":NEW:VEHICLE:"])),
-		SoldierStates:         uint16(len(RVExtArgsDataChannels[":NEW:SOLDIER:STATE:"])),
-		VehicleStates:         uint16(len(RVExtArgsDataChannels[":NEW:VEHICLE:STATE:"])),
-		FiredEvents:           uint16(len(RVExtArgsDataChannels[":FIRED:"])),
-		GeneralEvents:         uint16(len(RVExtArgsDataChannels[":EVENT:"])),
-		HitEvents:             uint16(len(RVExtArgsDataChannels[":HIT:"])),
-		KillEvents:            uint16(len(RVExtArgsDataChannels[":KILL:"])),
-		ChatEvents:            uint16(len(RVExtArgsDataChannels[":CHAT:"])),
-		RadioEvents:           uint16(len(RVExtArgsDataChannels[":RADIO:"])),
-		ServerFpsEvents:       uint16(len(RVExtArgsDataChannels[":FPS:"])),
-		Ace3DeathEvents:       uint16(len(RVExtArgsDataChannels[":ACE3:DEATH:"])),
-		Ace3UnconsciousEvents: uint16(len(RVExtArgsDataChannels[":ACE3:UNCONSCIOUS:"])),
-		MarkerCreates:         uint16(len(RVExtArgsDataChannels[":MARKER:CREATE:"])),
-		MarkerMoves:           uint16(len(RVExtArgsDataChannels[":MARKER:MOVE:"])),
-		MarkerDeletes:         uint16(len(RVExtArgsDataChannels[":MARKER:DELETE:"])),
-	}
-
-	writeQueuesObj := model.WriteQueueLengths{
-		Soldiers:              uint16(soldiersToWrite.Len()),
-		Vehicles:              uint16(vehiclesToWrite.Len()),
-		SoldierStates:         uint16(soldierStatesToWrite.Len()),
-		VehicleStates:         uint16(vehicleStatesToWrite.Len()),
-		FiredEvents:           uint16(firedEventsToWrite.Len()),
-		GeneralEvents:         uint16(generalEventsToWrite.Len()),
-		HitEvents:             uint16(hitEventsToWrite.Len()),
-		KillEvents:            uint16(killEventsToWrite.Len()),
-		ChatEvents:            uint16(chatEventsToWrite.Len()),
-		RadioEvents:           uint16(radioEventsToWrite.Len()),
-		ServerFpsEvents:       uint16(fpsEventsToWrite.Len()),
-		Ace3DeathEvents:       uint16(ace3DeathEventsToWrite.Len()),
-		Ace3UnconsciousEvents: uint16(ace3UnconsciousEventsToWrite.Len()),
-		Markers:               uint16(markersToWrite.Len()),
-		MarkerStates:          uint16(markerStatesToWrite.Len()),
-	}
-
-	perf := model.OcapPerformance{
-		Time:              time.Now(),
-		Mission:           *CurrentMission,
-		BufferLengths:     buffersObj,
-		WriteQueueLengths: writeQueuesObj,
-		// get float32 in ms
-		LastWriteDurationMs: float32(LastDBWriteDuration.Milliseconds()),
-	}
-
-	if rawBuffers {
-		rawBuffersStr, err := json.MarshalIndent(buffersObj, "", "  ")
-		if err != nil {
-			rawBuffersStr = []byte(fmt.Sprintf(`{"error": "%s"}`, err))
-		}
-		output = append(output, string(rawBuffersStr))
-	}
-	if writeQueues {
-		writeQueuesStr, err := json.MarshalIndent(writeQueuesObj, "", "  ")
-		if err != nil {
-			writeQueuesStr = []byte(fmt.Sprintf(`{"error": "%s"}`, err))
-		}
-		output = append(output, string(writeQueuesStr))
-	}
-	if lastWrite {
-		lastWriteStr, err := json.MarshalIndent(perf.LastWriteDurationMs, "", "  ")
-		if err != nil {
-			lastWriteStr = []byte(fmt.Sprintf(`{"error": "%s"}`, err))
-		}
-		output = append(output, string(lastWriteStr))
-	}
-
-	return output, perf
 }
 
 // /////////////////////
@@ -638,9 +434,9 @@ func getSqliteDB(path string) (db *gorm.DB, err error) {
 		return nil, err
 	}
 	if path != "" {
-		writeLog(functionName, fmt.Sprintf("Using local SQlite DB at '%s'", path), "INFO")
+		LogManager.WriteLog(functionName, fmt.Sprintf("Using local SQlite DB at '%s'", path), "INFO")
 	} else {
-		writeLog(functionName, "Using local SQlite DB in memory with periodic disk dump", "INFO")
+		LogManager.WriteLog(functionName, "Using local SQlite DB in memory with periodic disk dump", "INFO")
 	}
 	return db, nil
 }
@@ -654,10 +450,10 @@ func dumpMemoryDBToDisk() (err error) {
 	start := time.Now()
 	err = database.DumpMemoryDBToDisk(DB, SqliteDBFilePath)
 	if err != nil {
-		writeLog(functionName, "Error dumping memory DB to disk", "ERROR")
+		LogManager.WriteLog(functionName, "Error dumping memory DB to disk", "ERROR")
 		return err
 	}
-	writeLog(functionName, fmt.Sprintf(`Dumped memory DB to disk in %s`, time.Since(start)), "INFO")
+	LogManager.WriteLog(functionName, fmt.Sprintf(`Dumped memory DB to disk in %s`, time.Since(start)), "INFO")
 	Logger.Debug().
 		Dur("duration", time.Since(start)).Msg("Dumped memory DB to disk")
 	JSONLogger.Debug().
@@ -693,7 +489,7 @@ func getDB() (db *gorm.DB, err error) {
 	}
 	err = sqlDB.Ping()
 	if err != nil {
-		writeLog(functionName, fmt.Sprintf(`Failed to validate connection. Err: %s`, err), "ERROR")
+		LogManager.WriteLog(functionName, fmt.Sprintf(`Failed to validate connection. Err: %s`, err), "ERROR")
 		ShouldSaveLocal = true
 		db, err = getSqliteDB("")
 		if err != nil || db == nil {
@@ -703,7 +499,7 @@ func getDB() (db *gorm.DB, err error) {
 		IsDatabaseValid = true
 
 	} else {
-		writeLog(functionName, "Connected to database", "INFO")
+		LogManager.WriteLog(functionName, "Connected to database", "INFO")
 		IsDatabaseValid = true
 	}
 
@@ -727,7 +523,7 @@ func setupDB(db *gorm.DB) (err error) {
 		// Create the table
 		err = db.AutoMigrate(&model.OcapInfo{})
 		if err != nil {
-			writeLog(functionName, fmt.Sprintf(`Failed to create ocap_info table. Err: %s`, err), "ERROR")
+			LogManager.WriteLog(functionName, fmt.Sprintf(`Failed to create ocap_info table. Err: %s`, err), "ERROR")
 			IsDatabaseValid = false
 			return err
 		}
@@ -758,7 +554,7 @@ func setupDB(db *gorm.DB) (err error) {
 			IsDatabaseValid = false
 			return fmt.Errorf("failed to create PostGIS Extension: %s", err)
 		}
-		writeLog(functionName, "PostGIS Extension created", "INFO")
+		LogManager.WriteLog(functionName, "PostGIS Extension created", "INFO")
 	}
 
 	Logger.Info().Msg("Migrating schema")
@@ -777,18 +573,75 @@ func setupDB(db *gorm.DB) (err error) {
 }
 
 func startGoroutines() (err error) {
-
 	functionName := "startGoroutines"
 
-	Logger.Trace().Msg("Starting async processors")
-	startAsyncProcessors()
-	Logger.Trace().Msg("Starting DB writers")
-	startDBWriters()
+	// Initialize queues
+	queues = worker.NewQueues()
 
-	if !IsStatusProcessRunning {
-		Logger.Trace().Msg("Status process not runnning, starting it")
-		// start status monitor
-		startStatusMonitor()
+	// Initialize mission context
+	missionCtx := handlers.NewMissionContext()
+
+	// Initialize handler service
+	handlerService = handlers.NewService(handlers.Dependencies{
+		DB:            DB,
+		EntityCache:   EntityCache,
+		MarkerCache:   MarkerCache,
+		LogManager:    LogManager,
+		ExtensionName: ExtensionName,
+		AddonVersion:  addonVersion,
+	}, missionCtx)
+
+	// Initialize worker manager
+	workerManager = worker.NewManager(worker.Dependencies{
+		DB:              DB,
+		EntityCache:     EntityCache,
+		MarkerCache:     MarkerCache,
+		LogManager:      LogManager,
+		HandlerService:  handlerService,
+		IsDatabaseValid: func() bool { return IsDatabaseValid },
+		ShouldSaveLocal: func() bool { return ShouldSaveLocal },
+		DBInsertsPaused: func() bool { return DBInsertsPaused },
+	}, queues, RVExtArgsDataChannels)
+
+	// Set up InfluxDB integration for worker
+	workerManager.SetInfluxIntegration(
+		writeInfluxPoint,
+		processMetricData,
+		func() bool { return viper.GetBool("influx.enabled") },
+	)
+
+	Logger.Trace().Msg("Starting async processors")
+	workerManager.StartAsyncProcessors()
+	Logger.Trace().Msg("Starting DB writers")
+	workerManager.StartDBWriters()
+
+	// Initialize monitor service
+	monitorService = monitor.NewService(monitor.Dependencies{
+		DB:             DB,
+		LogManager:     LogManager,
+		HandlerService: handlerService,
+		WorkerManager:  workerManager,
+		Queues:         queues,
+		AddonFolder:    AddonFolder,
+		IsDatabaseValid: func() bool { return IsDatabaseValid },
+		GetChannelLength: func(name string) int {
+			if ch, ok := RVExtArgsDataChannels[name]; ok {
+				return len(ch)
+			}
+			return 0
+		},
+	})
+
+	// Set up InfluxDB integration for monitor
+	monitorService.SetInfluxIntegration(
+		writeInfluxPoint,
+		func() bool { return viper.GetBool("influx.enabled") },
+		func() string { return viper.GetString("influxdb.url") },
+	)
+
+	if !monitorService.IsRunning() {
+		Logger.Trace().Msg("Status process not running, starting it")
+		monitorService.Start()
 	}
 
 	// goroutine to, every x seconds, pause insert execution and dump memory sqlite db to disk
@@ -798,7 +651,6 @@ func startGoroutines() (err error) {
 			Msg("Starting DB dump goroutine")
 
 		for {
-
 			time.Sleep(3 * time.Minute)
 			if !ShouldSaveLocal {
 				continue
@@ -808,10 +660,10 @@ func startGoroutines() (err error) {
 			DBInsertsPaused = true
 
 			// dump memory sqlite db to disk
-			writeLog(functionName, "Dumping in-memory SQLite DB to disk", "DEBUG")
+			LogManager.WriteLog(functionName, "Dumping in-memory SQLite DB to disk", "DEBUG")
 			err = dumpMemoryDBToDisk()
 			if err != nil {
-				writeLog(functionName, fmt.Sprintf(`Error dumping memory db to disk: %v`, err), "ERROR")
+				LogManager.WriteLog(functionName, fmt.Sprintf(`Error dumping memory db to disk: %v`, err), "ERROR")
 			}
 
 			// resume insert execution
@@ -820,2352 +672,8 @@ func startGoroutines() (err error) {
 	}()
 
 	// log post goroutine creation
-	writeLog(functionName, "Goroutines started successfully", "INFO")
+	LogManager.WriteLog(functionName, "Goroutines started successfully", "INFO")
 	return nil
-}
-
-func validateHypertables(tables map[string][]string) (err error) {
-	functionName := "validateHypertables"
-	// HYPERTABLES
-
-	all := []interface{}{}
-	DB.Exec(`SELECT x.* FROM timescaledb_information.hypertables`).Scan(&all)
-	for _, row := range all {
-		writeLog(functionName, fmt.Sprintf(`hypertable row: %v`, row), "DEBUG")
-	}
-
-	// iterate through each provided table
-	for table := range tables {
-		hypertable := interface{}(nil)
-		// see if table is already configured
-		DB.Exec(`SELECT x.* FROM timescaledb_information.hypertables WHERE hypertable_name = ?`, table).Scan(&hypertable)
-		if hypertable != nil {
-			// table is already configured
-			writeLog(functionName, fmt.Sprintf(`Table %s is already configured`, table), "INFO")
-			continue
-		}
-
-		// if table doesn't exist, create it
-		queryCreateHypertable := fmt.Sprintf(`
-				SELECT create_hypertable('%s', 'time', chunk_time_interval => interval '1 day', if_not_exists => true);
-			`, table)
-		err = DB.Exec(queryCreateHypertable).Error
-		if err != nil {
-			writeLog(functionName, fmt.Sprintf(`Failed to create hypertable for %s. Err: %s`, table, err), "ERROR")
-			return err
-		}
-		writeLog(functionName, fmt.Sprintf(`Created hypertable for %s`, table), "INFO")
-
-		// set compression
-		queryCompressHypertable := fmt.Sprintf(`
-				ALTER TABLE %s SET (
-					timescaledb.compress,
-					timescaledb.compress_segmentby = ?);
-			`, table)
-		err = DB.Exec(
-			queryCompressHypertable,
-			strings.Join(tables[table], ","),
-		).Error
-		if err != nil {
-			writeLog(functionName, fmt.Sprintf(`Failed to enable compression for %s. Err: %s`, table, err), "ERROR")
-			return err
-		}
-		writeLog(functionName, fmt.Sprintf(`Enabled hypertable compression for %s`, table), "INFO")
-
-		// set compress_after
-		queryCompressAfterHypertable := fmt.Sprintf(`
-				SELECT add_compression_policy(
-					'%s',
-					compress_after => interval '14 day');
-			`, table)
-		err = DB.Exec(queryCompressAfterHypertable).Error
-		if err != nil {
-			writeLog(functionName, fmt.Sprintf(`Failed to set compress_after for %s. Err: %s`, table, err), "ERROR")
-			return err
-		}
-		writeLog(functionName, fmt.Sprintf(`Set compress_after for %s`, table), "INFO")
-
-	}
-	return nil
-}
-
-// start a goroutine that will output channel lengths to status.txt and influxdb every X time
-func startStatusMonitor() {
-	go func() {
-		IsStatusProcessRunning = true
-		defer func() {
-			IsStatusProcessRunning = false
-		}()
-
-		Logger.Debug().
-			Str("function", "startStatusMonitor").
-			Msg("Starting status monitor goroutine")
-
-		// get status file writer with full control of file
-		Logger.Trace().
-			Str("function", "startStatusMonitor").
-			Str("file", AddonFolder+"/status.txt")
-
-		statusFile, err := os.Create(AddonFolder + "/status.txt")
-		if err != nil {
-			Logger.Error().Err(err).Msg("Error creating status file")
-		}
-		defer statusFile.Close()
-
-		for {
-			time.Sleep(1000 * time.Millisecond)
-
-			if CurrentMission.ID == 0 {
-				continue
-			}
-
-			statusStr, perfModel := getProgramStatus(true, true, true)
-
-			if statusFile != nil {
-				// clear the file contents and then write status
-				statusFile.Truncate(0)
-				statusFile.Seek(0, 0)
-				for _, line := range statusStr {
-					statusFile.WriteString(line + "\n")
-				}
-			}
-
-			// ! write model to Postgres
-			if IsDatabaseValid {
-				err = DB.Create(&perfModel).Error
-				if err != nil {
-					Logger.Error().Err(err).Msg("Error writing perf model to Postgres")
-				}
-			}
-
-			// write to influxDB
-			if viper.GetBool("influx.enabled") {
-
-				// write buffer lengths
-				p := influxdb2.NewPointWithMeasurement(
-					"ext_buffer_lengths",
-				).
-					AddTag("db_url", viper.GetString("influxdb.url")).
-					AddTag("mission_name", perfModel.Mission.MissionName).
-					AddTag("mission_id", fmt.Sprintf("%d", perfModel.Mission.ID)).
-					AddField("soldiers", perfModel.BufferLengths.Soldiers).
-					AddField("vehicles", perfModel.BufferLengths.Vehicles).
-					AddField("soldier_states", perfModel.BufferLengths.SoldierStates).
-					AddField("vehicle_states", perfModel.BufferLengths.VehicleStates).
-					AddField("general_events", perfModel.BufferLengths.GeneralEvents).
-					AddField("hit_events", perfModel.BufferLengths.HitEvents).
-					AddField("kill_events", perfModel.BufferLengths.KillEvents).
-					AddField("fired_events", perfModel.BufferLengths.FiredEvents).
-					AddField("chat_events", perfModel.BufferLengths.ChatEvents).
-					AddField("radio_events", perfModel.BufferLengths.RadioEvents).
-					AddField("server_fps_events", perfModel.BufferLengths.ServerFpsEvents).
-					SetTime(time.Now())
-
-				writeInfluxPoint(
-					context.Background(),
-					"ocap_performance",
-					p,
-				)
-
-				// write db write queue lengths
-				p = influxdb2.NewPointWithMeasurement(
-					"ext_db_queue_lengths",
-				).
-					AddTag("db_url", viper.GetString("influxdb.url")).
-					AddTag("mission_name", perfModel.Mission.MissionName).
-					AddTag("mission_id", fmt.Sprintf("%d", perfModel.Mission.ID)).
-					AddField("soldiers", perfModel.WriteQueueLengths.Soldiers).
-					AddField("vehicles", perfModel.WriteQueueLengths.Vehicles).
-					AddField("soldier_states", perfModel.WriteQueueLengths.SoldierStates).
-					AddField("vehicle_states", perfModel.WriteQueueLengths.VehicleStates).
-					AddField("general_events", perfModel.WriteQueueLengths.GeneralEvents).
-					AddField("hit_events", perfModel.WriteQueueLengths.HitEvents).
-					AddField("kill_events", perfModel.WriteQueueLengths.KillEvents).
-					AddField("fired_events", perfModel.WriteQueueLengths.FiredEvents).
-					AddField("chat_events", perfModel.WriteQueueLengths.ChatEvents).
-					AddField("radio_events", perfModel.WriteQueueLengths.RadioEvents).
-					AddField("server_fps_events", perfModel.WriteQueueLengths.ServerFpsEvents).
-					SetTime(time.Now())
-
-				writeInfluxPoint(
-					context.Background(),
-					"ocap_performance",
-					p,
-				)
-
-				// write last write duration
-				p = influxdb2.NewPointWithMeasurement(
-					"ext_db_lastwrite_duration_ms",
-				).
-					AddTag("db_url", viper.GetString("influxdb.url")).
-					AddTag("mission_name", perfModel.Mission.MissionName).
-					AddTag("mission_id", fmt.Sprintf("%d", perfModel.Mission.ID)).
-					AddField("value", perfModel.LastWriteDurationMs).
-					SetTime(time.Now())
-
-				writeInfluxPoint(
-					context.Background(),
-					"ocap_performance",
-					p,
-				)
-			}
-		}
-	}()
-}
-
-/////////////////////////////////////
-// WORLDS AND MISSIONS
-/////////////////////////////////////
-
-// CurrentWorld is the world that is currently being played
-var CurrentWorld *model.World = &model.World{
-	WorldName: "No world loaded",
-}
-
-// CurrentMission is the mission that is currently being played
-var CurrentMission *model.Mission = &model.Mission{
-	MissionName: "No mission loaded",
-}
-
-// logNewMission logs a new mission to the database and associates the world it's played on
-func logNewMission(data []string) (err error) {
-	functionName := ":NEW:MISSION:"
-
-	// fix received data
-	for i, v := range data {
-		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
-	}
-
-	world := model.World{}
-	mission := model.Mission{}
-	// unmarshal data[0]
-	err = json.Unmarshal([]byte(data[0]), &world)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf(`Error unmarshalling world data: %v`, err), "ERROR")
-		return err
-	}
-
-	// preprocess the world 'location' to geopoint
-	worldLocation, err := geo.Coords3857From4326(
-		float64(world.Longitude),
-		float64(world.Latitude),
-	)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf(`Error converting world location to geopoint: %v`, err), "ERROR")
-		return err
-	}
-	world.Location = worldLocation
-
-	// unmarshal data[1]
-	// unmarshal to temp object too to extract addons
-	missionTemp := map[string]interface{}{}
-	if err = json.Unmarshal([]byte(data[1]), &missionTemp); err != nil {
-		writeLog(functionName, fmt.Sprintf(`Error unmarshalling mission data: %v`, err), "ERROR")
-		return err
-	}
-
-	// add addons
-	addons := []model.Addon{}
-	for _, addon := range missionTemp["addons"].([]interface{}) {
-		thisAddon := model.Addon{
-			Name: addon.([]interface{})[0].(string),
-		}
-		// if addon[1] workshopId is int, convert to string
-		if reflect.TypeOf(addon.([]interface{})[1]).Kind() == reflect.Float64 {
-			thisAddon.WorkshopID = strconv.Itoa(int(addon.([]interface{})[1].(float64)))
-		} else {
-			thisAddon.WorkshopID = addon.([]interface{})[1].(string)
-		}
-
-		// if addon doesn't exist, insert it
-		err = DB.Where("name = ?", thisAddon.Name).First(&thisAddon).Error
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			writeLog(functionName, fmt.Sprintf(`Error checking if addon exists: %v`, err), "ERROR")
-			return err
-		}
-		if thisAddon.ID == 0 {
-			// addon does not exist, create it
-			if err = DB.Create(&thisAddon).Error; err != nil {
-				writeLog(functionName, fmt.Sprintf(`Error creating addon: %v`, err), "ERROR")
-				return err
-			}
-			addons = append(addons, thisAddon)
-
-		} else {
-			// addon exists, append it
-			addons = append(addons, thisAddon)
-		}
-	}
-	mission.Addons = addons
-
-	mission.StartTime = time.Now()
-
-	mission.CaptureDelay = float32(missionTemp["captureDelay"].(float64))
-	mission.MissionNameSource = missionTemp["missionNameSource"].(string)
-	mission.MissionName = missionTemp["missionName"].(string)
-	mission.BriefingName = missionTemp["briefingName"].(string)
-	mission.ServerName = missionTemp["serverName"].(string)
-	mission.ServerProfile = missionTemp["serverProfile"].(string)
-	mission.OnLoadName = missionTemp["onLoadName"].(string)
-	mission.Author = missionTemp["author"].(string)
-	mission.Tag = missionTemp["tag"].(string)
-
-	// playableSlots
-	playableSlotsJSON := missionTemp["playableSlots"].([]interface{})
-	mission.PlayableSlots.East = uint8(playableSlotsJSON[0].(float64))
-	mission.PlayableSlots.West = uint8(playableSlotsJSON[1].(float64))
-	mission.PlayableSlots.Independent = uint8(playableSlotsJSON[2].(float64))
-	mission.PlayableSlots.Civilian = uint8(playableSlotsJSON[3].(float64))
-	mission.PlayableSlots.Logic = uint8(playableSlotsJSON[4].(float64))
-
-	// sideFriendly
-	sideFriendlyJSON := missionTemp["sideFriendly"].([]interface{})
-	mission.SideFriendly.EastWest = sideFriendlyJSON[0].(bool)
-	mission.SideFriendly.EastIndependent = sideFriendlyJSON[1].(bool)
-	mission.SideFriendly.WestIndependent = sideFriendlyJSON[2].(bool)
-
-	// received at extension init and saved to local memory
-	mission.AddonVersion = addonVersion
-
-	// get or insert world
-	created, err := world.GetOrInsert(DB)
-	if err != nil {
-		Logger.Error().Err(err).Msgf("Failed to get or insert world")
-		return err
-	}
-	if created {
-		Logger.Debug().Msgf("New world inserted: %s", world.WorldName)
-	} else {
-		Logger.Debug().Msgf("World already exists: %s", world.WorldName)
-	}
-
-	// always write new mission
-	mission.World = world
-	err = DB.Create(&mission).Error
-	if err != nil {
-		Logger.Error().Err(err).Msgf("Failed to insert new mission")
-		return err
-	} else {
-		Logger.Debug().Msgf("New mission inserted: %s", mission.MissionName)
-	}
-
-	// set current world and mission
-	CurrentWorld = &world
-	CurrentMission = &mission
-
-	// Clear marker cache for new mission
-	MarkerCacheLock.Lock()
-	MarkerCache = make(map[string]uint)
-	MarkerCacheLock.Unlock()
-
-	// write to log
-	writeLog(functionName, `New mission logged`, "INFO")
-
-	Logger.Debug().Dict("worldData", zerolog.Dict().
-		Str("worldName", world.WorldName).
-		Str("displayName", world.DisplayName),
-	).Send()
-	Logger.Debug().Dict(
-		"missionData", zerolog.Dict().
-			Str("missionName", mission.MissionName).
-			Str("briefingName", mission.BriefingName).
-			Str("serverName", mission.ServerName).
-			Str("serverProfile", mission.ServerProfile).
-			Str("onLoadName", mission.OnLoadName).
-			Str("author", mission.Author).
-			Str("tag", mission.Tag),
-	).Send()
-
-	// callback to addon to begin sending data
-	a3interface.WriteArmaCallback(ExtensionName, `:MISSION:OK:`, "OK")
-	return nil
-}
-
-// (UNITS) AND VEHICLES
-
-// logNewSoldier logs a new soldier to the database
-func logNewSoldier(data []string) (soldier model.Soldier, err error) {
-	functionName := ":NEW:SOLDIER:"
-
-	// fix received data
-	for i, v := range data {
-		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
-	}
-
-	// get frame
-	frameStr := data[0]
-	capframe, err := strconv.ParseInt(frameStr, 10, 64)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf(`Error converting capture frame to int: %s`, err), "ERROR")
-		return soldier, err
-	}
-
-	// parse array
-	soldier.MissionID = CurrentMission.ID
-	soldier.JoinFrame = uint(capframe)
-
-	// timestamp will always be appended as the last element of data, in unixnano format as a string
-	timestampStr := data[len(data)-1]
-	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf(`Error converting timestamp to int: %v`, err), "ERROR")
-		return soldier, err
-	}
-	soldier.JoinTime = time.Unix(0, timestampInt)
-
-	ocapID, err := strconv.ParseUint(data[1], 10, 64)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf(`Error converting ocapId to uint: %v`, err), "ERROR")
-		return soldier, err
-	}
-	soldier.OcapID = uint16(ocapID)
-	soldier.UnitName = data[2]
-	soldier.GroupID = data[3]
-	soldier.Side = data[4]
-	soldier.IsPlayer, err = strconv.ParseBool(data[5])
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf(`Error converting isPlayer to bool: %v`, err), "ERROR")
-		return soldier, err
-	}
-	soldier.RoleDescription = data[6]
-	soldier.ClassName = data[7]
-	soldier.DisplayName = data[8]
-	// player uid
-	soldier.PlayerUID = data[9]
-
-	// marshal squadparams
-	squadParams := data[10]
-	err = json.Unmarshal([]byte(squadParams), &soldier.SquadParams)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf(`Error unmarshalling squadParams: %v`, err), "ERROR")
-		return soldier, err
-	}
-
-	return soldier, nil
-}
-
-// logSoldierState logs a SoldierState state to the database
-func logSoldierState(data []string) (soldierState model.SoldierState, err error) {
-	functionName := ":NEW:SOLDIER:STATE:"
-
-	// fix received data
-	for i, v := range data {
-		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
-	}
-
-	soldierState.MissionID = CurrentMission.ID
-
-	frameStr := data[8]
-	capframe, err := strconv.ParseInt(frameStr, 10, 64)
-	if err != nil {
-		return soldierState, fmt.Errorf(`error converting capture frame to int: %s`, err)
-	}
-	soldierState.CaptureFrame = uint(capframe)
-
-	// parse data in array
-	ocapID, err := strconv.ParseUint(data[0], 10, 64)
-	if err != nil {
-		return soldierState, fmt.Errorf(`error converting ocapId to uint: %v`, err)
-	}
-
-	// try and find soldier in DB to associate
-	soldier, ok := EntityCache.GetSoldier(uint16(ocapID))
-	if !ok {
-		return soldierState, fmt.Errorf("soldier %d not found in cache", ocapID)
-	}
-
-	soldierState.SoldierID = soldier.ID
-
-	// timestamp will always be appended as the last element of data, in unixnano format as a string
-	timestampStr := data[len(data)-1]
-	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf(`Error converting timestamp to int: %v`, err), "ERROR")
-		return soldierState, err
-	}
-	soldierState.Time = time.Unix(0, timestampInt)
-
-	// parse pos from an arma string
-	pos := data[1]
-	pos = strings.TrimPrefix(pos, "[")
-	pos = strings.TrimSuffix(pos, "]")
-	point, elev, err := geo.Coord3857FromString(pos)
-	if err != nil {
-		json, _ := json.Marshal(data)
-		writeLog(functionName, fmt.Sprintf("Error converting position to Point:\n%s\n%v", json, err), "ERROR")
-		return soldierState, err
-	}
-	// fmt.Println(point.ToString())
-	soldierState.Position = point
-	soldierState.ElevationASL = float32(elev)
-
-	// bearing
-	bearing, _ := strconv.Atoi(data[2])
-	soldierState.Bearing = uint16(bearing)
-	// lifestate
-	lifeState, _ := strconv.Atoi(data[3])
-	soldierState.Lifestate = uint8(lifeState)
-	// in vehicle
-	soldierState.InVehicle, _ = strconv.ParseBool(data[4])
-	// name
-	soldierState.UnitName = data[5]
-	// is player
-	isPlayer, err := strconv.ParseBool(data[6])
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf(`Error converting isPlayer to bool: %v`, err), "ERROR")
-		return soldierState, err
-	}
-	soldierState.IsPlayer = isPlayer
-	// current role
-	soldierState.CurrentRole = data[7]
-
-	// parse ace3/medical data, is true/false default for vanilla
-	// has stable vitals
-	hasStableVitals, _ := strconv.ParseBool(data[9])
-	soldierState.HasStableVitals = hasStableVitals
-	// is dragged/carried
-	isDraggedCarried, _ := strconv.ParseBool(data[10])
-	soldierState.IsDraggedCarried = isDraggedCarried
-
-	// player scores come in as an array
-	if isPlayer {
-		scoresStr := data[11]
-		scoresArr := strings.Split(scoresStr, ",")
-		scoresInt := make([]uint8, len(scoresArr))
-		for i, v := range scoresArr {
-			num, _ := strconv.Atoi(v)
-			scoresInt[i] = uint8(num)
-		}
-
-		soldierState.Scores = model.SoldierScores{
-			InfantryKills: scoresInt[0],
-			VehicleKills:  scoresInt[1],
-			ArmorKills:    scoresInt[2],
-			AirKills:      scoresInt[3],
-			Deaths:        scoresInt[4],
-			TotalScore:    scoresInt[5],
-		}
-	}
-
-	// seat in vehicle
-	soldierState.VehicleRole = data[12]
-
-	// InVehicleObjectID, if -1 not in a vehicle
-	inVehicleID, _ := strconv.Atoi(data[13])
-	if inVehicleID == -1 {
-		soldierState.InVehicleObjectID = sql.NullInt32{
-			Int32: 0,
-			Valid: false,
-		}
-	} else {
-		soldierState.InVehicleObjectID = sql.NullInt32{
-			Int32: int32(inVehicleID),
-			Valid: true,
-		}
-	}
-
-	// stance
-	soldierState.Stance = data[14]
-
-	return soldierState, nil
-}
-
-// log a new vehicle
-func logNewVehicle(data []string) (vehicle model.Vehicle, err error) {
-	functionName := ":NEW:VEHICLE:"
-
-	// fix received data
-	for i, v := range data {
-		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
-	}
-
-	// get frame
-	frameStr := data[0]
-	capframe, err := strconv.ParseInt(frameStr, 10, 64)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf(`Error converting capture frame to int: %s`, err), "ERROR")
-		return vehicle, err
-	}
-
-	// timestamp will always be appended as the last element of data, in unixnano format as a string
-	timestampStr := data[len(data)-1]
-	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf(`Error converting timestamp to int: %v`, err), "ERROR")
-		return vehicle, err
-	}
-	vehicle.JoinTime = time.Unix(0, timestampInt)
-
-	// parse array
-	vehicle.MissionID = CurrentMission.ID
-	vehicle.JoinFrame = uint(capframe)
-	ocapID, err := strconv.ParseUint(data[1], 10, 64)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf(`Error converting ocapID to uint: %v`, err), "ERROR")
-		return vehicle, err
-	}
-	vehicle.OcapID = uint16(ocapID)
-	vehicle.OcapType = data[2]
-	vehicle.DisplayName = data[3]
-	vehicle.ClassName = data[4]
-	vehicle.Customization = data[5]
-
-	return vehicle, nil
-}
-
-func logVehicleState(data []string) (vehicleState model.VehicleState, err error) {
-	functionName := ":NEW:VEHICLE:STATE:"
-
-	// fix received data
-	for i, v := range data {
-		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
-	}
-
-	vehicleState.MissionID = CurrentMission.ID
-
-	// get frame
-	frameStr := data[5]
-	capframe, err := strconv.ParseInt(frameStr, 10, 64)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf(`Error converting capture frame to int: %s`, err), "ERROR")
-		return vehicleState, err
-	}
-	vehicleState.CaptureFrame = uint(capframe)
-
-	// parse data in array
-	ocapID, err := strconv.ParseUint(data[0], 10, 64)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf(`Error converting ocapId to uint: %v`, err), "ERROR")
-		return vehicleState, err
-	}
-
-	// try and find vehicle in DB to associate
-	vehicle, ok := EntityCache.GetVehicle(uint16(ocapID))
-	if !ok {
-		return vehicleState, fmt.Errorf("vehicle %d not found in cache", ocapID)
-	}
-	vehicleState.VehicleID = vehicle.ID
-
-	// timestamp will always be appended as the last element of data, in unixnano format as a string
-	timestampStr := data[len(data)-1]
-	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf(`Error converting timestamp to int: %v`, err), "ERROR")
-		return vehicleState, err
-	}
-	vehicleState.Time = time.Unix(0, timestampInt)
-
-	// parse pos from an arma string
-	pos := data[1]
-	pos = strings.TrimPrefix(pos, "[")
-	pos = strings.TrimSuffix(pos, "]")
-	point, elev, err := geo.Coord3857FromString(pos)
-	if err != nil {
-		json, _ := json.Marshal(data)
-		writeLog(functionName, fmt.Sprintf("Error converting position to Point:\n%s\n%v", json, err), "ERROR")
-		return vehicleState, err
-	}
-	// fmt.Println(point.ToString())
-	vehicleState.Position = point
-	vehicleState.ElevationASL = float32(elev)
-
-	// bearing
-	bearing, _ := strconv.Atoi(data[2])
-	vehicleState.Bearing = uint16(bearing)
-	// is alive
-	isAlive, _ := strconv.ParseBool(data[3])
-	vehicleState.IsAlive = isAlive
-	// parse crew, which is an array of ocap ids of soldiers
-	crew := data[4]
-	crew = strings.TrimPrefix(crew, "[")
-	crew = strings.TrimSuffix(crew, "]")
-	vehicleState.Crew = crew
-
-	// fuel
-	fuel, err := strconv.ParseFloat(data[6], 32)
-	if err != nil {
-		return vehicleState, fmt.Errorf(`error converting fuel to float: %v`, err)
-	}
-	vehicleState.Fuel = float32(fuel)
-
-	// damage
-	damage, err := strconv.ParseFloat(data[7], 32)
-	if err != nil {
-		return vehicleState, fmt.Errorf(`error converting damage to float: %v`, err)
-	}
-	vehicleState.Damage = float32(damage)
-
-	// isEngineOn
-	isEngineOn, err := strconv.ParseBool(data[8])
-	if err != nil {
-		return vehicleState, fmt.Errorf(`error converting isEngineOn to bool: %v`, err)
-	}
-	vehicleState.EngineOn = isEngineOn
-
-	// locked
-	locked, err := strconv.ParseBool(data[9])
-	if err != nil {
-		return vehicleState, fmt.Errorf(`error converting locked to bool: %v`, err)
-	}
-	vehicleState.Locked = locked
-
-	vehicleState.Side = data[10]
-
-	vehicleState.VectorDir = data[11]
-	vehicleState.VectorUp = data[12]
-
-	turretAzimuth, err := strconv.ParseFloat(data[13], 32)
-	if err != nil {
-		return vehicleState, fmt.Errorf(`error converting turretAzimuth to float: %v`, err)
-	}
-	vehicleState.TurretAzimuth = float32(turretAzimuth)
-
-	turretElevation, err := strconv.ParseFloat(data[14], 32)
-	if err != nil {
-		return vehicleState, fmt.Errorf(`error converting turretElevation to float: %v`, err)
-	}
-	vehicleState.TurretElevation = float32(turretElevation)
-
-	return vehicleState, nil
-}
-
-// FIRED EVENTS
-func logFiredEvent(data []string) (firedEvent model.FiredEvent, err error) {
-	functionName := ":FIRED:"
-
-	// fix received data
-	for i, v := range data {
-		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
-	}
-
-	firedEvent.MissionID = CurrentMission.ID
-
-	// get frame
-	frameStr := data[1]
-	capframe, err := strconv.ParseInt(frameStr, 10, 64)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf(`Error converting capture frame to int: %s`, err), "ERROR")
-		return firedEvent, err
-	}
-	firedEvent.CaptureFrame = uint(capframe)
-
-	// parse data in array
-	ocapID, err := strconv.ParseUint(data[0], 10, 64)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf(`Error converting ocapID to uint: %v`, err), "ERROR")
-		return firedEvent, err
-	}
-
-	// try and find soldier in DB to associate
-	soldier, ok := EntityCache.GetSoldier(uint16(ocapID))
-	if !ok {
-		return firedEvent, fmt.Errorf("soldier %d not found in cache", ocapID)
-	}
-	firedEvent.SoldierID = soldier.ID
-
-	// timestamp will always be appended as the last element of data, in unixnano format as a string
-	timestampStr := data[len(data)-1]
-	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf(`Error converting timestamp to int: %v`, err), "ERROR")
-		return firedEvent, err
-	}
-	firedEvent.Time = time.Unix(0, timestampInt)
-
-	// parse BULLET END POS from an arma string
-	endpos := data[2]
-	endpoint, endelev, err := geo.Coord3857FromString(endpos)
-	if err != nil {
-		json, _ := json.Marshal(data)
-		writeLog(functionName, fmt.Sprintf("Error converting position to Point:\n%s\n%v", json, err), "ERROR")
-		return firedEvent, err
-	}
-	firedEvent.EndPosition = endpoint
-	firedEvent.EndElevationASL = float32(endelev)
-
-	// parse BULLET START POS from an arma string
-	startpos := data[3]
-	startpoint, startelev, err := geo.Coord3857FromString(startpos)
-	if err != nil {
-		json, _ := json.Marshal(data)
-		writeLog(functionName, fmt.Sprintf("Error converting position to Point:\n%s\n%v", json, err), "ERROR")
-		return firedEvent, err
-	}
-	firedEvent.StartPosition = startpoint
-	firedEvent.StartElevationASL = float32(startelev)
-
-	// weapon name
-	firedEvent.Weapon = data[4]
-	// magazine name
-	firedEvent.Magazine = data[5]
-	// firing mode
-	firedEvent.FiringMode = data[6]
-
-	return firedEvent, nil
-}
-
-func logProjectileEvent(data []string) (projectileEvent model.ProjectileEvent, err error) {
-
-	// fix received data
-	for i, v := range data {
-		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
-	}
-
-	projectileEvent.MissionID = CurrentMission.ID
-
-	// this event will be sent as JSON, so we need to unmarshal it
-
-	Logger.Trace().Msgf("Projectile data: %v", data[0])
-
-	var rawJsonData map[string]interface{}
-	err = json.Unmarshal([]byte(data[0]), &rawJsonData)
-	if err != nil {
-		return projectileEvent, fmt.Errorf(`error unmarshalling json data: %v`, err)
-	}
-
-	// get data from json - this is done bit by bit to avoid errors if the data is missing or mismatching type due to SQF vs Go
-
-	Logger.Trace().Msg("Processing time and frame")
-	firedTime := rawJsonData["firedTime"].(string)
-	firedTimeInt, err := strconv.ParseInt(firedTime, 10, 64)
-	if err != nil {
-		return projectileEvent, fmt.Errorf(`error converting firedTime to int: %v`, err)
-	}
-	projectileEvent.Time = time.Unix(0, firedTimeInt)
-	projectileEvent.CaptureFrame = uint(rawJsonData["firedFrame"].(float64))
-
-	Logger.Trace().Msg("Processing soldierFired")
-	soldierFired, ok := EntityCache.GetSoldier(uint16(rawJsonData["firerID"].(float64)))
-	if !ok {
-		return projectileEvent, fmt.Errorf("soldier %d not found in cache", uint16(rawJsonData["firerID"].(float64)))
-	}
-	projectileEvent.FirerID = soldierFired.ID
-
-	Logger.Trace().Msg("Processing actualFirer")
-	actualFirer, ok := EntityCache.GetSoldier(uint16(rawJsonData["remoteControllerID"].(float64)))
-	if !ok {
-		return projectileEvent, fmt.Errorf("soldier %d not found in cache", uint16(rawJsonData["remoteControllerID"].(float64)))
-	}
-	projectileEvent.ActualFirerID = actualFirer.ID
-
-	Logger.Trace().Msg("Processing vehicleID")
-	vehicleID := rawJsonData["vehicleID"].(float64)
-	vehicle, ok := EntityCache.GetVehicle(uint16(vehicleID))
-	if ok {
-		projectileEvent.VehicleID = sql.NullInt32{
-			Int32: int32(vehicle.ID),
-			Valid: true,
-		}
-		// its ok if the vehicle isn't found in the vehicle cache, it might be the person themselves. we'll just leave it null
-	} else {
-		projectileEvent.VehicleID = sql.NullInt32{
-			Int32: 0,
-			Valid: false,
-		}
-	}
-
-	// for Positions parsing, we need to create a Linestring with XYZM dimensions
-	// X, Y, Z, time (unix time nanoseconds)
-
-	// first, we'll grab the positions and store XYZM in a sequence
-	Logger.Trace().Msgf("Projectile positions: %v", rawJsonData["positions"])
-	positionSequence := []float64{}
-	for _, v := range rawJsonData["positions"].([]interface{}) {
-		posArr := v.([]interface{})
-
-		Logger.Trace().Msgf("Projectile posArr: %v", posArr)
-
-		// process time as posArr[0]
-		unixTimeNano := posArr[0].(string)
-		// convert to float64
-		unixTimeNanoFloat, err := strconv.ParseFloat(unixTimeNano, 64)
-		if err != nil {
-			json, _ := json.Marshal(posArr)
-			Logger.Error().Err(err).Str("json", string(json)).Msg("Error converting timestamp to float64")
-			return projectileEvent, err
-		}
-
-		// process actual position xyz as posArr[2]
-		pos := posArr[2].(string)
-		point, _, err := geo.Coord3857FromString(pos)
-		if err != nil {
-			json, _ := json.Marshal(posArr)
-			Logger.Error().Err(err).Str("json", string(json)).Msg("Error converting position to Point")
-			return projectileEvent, err
-		}
-		coords, _ := point.Coordinates()
-
-		// append to sequence
-		positionSequence = append(
-			positionSequence,
-			coords.XY.X,
-			coords.XY.Y,
-			coords.Z,
-			unixTimeNanoFloat,
-		)
-	}
-
-	// next, we'll create the linestring
-	posSeq := geom.NewSequence(positionSequence, geom.DimXYZM)
-	ls, err := geom.NewLineString(posSeq)
-	if err != nil {
-		json, _ := json.Marshal(posSeq)
-		Logger.Error().Err(err).Str("json", string(json)).Msg("Error creating linestring")
-		return projectileEvent, err
-	}
-
-	Logger.Trace().
-		Interface("sequence", posSeq).
-		Interface("linestring", ls).
-		Interface("wkt", ls.AsText()).
-		Interface("wkb", ls.AsBinary()).
-		Msg("Created linestring")
-
-	projectileEvent.Positions = ls.AsGeometry()
-
-	Logger.Trace().Msg("Processing hit events")
-	// hit events
-
-	projectileEvent.HitSoldiers = []model.ProjectileHitsSoldier{}
-	projectileEvent.HitVehicles = []model.ProjectileHitsVehicle{}
-	for _, event := range rawJsonData["hitParts"].([]interface{}) {
-		eventArr := event.([]interface{})
-
-		Logger.Trace().Interface("eventArr", eventArr).Msg("Processing hit event")
-
-		// [1] is []string containing hit components
-		hitComponents := []string{}
-		for _, v := range eventArr[1].([]interface{}) {
-			hitComponents = append(hitComponents, v.(string))
-		}
-
-		// [2] is string with positionASL
-		hitPos := eventArr[2].(string)
-		hitPoint, _, err := geo.Coord3857FromString(hitPos)
-		if err != nil {
-			json, _ := json.Marshal(eventArr)
-			Logger.Error().Err(err).Str("json", string(json)).Msg("Error converting hit position to Point")
-			return projectileEvent, err
-		}
-
-		// [3] is uint capture frame
-		hitFrame := eventArr[3].(float64)
-
-		// marshal hit components to json array
-		hitComponentsJSON, err := json.Marshal(hitComponents)
-		if err != nil {
-			Logger.Error().Err(err).Msg("Error marshalling hit components to json")
-			return projectileEvent, err
-		}
-
-		Logger.Trace().Interface("hitComponents", hitComponents).Msg("Processed hit components")
-
-		// [0] is the hit entity ocap id
-		hitEntityID := eventArr[0].(float64)
-		hitEntity, ok := EntityCache.GetSoldier(uint16(hitEntityID))
-		if ok {
-			projectileEvent.HitSoldiers = append(
-				projectileEvent.HitSoldiers,
-				model.ProjectileHitsSoldier{
-					SoldierID:     hitEntity.ID,
-					ComponentsHit: hitComponentsJSON,
-					CaptureFrame:  uint(hitFrame),
-					Position:      hitPoint,
-				},
-			)
-		} else {
-			hitEntity, ok := EntityCache.GetVehicle(uint16(hitEntityID))
-			if ok {
-				projectileEvent.HitVehicles = append(
-					projectileEvent.HitVehicles,
-					model.ProjectileHitsVehicle{
-						VehicleID:     hitEntity.ID,
-						ComponentsHit: hitComponentsJSON,
-						CaptureFrame:  uint(hitFrame),
-						Position:      hitPoint,
-					},
-				)
-			} else {
-				Logger.Warn().Msgf("Hit entity %d not found in cache", uint16(hitEntityID))
-			}
-		}
-	}
-
-	Logger.Trace().Msg("Processing other properties")
-
-	projectileEvent.VehicleRole = rawJsonData["vehicleRole"].(string)
-	projectileEvent.Weapon = rawJsonData["weapon"].(string)
-	projectileEvent.WeaponDisplay = rawJsonData["weaponDisplay"].(string)
-	projectileEvent.Magazine = rawJsonData["magazine"].(string)
-	projectileEvent.MagazineDisplay = rawJsonData["magazineDisplay"].(string)
-	projectileEvent.Muzzle = rawJsonData["muzzle"].(string)
-	projectileEvent.MuzzleDisplay = rawJsonData["muzzleDisplay"].(string)
-	projectileEvent.Ammo = rawJsonData["ammo"].(string)
-	projectileEvent.Mode = rawJsonData["fireMode"].(string)
-	projectileEvent.InitialVelocity = rawJsonData["initialVelocity"].(string)
-
-	return projectileEvent, nil
-}
-
-// function to process events of different kinds
-func logGeneralEvent(data []string) (thisEvent model.GeneralEvent, err error) {
-
-	functionName := ":EVENT:"
-
-	// fix received data
-	for i, v := range data {
-		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
-	}
-
-	// get frame
-	frameStr := data[0]
-	capframe, err := strconv.ParseInt(frameStr, 10, 64)
-	if err != nil {
-		writeLog("processEvent", fmt.Sprintf(`Error converting capture frame to int: %s`, err), "ERROR")
-		return thisEvent, err
-	}
-
-	// timestamp will always be appended as the last element of data, in unixnano format as a string
-	timestampStr := data[len(data)-1]
-	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf(`Error converting timestamp to int: %v`, err), "ERROR")
-		return thisEvent, err
-	}
-	thisEvent.Time = time.Unix(0, timestampInt)
-
-	thisEvent.Mission = *CurrentMission
-
-	// get event type
-	thisEvent.CaptureFrame = uint(capframe)
-
-	// get event type
-	thisEvent.Name = data[1]
-
-	// get event message
-	thisEvent.Message = data[2]
-
-	// get extra event data
-	if len(data) > 3 {
-		// unmarshal the json string
-		err = json.Unmarshal([]byte(data[3]), &thisEvent.ExtraData)
-		if err != nil {
-			writeLog(functionName, fmt.Sprintf(`Error unmarshalling extra data: %s`, err), "ERROR")
-			return thisEvent, err
-		}
-	}
-
-	return thisEvent, nil
-}
-
-func logHitEvent(data []string) (hitEvent model.HitEvent, err error) {
-
-	// fix received data
-	for i, v := range data {
-		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
-	}
-
-	// get frame
-	frameStr := data[0]
-	capframe, err := strconv.ParseInt(frameStr, 10, 64)
-	if err != nil {
-		return hitEvent, fmt.Errorf(`error converting capture frame to int: %s`, err)
-	}
-
-	hitEvent.CaptureFrame = uint(capframe)
-	hitEvent.Mission = *CurrentMission
-
-	// timestamp will always be appended as the last element of data, in unixnano format as a string
-	timestampStr := data[len(data)-1]
-	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
-	if err != nil {
-		return hitEvent, fmt.Errorf(`error converting timestamp to int: %v`, err)
-	}
-	hitEvent.Time = time.Unix(0, timestampInt)
-
-	// parse data in array
-	victimOcapID, err := strconv.ParseUint(data[1], 10, 64)
-	if err != nil {
-		return hitEvent, fmt.Errorf(`error converting victim ocap id to uint: %v`, err)
-	}
-
-	// try and find victim in DB to associate
-	victimSoldier, ok := EntityCache.GetSoldier(uint16(victimOcapID))
-	if ok {
-		hitEvent.VictimSoldier = victimSoldier
-	} else {
-		victimVehicle, ok := EntityCache.GetVehicle(uint16(victimOcapID))
-		if ok {
-			hitEvent.VictimVehicle = victimVehicle
-		} else {
-			return hitEvent, fmt.Errorf(`victim ocap id not found in cache: %d`, victimOcapID)
-		}
-	}
-
-	// now look for the shooter
-	shooterOcapID, err := strconv.ParseUint(data[2], 10, 64)
-	if err != nil {
-		return hitEvent, fmt.Errorf(`error converting shooter ocap id to uint: %v`, err)
-	}
-
-	// try and find shooter in DB to associate
-	// first, look in soldiers
-	shooterSoldier, ok := EntityCache.GetSoldier(uint16(shooterOcapID))
-	if ok {
-		hitEvent.ShooterSoldier = shooterSoldier
-	} else {
-		// if not found, look in vehicles
-		shooterVehicle, ok := EntityCache.GetVehicle(uint16(shooterOcapID))
-		if ok {
-			hitEvent.ShooterVehicle = shooterVehicle
-		} else {
-			return hitEvent, fmt.Errorf(`shooter ocap id not found in cache: %d`, shooterOcapID)
-		}
-	}
-
-	// get event text
-	hitEvent.EventText = data[3]
-
-	// get event distance
-	distance, err := strconv.ParseFloat(data[4], 64)
-	if err != nil {
-		return hitEvent, fmt.Errorf(`error converting distance to float: %v`, err)
-	}
-	hitEvent.Distance = float32(distance)
-
-	return hitEvent, nil
-}
-
-func logKillEvent(data []string) (killEvent model.KillEvent, err error) {
-
-	// fix received data
-	for i, v := range data {
-		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
-	}
-
-	// get frame
-	frameStr := data[0]
-	capframe, err := strconv.ParseInt(frameStr, 10, 64)
-	if err != nil {
-		return killEvent, fmt.Errorf(`error converting capture frame to int: %s`, err)
-	}
-
-	// timestamp will always be appended as the last element of data, in unixnano format as a string
-	timestampStr := data[len(data)-1]
-	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
-	if err != nil {
-		return killEvent, fmt.Errorf(`error converting timestamp to int: %v`, err)
-	}
-	killEvent.Time = time.Unix(0, timestampInt)
-
-	killEvent.CaptureFrame = uint(capframe)
-	killEvent.Mission = *CurrentMission
-
-	// parse data in array
-	victimOcapID, err := strconv.ParseUint(data[1], 10, 64)
-	if err != nil {
-		return killEvent, fmt.Errorf(`error converting victim ocap id to uint: %v`, err)
-	}
-
-	// try and find victim in DB to associate
-	// first, look in soldiers
-	victimSoldier, ok := EntityCache.GetSoldier(uint16(victimOcapID))
-	if ok {
-		killEvent.VictimSoldier = victimSoldier
-	} else {
-		// if not found, look in vehicles
-		victimVehicle, ok := EntityCache.GetVehicle(uint16(victimOcapID))
-		if ok {
-			killEvent.VictimVehicle = victimVehicle
-		} else {
-			return killEvent, fmt.Errorf(`victim ocap id not found in cache: %d`, victimOcapID)
-		}
-	}
-
-	// now look for the killer
-	killerOcapID, err := strconv.ParseUint(data[2], 10, 64)
-	if err != nil {
-		return killEvent, fmt.Errorf(`error converting killer ocap id to uint: %v`, err)
-	}
-
-	// try and find killer in DB to associate
-	// first, look in soldiers
-	killerSoldier, ok := EntityCache.GetSoldier(uint16(killerOcapID))
-	if ok {
-		killEvent.KillerSoldier = killerSoldier
-	} else {
-		// if not found, look in vehicles
-		killerVehicle, ok := EntityCache.GetVehicle(uint16(killerOcapID))
-		if ok {
-			killEvent.KillerVehicle = killerVehicle
-		} else {
-			return killEvent, fmt.Errorf(`killer ocap id not found in cache: %d`, killerOcapID)
-		}
-	}
-
-	// get event text
-	killEvent.EventText = data[3]
-
-	// get event distance
-	distance, err := strconv.ParseFloat(data[4], 64)
-
-	if err != nil {
-		return killEvent, fmt.Errorf(`error converting distance to float: %v`, err)
-	}
-
-	killEvent.Distance = float32(distance)
-
-	return killEvent, nil
-}
-
-func logChatEvent(data []string) (chatEvent model.ChatEvent, err error) {
-
-	// fix received data
-	for i, v := range data {
-		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
-	}
-
-	// get frame
-	frameStr := data[0]
-	capframe, err := strconv.ParseInt(frameStr, 10, 64)
-	if err != nil {
-		return chatEvent, fmt.Errorf(`error converting capture frame to int: %s`, err)
-	}
-
-	// timestamp will always be appended as the last element of data, in unixnano format as a string
-	timestampStr := data[len(data)-1]
-	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
-	if err != nil {
-		return chatEvent, fmt.Errorf(`error converting timestamp to int: %v`, err)
-	}
-	chatEvent.Time = time.Unix(0, timestampInt)
-
-	chatEvent.CaptureFrame = uint(capframe)
-	chatEvent.Mission = *CurrentMission
-
-	// parse data in array
-	senderOcapID, err := strconv.ParseInt(data[1], 10, 64)
-	if err != nil {
-		return chatEvent, fmt.Errorf(`error converting sender ocap id to uint: %v`, err)
-	}
-
-	// try and find sender solder in DB to associate if not -1
-	if senderOcapID > -1 {
-		sendSoldier, ok := EntityCache.GetSoldier(uint16(senderOcapID))
-		if ok {
-			chatEvent.Soldier = sendSoldier
-		} else {
-			return chatEvent, fmt.Errorf(`sender ocap id not found in cache: %d`, senderOcapID)
-		}
-	}
-
-	// parse the rest of array
-
-	// channel is the 3rd element, compare against map
-	// parse string to int
-	channelInt, err := strconv.ParseInt(data[2], 10, 64)
-	if err != nil {
-		return chatEvent, fmt.Errorf(`error converting channel to int: %v`, err)
-	}
-	channelName, ok := model.ChatChannels[int(channelInt)]
-	if ok {
-		chatEvent.Channel = channelName
-	} else {
-		if channelInt > 5 && channelInt < 16 {
-			chatEvent.Channel = "Custom"
-		} else {
-			chatEvent.Channel = "System"
-		}
-	}
-
-	// next is from (formatted as the game message)
-	chatEvent.FromName = data[3]
-
-	// next is actual name
-	chatEvent.SenderName = data[4]
-
-	// next is message
-	chatEvent.Message = data[5]
-
-	// next is playerUID
-	chatEvent.PlayerUID = data[6]
-
-	return chatEvent, nil
-}
-
-// radio events
-func logRadioEvent(data []string) (radioEvent model.RadioEvent, err error) {
-
-	// fix received data
-	for i, v := range data {
-		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
-	}
-
-	// get frame
-	frameStr := data[0]
-	capframe, err := strconv.ParseInt(frameStr, 10, 64)
-	if err != nil {
-		return radioEvent, fmt.Errorf(`error converting capture frame to int: %s`, err)
-	}
-
-	// timestamp will always be appended as the last element of data, in unixnano format as a string
-	timestampStr := data[len(data)-1]
-	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
-	if err != nil {
-		return radioEvent, fmt.Errorf(`error converting timestamp to int: %v`, err)
-	}
-	radioEvent.Time = time.Unix(0, timestampInt)
-
-	radioEvent.CaptureFrame = uint(capframe)
-	radioEvent.Mission = *CurrentMission
-
-	// parse data in array
-	senderOcapID, err := strconv.ParseInt(data[1], 10, 64)
-	if err != nil {
-		return radioEvent, fmt.Errorf(`error converting sender ocap id to uint: %v`, err)
-	}
-
-	// try and find sender solder in DB to associate if not -1
-	if senderOcapID > -1 {
-		senderSoldier, ok := EntityCache.GetSoldier(uint16(senderOcapID))
-
-		if !ok {
-			return radioEvent, fmt.Errorf(`sender ocap id not found in cache: %d`, senderOcapID)
-		}
-		radioEvent.Soldier = senderSoldier
-	}
-
-	// parse the rest of array
-	// radio
-	radioEvent.Radio = data[2]
-	// radio type (SW or LR)
-	radioEvent.RadioType = data[3]
-	// transmission type (start/end)
-	radioEvent.StartEnd = data[4]
-	// channel on radio (1-8) int8
-	channelInt, err := strconv.ParseInt(data[5], 10, 64)
-	if err != nil {
-		return radioEvent, fmt.Errorf(`error converting channel to int: %v`, err)
-	}
-	radioEvent.Channel = int8(channelInt)
-	// is primary or additional channel
-	isAddtl, err := strconv.ParseBool(data[6])
-	if err != nil {
-		return radioEvent, fmt.Errorf(`error converting isAddtl to bool: %v`, err)
-	}
-	radioEvent.IsAdditional = isAddtl
-
-	// frequency
-	freq, err := strconv.ParseFloat(data[7], 64)
-	if err != nil {
-		return radioEvent, fmt.Errorf(`error converting freq to float: %v`, err)
-	}
-	radioEvent.Frequency = float32(freq)
-
-	radioEvent.Code = data[8]
-
-	return radioEvent, nil
-}
-
-func logFpsEvent(data []string) (fpsEvent model.ServerFpsEvent, err error) {
-
-	// fix received data
-	for i, v := range data {
-		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
-	}
-
-	// get frame
-	frameStr := data[0]
-	capframe, err := strconv.ParseInt(frameStr, 10, 64)
-	if err != nil {
-		return fpsEvent, fmt.Errorf(`error converting capture frame to int: %s`, err)
-	}
-
-	// timestamp will always be appended as the last element of data, in unixnano format as a string
-	timestampStr := data[len(data)-1]
-	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
-	if err != nil {
-		return fpsEvent, fmt.Errorf(`error converting timestamp to int: %v`, err)
-	}
-
-	fpsEvent.CaptureFrame = uint(capframe)
-	fpsEvent.Time = time.Unix(0, timestampInt)
-	fpsEvent.Mission = *CurrentMission
-
-	// parse data in array
-	fps, err := strconv.ParseFloat(data[1], 64)
-	if err != nil {
-		return fpsEvent, fmt.Errorf(`error converting fps to float: %v`, err)
-	}
-	fpsEvent.FpsAverage = float32(fps)
-
-	fpsMin, err := strconv.ParseFloat(data[2], 64)
-	if err != nil {
-		return fpsEvent, fmt.Errorf(`error converting fpsMin to float: %v`, err)
-	}
-	fpsEvent.FpsMin = float32(fpsMin)
-
-	return fpsEvent, nil
-}
-
-func logAce3DeathEvent(data []string) (deathEvent model.Ace3DeathEvent, err error) {
-
-	// fix received data
-	for i, v := range data {
-		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
-	}
-
-	// get frame
-	frameStr := data[0]
-	capframe, err := strconv.ParseInt(frameStr, 10, 64)
-	if err != nil {
-		return deathEvent, fmt.Errorf(`error converting capture frame to int: %s`, err)
-	}
-
-	// timestamp will always be appended as the last element of data, in unixnano format as a string
-	timestampStr := data[len(data)-1]
-	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
-	if err != nil {
-		return deathEvent, fmt.Errorf(`error converting timestamp to int: %v`, err)
-	}
-	deathEvent.Time = time.Unix(0, timestampInt)
-
-	deathEvent.CaptureFrame = uint(capframe)
-	deathEvent.Mission = *CurrentMission
-
-	// parse data in array
-	victimOcapID, err := strconv.ParseUint(data[1], 10, 64)
-	if err != nil {
-		return deathEvent, fmt.Errorf(`error converting victim ocap id to uint: %v`, err)
-	}
-
-	// try and find victim in DB to associate
-	// first, look in soldiers
-	soldier, ok := EntityCache.GetSoldier(uint16(victimOcapID))
-	if ok {
-		deathEvent.Soldier = soldier
-	} else {
-		return deathEvent, fmt.Errorf(`victim ocap id not found in cache: %d`, victimOcapID)
-	}
-
-	deathEvent.Reason = data[2]
-
-	// get last damage source id [3]
-	lastDamageSourceID, err := strconv.ParseInt(data[3], 10, 64)
-	if err != nil {
-		return deathEvent, fmt.Errorf(`error converting last damage source id to uint: %v`, err)
-	}
-
-	if lastDamageSourceID > -1 {
-		lastDamageSource, ok := EntityCache.GetSoldier(uint16(lastDamageSourceID))
-		if !ok {
-			return deathEvent, fmt.Errorf(`last damage source id not found in cache: %d`, lastDamageSourceID)
-		}
-		deathEvent.LastDamageSourceID = sql.NullInt32{Int32: int32(lastDamageSource.ID), Valid: true}
-	}
-
-	return deathEvent, nil
-}
-
-func logAce3UnconsciousEvent(data []string) (unconsciousEvent model.Ace3UnconsciousEvent, err error) {
-	// fix received data
-	for i, v := range data {
-		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
-	}
-
-	// get frame
-	frameStr := data[0]
-	capframe, err := strconv.ParseInt(frameStr, 10, 64)
-	if err != nil {
-		return unconsciousEvent, fmt.Errorf(`error converting capture frame to int: %s`, err)
-	}
-
-	unconsciousEvent.CaptureFrame = uint(capframe)
-	unconsciousEvent.Mission = *CurrentMission
-
-	// parse data in array
-	ocapID, err := strconv.ParseUint(data[1], 10, 64)
-	if err != nil {
-		return unconsciousEvent, fmt.Errorf(`error converting ocap id to uint: %v`, err)
-	}
-
-	// try and find soldier in DB to associate
-	soldier, ok := EntityCache.GetSoldier(uint16(ocapID))
-	if !ok {
-		return unconsciousEvent, fmt.Errorf("soldier %d not found in cache", ocapID)
-	}
-	unconsciousEvent.Soldier = soldier
-
-	isAwake, err := strconv.ParseBool(data[2])
-	if err != nil {
-		return unconsciousEvent, fmt.Errorf(`error converting isAwake to bool: %v`, err)
-	}
-	unconsciousEvent.IsAwake = isAwake
-
-	return unconsciousEvent, nil
-}
-
-// logMarkerCreate processes :MARKER:CREATE: command
-// Data format: [markerName, dir, type, text, frameNo, -1, ownerId, color, size, side, pos, shape, alpha, brush, timestamp]
-func logMarkerCreate(data []string) (marker model.Marker, err error) {
-	functionName := ":MARKER:CREATE:"
-
-	// fix received data
-	for i, v := range data {
-		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
-	}
-
-	marker.MissionID = CurrentMission.ID
-
-	// markerName
-	marker.MarkerName = data[0]
-
-	// direction
-	dir, err := strconv.ParseFloat(data[1], 32)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf("Error parsing direction: %v", err), "ERROR")
-		return marker, err
-	}
-	marker.Direction = float32(dir)
-
-	// type
-	marker.MarkerType = data[2]
-
-	// text
-	marker.Text = data[3]
-
-	// frameNo
-	frameStr := data[4]
-	capframe, err := strconv.ParseInt(frameStr, 10, 64)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf("Error parsing capture frame: %v", err), "ERROR")
-		return marker, err
-	}
-	marker.CaptureFrame = uint(capframe)
-
-	// data[5] is -1, skip
-
-	// ownerId
-	ownerId, err := strconv.Atoi(data[6])
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf("Error parsing ownerId: %v", err), "WARN")
-		ownerId = -1
-	}
-	marker.OwnerID = ownerId
-
-	// color
-	marker.Color = data[7]
-
-	// size (stored as string "[w,h]")
-	marker.Size = data[8]
-
-	// side
-	marker.Side = data[9]
-
-	// position - parse from arma string "[x,y,z]"
-	pos := data[10]
-	pos = strings.TrimPrefix(pos, "[")
-	pos = strings.TrimSuffix(pos, "]")
-	point, _, err := geo.Coord3857FromString(pos)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf("Error parsing position: %v", err), "ERROR")
-		return marker, err
-	}
-	marker.Position = point
-
-	// shape
-	marker.Shape = data[11]
-
-	// alpha
-	alpha, err := strconv.ParseFloat(data[12], 32)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf("Error parsing alpha: %v", err), "WARN")
-		alpha = 1.0
-	}
-	marker.Alpha = float32(alpha)
-
-	// brush
-	marker.Brush = data[13]
-
-	// timestamp
-	timestampStr := data[len(data)-1]
-	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf("Error parsing timestamp: %v", err), "ERROR")
-		return marker, err
-	}
-	marker.Time = time.Unix(0, timestampInt)
-
-	marker.IsDeleted = false
-
-	return marker, nil
-}
-
-// logMarkerMove processes :MARKER:MOVE: command
-// Data format: [markerName, frameNo, pos, dir, alpha, timestamp]
-func logMarkerMove(data []string) (markerState model.MarkerState, err error) {
-	functionName := ":MARKER:MOVE:"
-
-	// fix received data
-	for i, v := range data {
-		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
-	}
-
-	markerState.MissionID = CurrentMission.ID
-
-	// markerName - look up marker ID from cache
-	markerName := data[0]
-	MarkerCacheLock.RLock()
-	markerID, ok := MarkerCache[markerName]
-	MarkerCacheLock.RUnlock()
-	if !ok {
-		return markerState, fmt.Errorf("marker %s not found in cache", markerName)
-	}
-	markerState.MarkerID = markerID
-
-	// frameNo
-	frameStr := data[1]
-	capframe, err := strconv.ParseInt(frameStr, 10, 64)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf("Error parsing capture frame: %v", err), "ERROR")
-		return markerState, err
-	}
-	markerState.CaptureFrame = uint(capframe)
-
-	// position
-	pos := data[2]
-	pos = strings.TrimPrefix(pos, "[")
-	pos = strings.TrimSuffix(pos, "]")
-	point, _, err := geo.Coord3857FromString(pos)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf("Error parsing position: %v", err), "ERROR")
-		return markerState, err
-	}
-	markerState.Position = point
-
-	// direction
-	dir, err := strconv.ParseFloat(data[3], 32)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf("Error parsing direction: %v", err), "WARN")
-		dir = 0
-	}
-	markerState.Direction = float32(dir)
-
-	// alpha
-	alpha, err := strconv.ParseFloat(data[4], 32)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf("Error parsing alpha: %v", err), "WARN")
-		alpha = 1.0
-	}
-	markerState.Alpha = float32(alpha)
-
-	// timestamp
-	timestampStr := data[len(data)-1]
-	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf("Error parsing timestamp: %v", err), "ERROR")
-		return markerState, err
-	}
-	markerState.Time = time.Unix(0, timestampInt)
-
-	return markerState, nil
-}
-
-// logMarkerDelete processes :MARKER:DELETE: command
-// Data format: [markerName, frameNo, timestamp]
-func logMarkerDelete(data []string) (markerName string, frameNo uint, err error) {
-	functionName := ":MARKER:DELETE:"
-
-	// fix received data
-	for i, v := range data {
-		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
-	}
-
-	markerName = data[0]
-
-	// frameNo
-	frameStr := data[1]
-	capframe, err := strconv.ParseInt(frameStr, 10, 64)
-	if err != nil {
-		writeLog(functionName, fmt.Sprintf("Error parsing capture frame: %v", err), "ERROR")
-		return markerName, 0, err
-	}
-	frameNo = uint(capframe)
-
-	return markerName, frameNo, nil
-}
-
-///////////////////////
-// GOROUTINES //
-///////////////////////
-
-func startAsyncProcessors() {
-	functionName := ":DATA:PROCESSOR:"
-
-	// these goroutines will receive data from buffered channels & process them into defined models, then push them into queues for writing
-	go func() {
-		// process channel data
-		for v := range RVExtArgsDataChannels[":NEW:SOLDIER:"] {
-			if !IsDatabaseValid {
-				continue
-			}
-
-			obj, err := logNewSoldier(v)
-			if err == nil {
-				soldiersToWrite.Push([]model.Soldier{obj})
-			} else {
-				writeLog(functionName, fmt.Sprintf(`Failed to log new soldier. Err: %s`, err), "ERROR")
-			}
-		}
-	}()
-
-	go func() {
-		// process channel data
-		for v := range RVExtArgsDataChannels[":NEW:VEHICLE:"] {
-			if !IsDatabaseValid {
-				continue
-			}
-
-			obj, err := logNewVehicle(v)
-			if err == nil {
-				vehiclesToWrite.Push([]model.Vehicle{obj})
-			} else {
-
-				writeLog(functionName, fmt.Sprintf(`Failed to log new vehicle. Err: %s`, err), "ERROR")
-			}
-		}
-	}()
-
-	go func() {
-		// process channel data
-		for v := range RVExtArgsDataChannels[":NEW:SOLDIER:STATE:"] {
-			if !IsDatabaseValid {
-				continue
-			}
-
-			obj, err := logSoldierState(v)
-			if err == nil {
-				soldierStatesToWrite.Push([]model.SoldierState{obj})
-			} else {
-				// if its within the first 10 frames, we don't want to log the error (because it's likely the unit itself isn't inserted yet)
-				if err == errTooEarlyForStateAssociation {
-					continue
-				}
-				writeLog(functionName, fmt.Sprintf(`Failed to log soldier state. Err: %s`, err), "ERROR")
-			}
-		}
-	}()
-
-	go func() {
-		// process channel data
-		for v := range RVExtArgsDataChannels[":NEW:VEHICLE:STATE:"] {
-			if !IsDatabaseValid {
-				continue
-			}
-
-			obj, err := logVehicleState(v)
-			if err == nil {
-				vehicleStatesToWrite.Push([]model.VehicleState{obj})
-				continue
-			} else {
-				// if its within the first 10 frames, we don't want to log the error (because it's likely the unit itself isn't inserted yet)
-				if err == errTooEarlyForStateAssociation {
-					continue
-				}
-				writeLog(functionName, fmt.Sprintf(`Failed to log vehicle state. Err: %s`, err), "ERROR")
-				continue
-			}
-		}
-	}()
-
-	go func() {
-		// process channel data
-		for v := range RVExtArgsDataChannels[":FIRED:"] {
-			if !IsDatabaseValid {
-				continue
-			}
-
-			obj, err := logFiredEvent(v)
-			if err == nil {
-				firedEventsToWrite.Push([]model.FiredEvent{obj})
-			} else {
-				// if its within the first 10 frames, we don't want to log the error (because it's likely the unit itself isn't inserted yet)
-				if err == errTooEarlyForStateAssociation {
-					continue
-				}
-				writeLog(functionName, fmt.Sprintf(`Failed to log fired event. Err: %s`, err), "ERROR")
-			}
-		}
-	}()
-
-	// projectile events
-	go func() {
-		for v := range RVExtArgsDataChannels[":PROJECTILE:"] {
-			// new projectile events use linestringzm geo format, which is not supported by SQLite
-			if !IsDatabaseValid || ShouldSaveLocal {
-				continue
-			}
-
-			obj, err := logProjectileEvent(v)
-			if err == nil {
-				projectileEventsToWrite.Push([]model.ProjectileEvent{obj})
-			} else {
-				// if its within the first 10 frames, we don't want to log the error (because it's likely the unit itself isn't inserted yet)
-				if err == errTooEarlyForStateAssociation {
-					continue
-				}
-				writeLog(functionName, fmt.Sprintf(`Failed to log projectile event. Err: %s`, err), "ERROR")
-			}
-		}
-	}()
-
-	go func() {
-		// process channel data
-		for v := range RVExtArgsDataChannels[":EVENT:"] {
-			if !IsDatabaseValid {
-				continue
-			}
-
-			obj, err := logGeneralEvent(v)
-			if err == nil {
-				generalEventsToWrite.Push([]model.GeneralEvent{obj})
-			} else {
-				writeLog(functionName, fmt.Sprintf(`Failed to log fired event. Err: %s`, err), "ERROR")
-			}
-		}
-	}()
-
-	go func() {
-		// process channel data
-		for v := range RVExtArgsDataChannels[":HIT:"] {
-			if !IsDatabaseValid {
-				continue
-			}
-
-			obj, err := logHitEvent(v)
-			if err == nil {
-				hitEventsToWrite.Push([]model.HitEvent{obj})
-			} else {
-				// if its within the first 10 frames, we don't want to log the error (because it's likely the unit itself isn't inserted yet)
-				if err == errTooEarlyForStateAssociation {
-					continue
-				}
-				writeLog(functionName, fmt.Sprintf(`Failed to log hit event. Err: %s`, err), "ERROR")
-			}
-		}
-	}()
-
-	go func() {
-		// process channel data
-		for v := range RVExtArgsDataChannels[":KILL:"] {
-			if !IsDatabaseValid {
-				continue
-			}
-
-			obj, err := logKillEvent(v)
-			if err == nil {
-				killEventsToWrite.Push([]model.KillEvent{obj})
-			} else {
-				// if its within the first 10 frames, we don't want to log the error (because it's likely the unit itself isn't inserted yet)
-				if err == errTooEarlyForStateAssociation {
-					continue
-				}
-				writeLog(functionName, fmt.Sprintf(`Failed to log kill event. Err: %s`, err), "ERROR")
-			}
-		}
-	}()
-
-	// chat events
-	go func() {
-		// process channel data
-		for v := range RVExtArgsDataChannels[":CHAT:"] {
-			if !IsDatabaseValid {
-				continue
-			}
-
-			obj, err := logChatEvent(v)
-			if err == nil {
-				chatEventsToWrite.Push([]model.ChatEvent{obj})
-			} else {
-				// if its within the first 10 frames, we don't want to log the error (because it's likely the unit itself isn't inserted yet)
-				if err == errTooEarlyForStateAssociation {
-					continue
-				}
-				writeLog(functionName, fmt.Sprintf(`Failed to log chat event. Err: %s`, err), "ERROR")
-			}
-		}
-	}()
-
-	// radio events
-	go func() {
-		// process channel data
-		for v := range RVExtArgsDataChannels[":RADIO:"] {
-			if !IsDatabaseValid {
-				continue
-			}
-
-			obj, err := logRadioEvent(v)
-			if err == nil {
-				radioEventsToWrite.Push([]model.RadioEvent{obj})
-			} else {
-				// if its within the first 10 frames, we don't want to log the error (because it's likely the unit itself isn't inserted yet)
-				if err == errTooEarlyForStateAssociation {
-					continue
-				}
-				writeLog(functionName, fmt.Sprintf(`Failed to log radio event. Err: %s`, err), "ERROR")
-			}
-		}
-	}()
-
-	// fps events
-	go func() {
-		// process channel data
-		for v := range RVExtArgsDataChannels[":FPS:"] {
-			if !IsDatabaseValid {
-				continue
-			}
-
-			obj, err := logFpsEvent(v)
-			if err == nil {
-				fpsEventsToWrite.Push([]model.ServerFpsEvent{obj})
-			} else {
-				// if its within the first 10 frames, we don't want to log the error (because it's likely the unit itself isn't inserted yet)
-				if err == errTooEarlyForStateAssociation {
-					continue
-				}
-				writeLog(functionName, fmt.Sprintf(`Failed to log fps event. Err: %s`, err), "ERROR")
-			}
-		}
-	}()
-
-	// ace3 death events
-	go func() {
-		// process channel data
-		for v := range RVExtArgsDataChannels[":ACE3:DEATH:"] {
-			if !IsDatabaseValid {
-				continue
-			}
-
-			obj, err := logAce3DeathEvent(v)
-			if err == nil {
-				ace3DeathEventsToWrite.Push([]model.Ace3DeathEvent{obj})
-			} else {
-				// if its within the first 10 frames, we don't want to log the error (because it's likely the unit itself isn't inserted yet)
-				if err == errTooEarlyForStateAssociation {
-					continue
-				}
-				writeLog(functionName, fmt.Sprintf(`Failed to log ace3 death event. Err: %s`, err), "ERROR")
-			}
-		}
-	}()
-
-	// ace3 unconscious events
-	go func() {
-		// process channel data
-		for v := range RVExtArgsDataChannels[":ACE3:UNCONSCIOUS:"] {
-			if !IsDatabaseValid {
-				continue
-			}
-
-			obj, err := logAce3UnconsciousEvent(v)
-			if err == nil {
-				ace3UnconsciousEventsToWrite.Push([]model.Ace3UnconsciousEvent{obj})
-			} else {
-				writeLog(functionName, fmt.Sprintf(`Failed to log ace3 unconscious event. Err: %s`, err), "ERROR")
-			}
-		}
-	}()
-
-	// metric data
-	go func() {
-		var err error
-		for data := range RVExtArgsDataChannels[":METRIC:"] {
-
-			if InfluxManager == nil {
-				continue
-			}
-
-			// process data
-			var bucket string
-			var point *influxdb2_write.Point
-			bucket, point, err = processMetricData(data)
-			if err != nil {
-				Logger.Error().Err(err).Msg("error processing metric data")
-				continue
-			}
-
-			err = writeInfluxPoint(context.Background(), bucket, point)
-			if err != nil {
-				Logger.Error().Err(err).Msg("error writing influx point")
-				continue
-			}
-		}
-	}()
-
-	// :MARKER:CREATE: processor
-	go func() {
-		for data := range RVExtArgsDataChannels[":MARKER:CREATE:"] {
-			if !IsDatabaseValid {
-				continue
-			}
-
-			marker, err := logMarkerCreate(data)
-			if err != nil {
-				Logger.Error().Err(err).Msg("Error processing marker create")
-				continue
-			}
-			markersToWrite.Push([]model.Marker{marker})
-		}
-	}()
-
-	// :MARKER:MOVE: processor
-	go func() {
-		for data := range RVExtArgsDataChannels[":MARKER:MOVE:"] {
-			if !IsDatabaseValid {
-				continue
-			}
-
-			markerState, err := logMarkerMove(data)
-			if err != nil {
-				Logger.Warn().Err(err).Msg("Error processing marker move")
-				continue
-			}
-			markerStatesToWrite.Push([]model.MarkerState{markerState})
-		}
-	}()
-
-	// :MARKER:DELETE: processor
-	go func() {
-		for data := range RVExtArgsDataChannels[":MARKER:DELETE:"] {
-			if !IsDatabaseValid {
-				continue
-			}
-
-			markerName, frameNo, err := logMarkerDelete(data)
-			if err != nil {
-				Logger.Error().Err(err).Msg("Error processing marker delete")
-				continue
-			}
-
-			// Look up marker and mark as deleted
-			MarkerCacheLock.RLock()
-			markerID, ok := MarkerCache[markerName]
-			MarkerCacheLock.RUnlock()
-			if ok {
-				// Create a marker state marking deletion
-				deleteState := model.MarkerState{
-					MissionID:    CurrentMission.ID,
-					MarkerID:     markerID,
-					CaptureFrame: frameNo,
-					Time:         time.Now(),
-					Alpha:        0, // Zero alpha indicates deletion
-				}
-				markerStatesToWrite.Push([]model.MarkerState{deleteState})
-
-				// Update marker as deleted in DB
-				DB.Model(&model.Marker{}).Where("id = ?", markerID).Update("is_deleted", true)
-			}
-		}
-	}()
-}
-
-var errTooEarlyForStateAssociation error = fmt.Errorf(`too early for state association`)
-
-func startDBWriters() {
-	functionName := ":DB:WRITER:"
-	// start the DB Write goroutine
-	go func() {
-		for {
-			if !IsDatabaseValid {
-				time.Sleep(1 * time.Second)
-				continue
-			}
-
-			if DBInsertsPaused {
-				time.Sleep(1 * time.Second)
-				continue
-			}
-
-			var (
-				writeStart time.Time = time.Now()
-			)
-
-			// write new soldiers
-			if !soldiersToWrite.Empty() {
-				tx := DB.Begin()
-				toWrite := soldiersToWrite.GetAndEmpty()
-				err := tx.Create(&toWrite).Error
-				if err != nil {
-					writeLog(functionName, fmt.Sprintf(`Error creating soldiers: %v`, err), "ERROR")
-					tx.Rollback()
-				} else {
-					tx.Commit()
-
-					// update entity cache
-					for _, v := range toWrite {
-						EntityCache.AddSoldier(v)
-					}
-				}
-			}
-
-			// write soldier states
-			if !soldierStatesToWrite.Empty() {
-				tx := DB.Begin()
-				toWrite := soldierStatesToWrite.GetAndEmpty()
-				err := tx.Create(&toWrite).Error
-				if err != nil {
-					writeLog(functionName, fmt.Sprintf(`Error creating soldier states: %v`, err), "ERROR")
-					tx.Rollback()
-				} else {
-					tx.Commit()
-				}
-			}
-
-			// write new vehicles
-			if !vehiclesToWrite.Empty() {
-				tx := DB.Begin()
-				toWrite := vehiclesToWrite.GetAndEmpty()
-				err := tx.Create(&toWrite).Error
-				if err != nil {
-					writeLog(functionName, fmt.Sprintf(`Error creating vehicles: %v`, err), "ERROR")
-					tx.Rollback()
-				} else {
-					tx.Commit()
-
-					// update entity cache
-					for _, v := range toWrite {
-						EntityCache.AddVehicle(v)
-					}
-				}
-			}
-
-			// write vehicle states
-			if !vehicleStatesToWrite.Empty() {
-				tx := DB.Begin()
-				toWrite := vehicleStatesToWrite.GetAndEmpty()
-				err := tx.Create(&toWrite).Error
-				if err != nil {
-					writeLog(functionName, fmt.Sprintf(`Error creating vehicle states: %v`, err), "ERROR")
-					stmt := tx.Statement.SQL.String()
-					writeLog(functionName, stmt, "ERROR")
-					tx.Rollback()
-				} else {
-					tx.Commit()
-				}
-			}
-
-			// write fired events
-			if !firedEventsToWrite.Empty() {
-				tx := DB.Begin()
-				toWrite := firedEventsToWrite.GetAndEmpty()
-				err := tx.Create(&toWrite).Error
-				if err != nil {
-					writeLog(functionName, fmt.Sprintf(`Error creating fired events: %v`, err), "ERROR")
-					stmt := tx.Statement.SQL.String()
-					writeLog(functionName, stmt, "ERROR")
-					tx.Rollback()
-				} else {
-					tx.Commit()
-				}
-			}
-
-			// write projectile events
-			if !projectileEventsToWrite.Empty() {
-				tx := DB.Begin()
-				toWrite := projectileEventsToWrite.GetAndEmpty()
-				err := tx.Create(&toWrite).Error
-				if err != nil {
-					writeLog(functionName, fmt.Sprintf(`Error creating projectile events: %v`, err), "ERROR")
-					stmt := tx.Statement.SQL.String()
-					writeLog(functionName, stmt, "ERROR")
-					tx.Rollback()
-				} else {
-					tx.Commit()
-				}
-			}
-
-			// write general events
-			if !generalEventsToWrite.Empty() {
-				tx := DB.Begin()
-				toWrite := generalEventsToWrite.GetAndEmpty()
-				err := tx.Create(&toWrite).Error
-				if err != nil {
-					writeLog(functionName, fmt.Sprintf(`Error creating general events: %v`, err), "ERROR")
-					tx.Rollback()
-				} else {
-					tx.Commit()
-				}
-			}
-
-			// write hit events
-			if !hitEventsToWrite.Empty() {
-				tx := DB.Begin()
-				toWrite := hitEventsToWrite.GetAndEmpty()
-				err := tx.Create(&toWrite).Error
-				if err != nil {
-					writeLog(functionName, fmt.Sprintf(`Error creating hit events: %v`, err), "ERROR")
-					tx.Rollback()
-				} else {
-					tx.Commit()
-				}
-			}
-
-			// write kill events
-			if !killEventsToWrite.Empty() {
-				tx := DB.Begin()
-				toWrite := killEventsToWrite.GetAndEmpty()
-				err := tx.Create(&toWrite).Error
-				if err != nil {
-					writeLog(functionName, fmt.Sprintf(`Error creating killed events: %v`, err), "ERROR")
-					tx.Rollback()
-				} else {
-					tx.Commit()
-				}
-			}
-
-			// write chat events
-			if !chatEventsToWrite.Empty() {
-				tx := DB.Begin()
-				toWrite := chatEventsToWrite.GetAndEmpty()
-				err := tx.Create(&toWrite).Error
-				if err != nil {
-					writeLog(functionName, fmt.Sprintf(`Error creating chat events: %v`, err), "ERROR")
-					tx.Rollback()
-				} else {
-					tx.Commit()
-				}
-			}
-
-			// write radio events
-			if !radioEventsToWrite.Empty() {
-				tx := DB.Begin()
-				toWrite := radioEventsToWrite.GetAndEmpty()
-				err := tx.Create(&toWrite).Error
-				if err != nil {
-					writeLog(functionName, fmt.Sprintf(`Error creating radio events: %v`, err), "ERROR")
-					tx.Rollback()
-				} else {
-					tx.Commit()
-				}
-			}
-
-			// write serverfps events
-			if !fpsEventsToWrite.Empty() {
-				tx := DB.Begin()
-				toWrite := fpsEventsToWrite.GetAndEmpty()
-				err := tx.Create(&toWrite).Error
-				if err != nil {
-					writeLog(functionName, fmt.Sprintf(`Error creating serverfps events: %v`, err), "ERROR")
-					tx.Rollback()
-				} else {
-					tx.Commit()
-				}
-			}
-
-			// write ace3 death events
-			if !ace3DeathEventsToWrite.Empty() {
-				tx := DB.Begin()
-				toWrite := ace3DeathEventsToWrite.GetAndEmpty()
-				err := tx.Create(&toWrite).Error
-				if err != nil {
-					writeLog(functionName, fmt.Sprintf(`Error creating ace3 death events: %v`, err), "ERROR")
-					tx.Rollback()
-				} else {
-					tx.Commit()
-				}
-			}
-
-			// write ace3 unconscious events
-			if !ace3UnconsciousEventsToWrite.Empty() {
-				tx := DB.Begin()
-				toWrite := ace3UnconsciousEventsToWrite.GetAndEmpty()
-				err := tx.Create(&toWrite).Error
-				if err != nil {
-					writeLog(functionName, fmt.Sprintf(`Error creating ace3 unconscious events: %v`, err), "ERROR")
-					tx.Rollback()
-				} else {
-					tx.Commit()
-				}
-			}
-
-			// write markers
-			if !markersToWrite.Empty() {
-				tx := DB.Begin()
-				toWrite := markersToWrite.GetAndEmpty()
-				err := tx.Create(&toWrite).Error
-				if err != nil {
-					writeLog(functionName, fmt.Sprintf(`Error creating markers: %v`, err), "ERROR")
-					tx.Rollback()
-				} else {
-					tx.Commit()
-
-					// update marker cache with new IDs
-					MarkerCacheLock.Lock()
-					for _, m := range toWrite {
-						if m.ID != 0 {
-							MarkerCache[m.MarkerName] = m.ID
-						}
-					}
-					MarkerCacheLock.Unlock()
-				}
-			}
-
-			// write marker states
-			if !markerStatesToWrite.Empty() {
-				tx := DB.Begin()
-				toWrite := markerStatesToWrite.GetAndEmpty()
-				err := tx.Create(&toWrite).Error
-				if err != nil {
-					writeLog(functionName, fmt.Sprintf(`Error creating marker states: %v`, err), "ERROR")
-					tx.Rollback()
-				} else {
-					tx.Commit()
-				}
-			}
-
-			LastDBWriteDuration = time.Since(writeStart)
-
-			// sleep
-			time.Sleep(2 * time.Second)
-
-		}
-	}()
-}
-
-// /////////////////////
-// EXPORTED FUNCTIONS //
-// /////////////////////
-
-func writeLog(
-	functionName string,
-	data string,
-	level string,
-) {
-	// get calling function & line
-	// _, file, line, _ := runtime.Caller(1)
-
-	var logLevelActual zerolog.Level
-	switch level {
-	case "DEBUG":
-		logLevelActual = zerolog.DebugLevel
-	case "INFO":
-		logLevelActual = zerolog.InfoLevel
-	case "WARN":
-		logLevelActual = zerolog.WarnLevel
-	case "ERROR":
-		logLevelActual = zerolog.ErrorLevel
-	case "FATAL":
-		logLevelActual = zerolog.FatalLevel
-	}
-
-	// debug limits configured in global defs based on config
-	Logger.WithLevel(logLevelActual).
-		Str("function", functionName).
-		Msg(data)
-
-	JSONLogger.WithLevel(logLevelActual).
-		Str("function", functionName).
-		Msg(data)
 }
 
 //////////////////////////////////////////////////////////////
@@ -3197,112 +705,92 @@ func migrateBackupsSqlite() (err error) {
 		tx := postgresDB.Begin()
 
 		// migrate all tables
-		// ocap_infos
 		err = migrateTable(sqliteDB, tx, model.OcapInfo{}, "ocap_infos")
 		if err != nil {
 			return fmt.Errorf("error migrating ocapinfo: %v", err)
 		}
-		// after_action_reviews
 		err = migrateTable(sqliteDB, tx, model.AfterActionReview{}, "after_action_reviews")
 		if err != nil {
 			return fmt.Errorf("error migrating after_action_reviews: %v", err)
 		}
-		// worlds
 		err = migrateTable(sqliteDB, tx, model.World{}, "worlds")
 		if err != nil {
 			return fmt.Errorf("error migrating worlds: %v", err)
 		}
-		// missions
 		err = migrateTable(sqliteDB, tx, model.Mission{}, "missions")
 		if err != nil {
 			return fmt.Errorf("error migrating missions: %v", err)
 		}
-
-		// soldiers
 		err = migrateTable(sqliteDB, tx, model.Soldier{}, "soldiers")
 		if err != nil {
 			tx.Rollback()
 			return fmt.Errorf("error migrating soldiers: %v", err)
 		}
-		//soldier_states
 		err = migrateTable(sqliteDB, tx, model.SoldierState{}, "soldier_states")
 		if err != nil {
 			tx.Rollback()
 			return fmt.Errorf("error migrating soldier_states: %v", err)
 		}
-		// vehicles
 		err = migrateTable(sqliteDB, tx, model.Vehicle{}, "vehicles")
 		if err != nil {
 			tx.Rollback()
 			return fmt.Errorf("error migrating vehicles: %v", err)
 		}
-		// vehicle_states
 		err = migrateTable(sqliteDB, tx, model.VehicleState{}, "vehicle_states")
 		if err != nil {
 			tx.Rollback()
 			return fmt.Errorf("error migrating vehicle_states: %v", err)
 		}
-		// fired_events
 		err = migrateTable(sqliteDB, tx, model.FiredEvent{}, "fired_events")
 		if err != nil {
 			tx.Rollback()
 			return fmt.Errorf("error migrating fired_events: %v", err)
 		}
-		// projectile_events
 		err = migrateTable(sqliteDB, tx, model.ProjectileEvent{}, "projectile_events")
 		if err != nil {
 			tx.Rollback()
 			return fmt.Errorf("error migrating projectile_events: %v", err)
 		}
-		// general_events
 		err = migrateTable(sqliteDB, tx, model.GeneralEvent{}, "general_events")
 		if err != nil {
 			tx.Rollback()
 			return fmt.Errorf("error migrating general_events: %v", err)
 		}
-		// hit_events
 		err = migrateTable(sqliteDB, tx, model.HitEvent{}, "hit_events")
 		if err != nil {
 			tx.Rollback()
 			return fmt.Errorf("error migrating hit_events: %v", err)
 		}
-		// kill_events
 		err = migrateTable(sqliteDB, tx, model.KillEvent{}, "kill_events")
 		if err != nil {
 			tx.Rollback()
 			return fmt.Errorf("error migrating kill_events: %v", err)
 		}
-		// chat_events
 		err = migrateTable(sqliteDB, tx, model.ChatEvent{}, "chat_events")
 		if err != nil {
 			tx.Rollback()
 			return fmt.Errorf("error migrating chat_events: %v", err)
 		}
-		// radio_events
 		err = migrateTable(sqliteDB, tx, model.RadioEvent{}, "radio_events")
 		if err != nil {
 			tx.Rollback()
 			return fmt.Errorf("error migrating radio_events: %v", err)
 		}
-		// server_fps_events
 		err = migrateTable(sqliteDB, tx, model.ServerFpsEvent{}, "server_fps_events")
 		if err != nil {
 			tx.Rollback()
 			return fmt.Errorf("error migrating server_fps_events: %v", err)
 		}
-		// ace3_death_events
 		err = migrateTable(sqliteDB, tx, model.Ace3DeathEvent{}, "ace3_death_events")
 		if err != nil {
 			tx.Rollback()
 			return fmt.Errorf("error migrating ace3_death_events: %v", err)
 		}
-		// ace3_unconscious_events
 		err = migrateTable(sqliteDB, tx, model.Ace3UnconsciousEvent{}, "ace3_unconscious_events")
 		if err != nil {
 			tx.Rollback()
 			return fmt.Errorf("error migrating ace3_unconscious_events: %v", err)
 		}
-		// ocap_performances
 		err = migrateTable(sqliteDB, tx, model.OcapPerformance{}, "ocap_performances")
 		if err != nil {
 			tx.Rollback()
@@ -3351,7 +839,7 @@ func migrateTable[M any](
 	model M,
 	tableName string,
 ) (err error) {
-	var data = &map[string]interface{}{}
+	var data = &map[string]any{}
 	sqliteDB.Model(&model).
 		Assign("id", gorm.Expr("NULL")). // remove the id field from the data
 		Find(data)
@@ -3390,142 +878,68 @@ func populateDemoData() {
 	// declare test size counts
 	var (
 		numMissions              int = 2
-		missionDuration          int = 60 * 15                                                    // s * value (m) = total (s)
-		numUnitsPerMission       int = 60                                                         // num units per mission
-		numSoldiers              int = int(math.Ceil(float64(numUnitsPerMission) * float64(0.8))) // numUnits / 3
+		missionDuration          int = 60 * 15
+		numUnitsPerMission       int = 60
+		numSoldiers              int = int(math.Ceil(float64(numUnitsPerMission) * float64(0.8)))
 		numFiredEventsPerSoldier int = 2700
-		numVehicles              int = numUnitsPerMission - numSoldiers // numUnits / 3
+		numVehicles              int = numUnitsPerMission - numSoldiers
 
 		waitGroup = sync.WaitGroup{}
 
-		sides []string = []string{
-			"WEST",
-			"EAST",
-			"GUER",
-			"CIV",
-		}
+		sides []string = []string{"WEST", "EAST", "GUER", "CIV"}
 
 		vehicleClassnames []string = []string{
-			"B_MRAP_01_F",
-			"B_MRAP_01_gmg_F",
-			"B_MRAP_01_hmg_F",
-			"B_G_Offroad_01_armed_F",
-			"B_G_Offroad_01_AT_F",
-			"B_G_Offroad_01_F",
-			"B_G_Offroad_01_repair_F",
-			"B_APC_Wheeled_01_cannon_F",
-			"B_APC_Tracked_01_AA_F",
-			"B_APC_Tracked_01_CRV_F",
+			"B_MRAP_01_F", "B_MRAP_01_gmg_F", "B_MRAP_01_hmg_F",
+			"B_G_Offroad_01_armed_F", "B_G_Offroad_01_AT_F", "B_G_Offroad_01_F",
+			"B_G_Offroad_01_repair_F", "B_APC_Wheeled_01_cannon_F",
+			"B_APC_Tracked_01_AA_F", "B_APC_Tracked_01_CRV_F",
 			"B_APC_Tracked_01_rcws_F",
-			"B_APC_Tracked_01_CRV_F",
 		}
 
 		ocapTypes []string = []string{
-			"ship",
-			"parachute",
-			"heli",
-			"plane",
-			"truck",
-			"car",
-			"apc",
-			"tank",
-			"staticMortar",
-			"unknown",
+			"ship", "parachute", "heli", "plane", "truck",
+			"car", "apc", "tank", "staticMortar", "unknown",
 		}
 
 		roles []string = []string{
-			"Rifleman",
-			"Team Leader",
-			"Auto Rifleman",
-			"Assistant Auto Rifleman",
-			"Grenadier",
-			"Machine Gunner",
-			"Assistant Machine Gunner",
-			"Medic",
-			"Engineer",
-			"Explosive Specialist",
-			"Rifleman (AT)",
-			"Rifleman (AA)",
-			"Officer",
+			"Rifleman", "Team Leader", "Auto Rifleman", "Assistant Auto Rifleman",
+			"Grenadier", "Machine Gunner", "Assistant Machine Gunner", "Medic",
+			"Engineer", "Explosive Specialist", "Rifleman (AT)", "Rifleman (AA)", "Officer",
 		}
 
 		roleDescriptions []string = []string{
-			"Rifleman@Alpha",
-			"Team Leader@Alpha",
-			"Auto Rifleman@Alpha",
-			"Assistant Auto Rifleman@Alpha",
-			"Grenadier@Alpha",
-			"Machine Gunner@Alpha",
-			"Assistant Machine Gunner@Alpha",
-			"Medic@Alpha",
-			"Rifleman@Bravo",
-			"Team Leader@Bravo",
-			"Auto Rifleman@Bravo",
-			"Assistant Auto Rifleman@Bravo",
-			"Grenadier@Bravo",
-			"Machine Gunner@Bravo",
-			"Assistant Machine Gunner@Bravo",
-			"Medic@Bravo",
+			"Rifleman@Alpha", "Team Leader@Alpha", "Auto Rifleman@Alpha",
+			"Assistant Auto Rifleman@Alpha", "Grenadier@Alpha", "Machine Gunner@Alpha",
+			"Assistant Machine Gunner@Alpha", "Medic@Alpha",
+			"Rifleman@Bravo", "Team Leader@Bravo", "Auto Rifleman@Bravo",
+			"Assistant Auto Rifleman@Bravo", "Grenadier@Bravo", "Machine Gunner@Bravo",
+			"Assistant Machine Gunner@Bravo", "Medic@Bravo",
 		}
 
 		weapons []string = []string{
-			"Katiba",
-			"MXC 6.5 mm",
-			"MX 6.5 mm",
-			"MX SW 6.5 mm",
-			"MXM 6.5 mm",
-			"SPAR-16 5.56 mm",
-			"SPAR-16S 5.56 mm",
-			"SPAR-17 7.62 mm",
-			"TAR-21 5.56 mm",
-			"TRG-21 5.56 mm",
-			"TRG-20 5.56 mm",
-			"TRG-21 EGLM 5.56 mm",
-			"CAR-95 5.8 mm",
-			"CAR-95-1 5.8 mm",
-			"CAR-95 GL 5.8 mm",
+			"Katiba", "MXC 6.5 mm", "MX 6.5 mm", "MX SW 6.5 mm", "MXM 6.5 mm",
+			"SPAR-16 5.56 mm", "SPAR-16S 5.56 mm", "SPAR-17 7.62 mm",
+			"TAR-21 5.56 mm", "TRG-21 5.56 mm", "TRG-20 5.56 mm",
+			"TRG-21 EGLM 5.56 mm", "CAR-95 5.8 mm", "CAR-95-1 5.8 mm", "CAR-95 GL 5.8 mm",
 		}
 
 		magazines []string = []string{
-			"30rnd 6.5 mm Caseless Mag",
-			"30rnd 6.5 mm Caseless Mag Tracer",
-			"100rnd 6.5 mm Caseless Mag",
-			"100rnd 6.5 mm Caseless Mag Tracer",
-			"200rnd 6.5 mm Caseless Mag",
-			"200rnd 6.5 mm Caseless Mag Tracer",
-			"30rnd 5.56 mm STANAG",
-			"30rnd 5.56 mm STANAG Tracer (Yellow)",
-			"30rnd 5.56 mm STANAG Tracer (Red)",
-			"30rnd 5.56 mm STANAG Tracer (Green)",
+			"30rnd 6.5 mm Caseless Mag", "30rnd 6.5 mm Caseless Mag Tracer",
+			"100rnd 6.5 mm Caseless Mag", "100rnd 6.5 mm Caseless Mag Tracer",
+			"200rnd 6.5 mm Caseless Mag", "200rnd 6.5 mm Caseless Mag Tracer",
+			"30rnd 5.56 mm STANAG", "30rnd 5.56 mm STANAG Tracer (Yellow)",
+			"30rnd 5.56 mm STANAG Tracer (Red)", "30rnd 5.56 mm STANAG Tracer (Green)",
 		}
 
-		firemodes []string = []string{
-			"Single",
-			"FullAuto",
-			"Burst3",
-			"Burst5",
-		}
+		firemodes []string = []string{"Single", "FullAuto", "Burst3", "Burst5"}
 
 		worldNames []string = []string{
-			"Altis",
-			"Stratis",
-			"VR",
-			"Bootcamp_ACR",
-			"Malden",
-			"ProvingGrounds_PMC",
-			"Shapur_BAF",
-			"Sara",
-			"Sara_dbe1",
-			"SaraLite",
-			"Woodland_ACR",
-			"Chernarus",
-			"Desert_E",
-			"Desert_Island",
-			"Intro",
-			"Desert2",
+			"Altis", "Stratis", "VR", "Bootcamp_ACR", "Malden",
+			"ProvingGrounds_PMC", "Shapur_BAF", "Sara", "Sara_dbe1", "SaraLite",
+			"Woodland_ACR", "Chernarus", "Desert_E", "Desert_Island", "Intro", "Desert2",
 		}
 
-		demoAddons [][]interface{} = [][]interface{}{
+		demoAddons [][]any = [][]any{
 			{"Community Base Addons v3.15.1", 0},
 			{"Arma 3 Contact", 0},
 			{"Arma 3 Creator DLC: Global Mobilization - Cold War Germany", 0},
@@ -3545,33 +959,19 @@ func populateDemoData() {
 	for i := 0; i < numMissions; i++ {
 		data := make([]string, 2)
 
-		// WORLD CONTEXT SENT AS JSON IN DATA[0]
-		// ["author", _author],
-		// ["workshopID", _workshopID],
-		// ["displayName", _name],
-		// ["worldName", toLower worldName],
-		// ["worldNameOriginal", worldName],
-		// ["worldSize", getNumber(configFile >> "CfgWorlds" >> worldName >> "worldSize")],
-		// ["latitude", getNumber(configFile >> "CfgWorlds" >> worldName >> "latitude")],
-		// ["longitude", getNumber(configFile >> "CfgWorlds" >> worldName >> "longitude")]
-
-		// pick random name from list
 		worldNameOriginal := worldNames[rand.Intn(len(worldNames))]
-		// displayname, replace underscores with spaces
 		displayName := strings.Replace(worldNameOriginal, "_", " ", -1)
-		// worldName, lowercase
 		worldName := strings.ToLower(worldNameOriginal)
 
-		worldData := map[string]interface{}{
+		worldData := map[string]any{
 			"author":            "Demo Author",
 			"workshopID":        "123456789",
 			"displayName":       displayName,
 			"worldName":         worldName,
 			"worldNameOriginal": worldNameOriginal,
 			"worldSize":         10240,
-			// random lon lat
-			"latitude":  rand.Float64() * 180,
-			"longitude": rand.Float64() * 180,
+			"latitude":          rand.Float64() * 180,
+			"longitude":         rand.Float64() * 180,
 		}
 		worldDataJSON, err := json.Marshal(worldData)
 		if err != nil {
@@ -3579,10 +979,7 @@ func populateDemoData() {
 		}
 		data[0] = string(worldDataJSON)
 
-		// MISSION CONTEXT SENT AS STRING IN DATA[1]
-
-		// ["tag", EGVAR(settings,saveTag)]
-		missionData := map[string]interface{}{
+		missionData := map[string]any{
 			"missionName":                  fmt.Sprintf("Demo Mission %d", i),
 			"briefingName":                 fmt.Sprintf("Demo Briefing %d", i),
 			"missionNameSource":            fmt.Sprintf("Demo Mission %d", i),
@@ -3590,7 +987,7 @@ func populateDemoData() {
 			"author":                       "Demo Author",
 			"serverName":                   "Demo Server",
 			"serverProfile":                "Demo Profile",
-			"missionStart":                 nil, // random time
+			"missionStart":                 nil,
 			"worldName":                    fmt.Sprintf("demo_world_%d", i),
 			"tag":                          "Demo Tag",
 			"captureDelay":                 1.0,
@@ -3625,20 +1022,20 @@ func populateDemoData() {
 
 	waitGroup = sync.WaitGroup{}
 	for _, mission := range missions {
-		CurrentMission = &mission
+		if handlerService != nil {
+			handlerService.GetMissionContext().SetMission(&mission, nil)
+		}
 
 		fmt.Printf("Populating mission with ID %d\n", mission.ID)
 
-		// write soldiers, now that our missions exist and the channels have been created
+		// write soldiers
 		idCounter := 1
 
 		for i := 0; i <= numSoldiers; i++ {
 			waitGroup.Add(1)
 			go func(thisId int) {
-				// these will be sent as an array
-				// frame := strconv.FormatInt(int64(rand.Intn(missionDuration)), 10)
 				soldierID := strconv.FormatInt(int64(thisId), 10)
-				squadParams := []interface{}{
+				squadParams := []any{
 					[]string{"DD", "Diamond Dogs", "t@example.com", "https://example.com", "", "Diamond Dogs"},
 					[]string{"12491654", "Sleeping Tiger", "Sleeping Tiger", "st@example.com", "", "Thanks, Boss!"},
 					"1294510750",
@@ -3650,25 +1047,22 @@ func populateDemoData() {
 				}
 
 				soldier := []string{
-					soldierID,                                          // join frame
-					soldierID,                                          // ocapid
-					fmt.Sprintf("Demo Unit %d", i),                     // unit name
-					fmt.Sprintf("Demo Group %d", i),                    // group id
-					sides[rand.Intn(len(sides))],                       // side
-					strconv.FormatBool(rand.Intn(2) == 1),              // isplayer
-					roleDescriptions[rand.Intn(len(roleDescriptions))], // roleDescription
-					"B_Soldier_F",                                      // unit classname
-					"Rifleman",                                         // unit display name
-					strconv.FormatInt(int64(rand.Intn(1000000000)), 10), // random player uid
-					// json squad params
+					soldierID,
+					soldierID,
+					fmt.Sprintf("Demo Unit %d", i),
+					fmt.Sprintf("Demo Group %d", i),
+					sides[rand.Intn(len(sides))],
+					strconv.FormatBool(rand.Intn(2) == 1),
+					roleDescriptions[rand.Intn(len(roleDescriptions))],
+					"B_Soldier_F",
+					"Rifleman",
+					strconv.FormatInt(int64(rand.Intn(1000000000)), 10),
 					string(squadParamsJSON),
 				}
 
-				// add timestamp to end of array
 				soldier = append(soldier, fmt.Sprintf("%d", time.Now().UnixNano()))
 				RVExtArgsDataChannels[":NEW:SOLDIER:"] <- soldier
 
-				//wait loop to check if in cache yet
 				for {
 					time.Sleep(100 * time.Millisecond)
 					if _, ok := EntityCache.GetSoldier(uint16(thisId)); ok {
@@ -3676,18 +1070,15 @@ func populateDemoData() {
 					}
 				}
 
-				// write soldier states
 				var randomPos [3]float64 = [3]float64{rand.Float64() * 30720, rand.Float64() * 30720, rand.Float64() * 30720}
 				var randomDir float64 = rand.Float64() * 360
 				var dirMoveOffset float64 = rand.Float64() * 360
 				var randomLifestate int = rand.Intn(3)
 				var currentRole string = roles[rand.Intn(len(roles))]
-				for i := 0; i <= missionDuration; i++ {
-					// sleep 500 ms to make sure there's enough time between processing so time doesn't match exactly
+				for j := 0; j <= missionDuration; j++ {
 					time.Sleep(100 * time.Millisecond)
 
-					stateFrame := i
-					// determine xy transform to translate pos in randomDir limited to 180 degress of dirMoveOffset
+					stateFrame := j
 					var xyTransform [2]float64 = [2]float64{0, 0}
 					if randomDir < 180 {
 						xyTransform[0] = math.Sin((randomDir + dirMoveOffset) * (math.Pi / 180))
@@ -3696,56 +1087,35 @@ func populateDemoData() {
 						xyTransform[0] = math.Sin((randomDir - dirMoveOffset) * (math.Pi / 180))
 						xyTransform[1] = math.Cos((randomDir - dirMoveOffset) * (math.Pi / 180))
 					}
-					// adjust random pos by random + or - 4m in xyTransform direction
 					randomPos[0] += xyTransform[0] + (rand.Float64() * 8) - 4
 					randomPos[1] += xyTransform[1] + (rand.Float64() * 8) - 4
 					randomPos[2] += (rand.Float64() * 8) - 4
-
-					// adjust random dir by random + or - 4
 					randomDir += (rand.Float64() * 8) - 4
-
-					// 10% chance of setting random lifestate
 					if rand.Intn(10) == 0 {
 						randomLifestate = rand.Intn(3)
 					}
-
-					// 5% chance of setting random role
 					if rand.Intn(20) == 0 {
 						currentRole = roles[rand.Intn(len(roles))]
 					}
 
 					soldierState := []string{
-						// soldier id we just made
 						soldierID,
-						// random pos
 						fmt.Sprintf("[%f,%f,%f]", randomPos[0], randomPos[1], randomPos[2]),
-						// random dir rounded to int
 						strconv.FormatFloat(randomDir, 'f', 0, 64),
-						// random lifestate (0 to 2)
 						strconv.FormatInt(int64(randomLifestate), 10),
-						// random inVehicle bool
 						strconv.FormatBool(rand.Intn(2) == 1),
-						// random name
-						fmt.Sprintf("Demo Unit %d", i),
-						// random isPlayer bool
+						fmt.Sprintf("Demo Unit %d", j),
 						strconv.FormatBool(rand.Intn(2) == 1),
-						// random role
 						currentRole,
-						// capture frame
 						strconv.FormatInt(int64(stateFrame), 10),
-						// hasStableVitals 0 or 1
 						strconv.FormatInt(int64(rand.Intn(2)), 10),
-						// is being dragged/carried 0 or 1
 						strconv.FormatInt(int64(rand.Intn(2)), 10),
-						// scores, random uint array of length 6
 						fmt.Sprintf("%d,%d,%d,%d,%d,%d", rand.Intn(20), rand.Intn(20), rand.Intn(20), rand.Intn(20), rand.Intn(20), rand.Intn(20)),
-						// vehicle role, select random
 						"Passenger",
-						// random stance
+						"-1",
 						[]string{"Up", "Middle", "Down"}[rand.Intn(3)],
 					}
 
-					// add timestamp to end of array
 					soldierState = append(soldierState, fmt.Sprintf("%d", time.Now().UnixNano()))
 					RVExtArgsDataChannels[":NEW:SOLDIER:STATE:"] <- soldierState
 				}
@@ -3764,76 +1134,44 @@ func populateDemoData() {
 			go func(thisId int) {
 				vehicleID := strconv.FormatInt(int64(thisId), 10)
 				vehicle := []string{
-					// join frame
 					vehicleID,
-					// ocapid
 					vehicleID,
-					// random ocap type
 					ocapTypes[rand.Intn(len(ocapTypes))],
-					// random display name
 					fmt.Sprintf("Demo Vehicle %d", i),
-					// random classname
 					vehicleClassnames[rand.Intn(len(vehicleClassnames))],
-					// random vehicle customization
-					fmt.Sprintf(
-						`"[[""%s"", %d], [""%s"", %d], [""%s"", %d]]"`,
-						"wasp",
-						1,
-						"AddTread",
-						1,
-						"AddTread_Short",
-						1,
-					),
+					fmt.Sprintf(`"[[""%s"", %d], [""%s"", %d], [""%s"", %d]]"`, "wasp", 1, "AddTread", 1, "AddTread_Short", 1),
 				}
 
-				// add timestamp to end of array
 				vehicle = append(vehicle, fmt.Sprintf("%d", time.Now().UnixNano()))
 				RVExtArgsDataChannels[":NEW:VEHICLE:"] <- vehicle
 
-				// use loop, waiting for vehicle to be written (available in cache)
 				for {
-					// sleep 1000 ms
 					time.Sleep(1000 * time.Millisecond)
-					// check if vehicle is in cache
 					if _, ok := EntityCache.GetVehicle(uint16(thisId)); ok {
 						break
 					}
 				}
 
-				// send vehicle states
-				for i := 0; i <= missionDuration; i++ {
-					// sleep for timestamp
+				for j := 0; j <= missionDuration; j++ {
 					time.Sleep(100 * time.Millisecond)
 					vehicleState := []string{
-						// ocap id
 						vehicleID,
-						// random pos
 						fmt.Sprintf("[%f,%f,%f]", rand.Float64()*30720+1, rand.Float64()*30720+1, rand.Float64()*30720+1),
-						// random dir
 						fmt.Sprintf("%d", rand.Intn(360)),
-						// random isAlive bool
 						strconv.FormatBool(rand.Intn(2) == 1),
-						// random crew (array of soldiers)
 						fmt.Sprintf("[%d,%d,%d]", rand.Intn(numSoldiers)+1, rand.Intn(numSoldiers)+1, rand.Intn(numSoldiers)+1),
-						// random frame
 						strconv.FormatInt(int64(rand.Intn(missionDuration)), 10),
-						// random fuel 0 to 1.0
 						fmt.Sprintf("%f", rand.Float64()),
-						// random damage 0 to 1.0
 						fmt.Sprintf("%f", rand.Float64()),
-						// random isEngineOn bool (1 in 10 chance of being true)
 						strconv.FormatBool(rand.Intn(10) == 0),
-						// random locked bool (1 in 10 chance of being true)
 						strconv.FormatBool(rand.Intn(10) == 0),
-						// random side
 						sides[rand.Intn(len(sides))],
-						// vectordir
 						fmt.Sprintf("[%f,%f,%f]", rand.Float64(), rand.Float64(), rand.Float64()),
-						// vectorup
 						fmt.Sprintf("[%f,%f,%f]", rand.Float64(), rand.Float64(), rand.Float64()),
+						fmt.Sprintf("%f", rand.Float64()),
+						fmt.Sprintf("%f", rand.Float64()),
 					}
 
-					// add timestamp to end of array
 					vehicleState = append(vehicleState, fmt.Sprintf("%d", time.Now().UnixNano()))
 					RVExtArgsDataChannels[":NEW:VEHICLE:STATE:"] <- vehicleState
 				}
@@ -3842,47 +1180,32 @@ func populateDemoData() {
 			idCounter++
 		}
 
-		// wait for all units and states to be created so fired events can associate
 		waitGroup.Wait()
 
 		fmt.Println("Finished creating units and states.")
 		fmt.Println("Creating fired events...")
 
-		// create a new wait group
 		wg2 := sync.WaitGroup{}
-		// demo fired events, X per soldier per mission
 		for i := 0; i <= numSoldiers*numFiredEventsPerSoldier; i++ {
 			wg2.Add(1)
 
-			// sleep 100 ms
-			// time.Sleep(100 * time.Millisecond)
-
 			go func() {
 				var randomStartPos []float64 = []float64{rand.Float64()*30720 + 1, rand.Float64()*30720 + 1, rand.Float64()*30720 + 1}
-				// generate random end pos within 200 m
 				var randomEndPos []float64
 				for j := 0; j < 3; j++ {
 					randomEndPos = append(randomEndPos, randomStartPos[j]+rand.Float64()*400-200)
 				}
 
 				firedEvent := []string{
-					// random soldier id
 					strconv.FormatInt(int64(rand.Intn(numSoldiers)+1), 10),
-					// random frame
 					strconv.FormatInt(int64(rand.Intn(missionDuration)), 10),
-					// random start pos
 					fmt.Sprintf("%f,%f,%f", randomStartPos[0], randomStartPos[1], randomStartPos[2]),
-					// random end pos within 200m of start pos
 					fmt.Sprintf("%f,%f,%f", randomEndPos[0], randomEndPos[1], randomEndPos[2]),
-					// random weapon
 					weapons[rand.Intn(len(weapons))],
-					// random magazine
 					magazines[rand.Intn(len(magazines))],
-					// random firemode
 					firemodes[rand.Intn(len(firemodes))],
 				}
 
-				// add timestamp to end of array
 				firedEvent = append(firedEvent, fmt.Sprintf("%d", time.Now().UnixNano()))
 				RVExtArgsDataChannels[":FIRED:"] <- firedEvent
 				wg2.Done()
@@ -3897,40 +1220,24 @@ func populateDemoData() {
 
 		for i := 0; i < 10; i++ {
 			marker := []string{
-				// markerName
 				fmt.Sprintf("DemoMarker_%d", i),
-				// direction
 				fmt.Sprintf("%d", rand.Intn(360)),
-				// type
 				markerTypes[rand.Intn(len(markerTypes))],
-				// text
 				fmt.Sprintf("Demo Marker %d", i),
-				// frameNo
 				strconv.Itoa(rand.Intn(missionDuration)),
-				// -1
 				"-1",
-				// ownerId
 				strconv.Itoa(rand.Intn(numSoldiers) + 1),
-				// color
 				markerColors[rand.Intn(len(markerColors))],
-				// size
 				"[1,1]",
-				// side
 				sides[rand.Intn(len(sides))],
-				// position
 				fmt.Sprintf("[%f,%f,%f]", rand.Float64()*30720+1, rand.Float64()*30720+1, 0.0),
-				// shape
 				markerShapes[rand.Intn(len(markerShapes))],
-				// alpha
 				"1.0",
-				// brush
 				"Solid",
 			}
-			// add timestamp
 			marker = append(marker, fmt.Sprintf("%d", time.Now().UnixNano()))
 			RVExtArgsDataChannels[":MARKER:CREATE:"] <- marker
 
-			// Add some marker moves
 			for j := 0; j < 3; j++ {
 				time.Sleep(100 * time.Millisecond)
 				markerMove := []string{
@@ -3945,7 +1252,6 @@ func populateDemoData() {
 			}
 		}
 
-		// Delete some markers
 		for i := 0; i < 3; i++ {
 			markerDelete := []string{
 				fmt.Sprintf("DemoMarker_%d", i),
@@ -3956,39 +1262,28 @@ func populateDemoData() {
 		}
 	}
 
-	// pause until RVExtArgsDataChannels[":FIRED:"] is empty
 	for len(RVExtArgsDataChannels[":FIRED:"]) > 0 {
 		time.Sleep(1000 * time.Millisecond)
 	}
-
 }
 
 func getOcapRecording(missionIDs []string) (err error) {
 	fmt.Println("Getting JSON for mission IDs: ", missionIDs)
 
-	queries := []string{}
-
 	for _, missionID := range missionIDs {
-
-		// get missionIdInt
 		missionIDInt, err := strconv.Atoi(missionID)
 		if err != nil {
 			return err
 		}
 
-		// var result string
-		var txStart time.Time
-
-		// get mission data
-		txStart = time.Now()
+		txStart := time.Now()
 		var mission model.Mission
-		ocapMission := make(map[string]interface{})
+		ocapMission := make(map[string]any)
 		err = DB.Model(&model.Mission{}).Where("id = ?", missionIDInt).First(&mission).Error
 		if err != nil {
 			return err
 		}
 
-		// preprocess mission data into an object
 		ocapMission["addonVersion"] = mission.AddonVersion
 		ocapMission["extensionVersion"] = mission.ExtensionVersion
 		ocapMission["extensionBuild"] = mission.ExtensionBuild
@@ -3997,613 +1292,189 @@ func getOcapRecording(missionIDs []string) (err error) {
 		ocapMission["missionAuthor"] = mission.Author
 		ocapMission["missionName"] = mission.OnLoadName
 		if mission.OnLoadName == "" {
-			ocapMission["missionName"] = mission.BriefingName
+			ocapMission["missionName"] = mission.MissionName
 		}
-		ocapMission["tags"] = mission.Tag
-		ocapMission["captureDelay"] = mission.CaptureDelay
 
-		ocapMission["Markers"] = make([]interface{}, 0)
-		ocapMission["entities"] = make([]interface{}, 0)
-		ocapMission["events"] = make([]interface{}, 0)
-		ocapMission["times"] = make([]interface{}, 0)
-
-		// get world name by checking relation
-		var world model.World
-		err = DB.Model(&model.World{}).Where("id = ?", mission.WorldID).Select([]string{"world_name", "display_name"}).Scan(&world).Error
+		world := model.World{}
+		err = DB.Model(&model.World{}).Where("id = ?", mission.WorldID).First(&world).Error
 		if err != nil {
-			return err
+			return fmt.Errorf("error getting world: %w", err)
 		}
 		ocapMission["worldName"] = world.WorldName
-		ocapMission["worldDisplayName"] = world.DisplayName
 
-		// check for an endmission event in the general events table
-		var endMissionEventFrame uint
-		err = DB.Model(&model.GeneralEvent{}).Where("name = ?", "endMission").Order("capture_frame DESC").Limit(1).Pluck("capture_frame", &endMissionEventFrame).Error
+		totalSoldiers := int64(0)
+		err = DB.Model(&model.Soldier{}).Where("mission_id = ?", missionIDInt).Count(&totalSoldiers).Error
 		if err != nil {
-			return err
+			return fmt.Errorf("error getting soldier count: %w", err)
 		}
-		// if not found,
-		// get last soldier state
-		if endMissionEventFrame == 0 {
-			var endSoldierStatesFrame uint
-			err = DB.Model(&model.SoldierState{}).Where("mission_id = ?", mission.ID).Order("capture_frame DESC").Limit(1).Pluck("capture_frame", &endSoldierStatesFrame).Error
-			if err != nil {
-				return err
-			}
 
-			// get last vehicle state
-			var endVehicleStatesFrame uint
-			err = DB.Model(&model.VehicleState{}).Where("mission_id = ?", mission.ID).Order("capture_frame DESC").Limit(1).Pluck("capture_frame", &endVehicleStatesFrame).Error
-			if err != nil {
-				return err
-			}
-
-			// take the higher of the two
-			if endSoldierStatesFrame > endVehicleStatesFrame {
-				endMissionEventFrame = endSoldierStatesFrame
-			} else {
-				endMissionEventFrame = endVehicleStatesFrame
-			}
-
-			fmt.Println("No endMission event found, using last soldier or vehicle state frame: ", endMissionEventFrame)
-		} else {
-			fmt.Println("Found endMission event at frame: ", endMissionEventFrame)
-		}
-		ocapMission["endFrame"] = endMissionEventFrame
-
-		fmt.Printf("Got mission data from DB in %s\n", time.Since(txStart))
-
-		// process soldier entities
-		txStart = time.Now()
-		var missionSoldiers []model.Soldier
-
-		err = DB.Model(&mission).Association("Soldiers").Find(&missionSoldiers)
+		totalVehicles := int64(0)
+		err = DB.Model(&model.Vehicle{}).Where("mission_id = ?", missionIDInt).Count(&totalVehicles).Error
 		if err != nil {
-			return err
+			return fmt.Errorf("error getting vehicle count: %w", err)
 		}
-		fmt.Printf("Found %d soldiers in mission in %s\n", len(missionSoldiers), time.Since(txStart))
 
-		// process soldier data and states into json
-		txStart = time.Now()
-		for _, dbSoldier := range missionSoldiers {
-			// preprocess soldier data into an object
-			jsonSoldier := make(map[string]interface{})
-			jsonSoldier["id"] = dbSoldier.OcapID
-			jsonSoldier["name"] = dbSoldier.UnitName
-			jsonSoldier["group"] = dbSoldier.GroupID
-			jsonSoldier["side"] = dbSoldier.Side
-			jsonSoldier["isPlayer"] = 0
-			if dbSoldier.IsPlayer {
-				jsonSoldier["isPlayer"] = 1
+		ocapMission["Rone"] = map[string]any{}
+		ocapMission["events"] = []any{}
+
+		soldiers := []model.Soldier{}
+		soldierTxStart := time.Now()
+		err = DB.Model(&model.Soldier{}).Where("mission_id = ?", missionIDInt).Find(&soldiers).Error
+		if err != nil {
+			return fmt.Errorf("error getting soldiers: %w", err)
+		}
+		fmt.Println("Got soldiers in ", time.Since(soldierTxStart))
+
+		entities := []map[string]any{}
+		for _, soldier := range soldiers {
+			entity := map[string]any{}
+			entity["id"] = soldier.OcapID
+			entity["name"] = soldier.UnitName
+			entity["group"] = soldier.GroupID
+			entity["side"] = soldier.Side
+			entity["isPlayer"] = 0
+			if soldier.IsPlayer {
+				entity["isPlayer"] = 1
 			}
-			jsonSoldier["role"] = dbSoldier.RoleDescription
-			jsonSoldier["startFrameNum"] = dbSoldier.JoinFrame
-			jsonSoldier["type"] = "unit"
-			jsonSoldier["framesFired"] = make([]interface{}, 0)
+			entity["type"] = "unit"
+			entity["startFrameNum"] = soldier.JoinFrame
 
-			// get soldier states
-			var soldierStates []model.SoldierState
-			err = DB.Model(&dbSoldier).Order("capture_frame ASC").Association("SoldierStates").Find(&soldierStates)
+			soldierStates := []model.SoldierState{}
+			err = DB.Model(&model.SoldierState{}).
+				Where("mission_id = ? AND soldier_id = ?", missionIDInt, soldier.ID).
+				Order("capture_frame ASC").
+				Find(&soldierStates).Error
 			if err != nil {
-				return err
-			}
-			// if no states, skip this entity
-			if len(soldierStates) == 0 {
-				continue
+				return fmt.Errorf("error getting soldier states: %w", err)
 			}
 
-			// preprocess the soldier states into a map of capture frame to interface
-			soldierStatesMap := queue.NewSoldierStatesMap()
+			positions := []any{}
 			for _, state := range soldierStates {
-				var thisPosition []interface{}
-
-				pos := state.Position
-				coords, _ := pos.Coordinates()
-				posArr := []float64{coords.X, coords.Y, coords.Z}
-				thisPosition = append(thisPosition, posArr)
-				thisPosition = append(thisPosition, state.Bearing)
-				thisPosition = append(thisPosition, state.Lifestate)
-				if state.InVehicle {
-					thisPosition = append(thisPosition, 1)
-				} else {
-					thisPosition = append(thisPosition, 0)
+				coord, _ := state.Position.Coordinates()
+				position := []any{
+					[]float64{coord.XY.X, coord.XY.Y},
+					state.Bearing,
+					state.Lifestate,
+					state.InVehicleObjectID,
+					state.UnitName,
+					state.IsPlayer,
+					state.CurrentRole,
 				}
-				thisPosition = append(thisPosition, state.UnitName)
-				if state.IsPlayer {
-					thisPosition = append(thisPosition, 1)
-				} else {
-					thisPosition = append(thisPosition, 0)
-				}
-				// unused by web
-				// thisPosition = append(thisPosition, state.CurrentRole)
-
-				// add to map
-				soldierStatesMap.Set(state.CaptureFrame, thisPosition)
+				positions = append(positions, position)
 			}
+			entity["positions"] = positions
 
-			// fmt.Printf("Got soldier states map of length %d in %s\n", soldierStatesMap.Len(), time.Since(txStart))
-
-			// get "positions" arrays
-			// start at JoinFrame
-			jsonSoldier["positions"] = make([]interface{}, 0)
-			for capFrame := dbSoldier.JoinFrame; capFrame <= endMissionEventFrame; capFrame++ {
-				// get the soldier frame matching the capture frame
-				state, err := soldierStatesMap.GetStateAtFrame(capFrame, endMissionEventFrame)
-				if err == nil {
-					// add frame to positions
-					jsonSoldier["positions"] = append(jsonSoldier["positions"].([]interface{}), state)
-				} else {
-					// if no state, add last state to positions
-					jsonSoldier["positions"] = append(jsonSoldier["positions"].([]interface{}), soldierStatesMap.GetLastState())
-					continue
-				}
-			}
-
-			// fired frames
-			var firedEvents []model.FiredEvent
-			err = DB.Model(&dbSoldier).Order("capture_frame ASC").Association("FiredEvents").Find(&firedEvents)
+			firedEvents := []model.FiredEvent{}
+			err = DB.Model(&model.FiredEvent{}).
+				Where("mission_id = ? AND soldier_id = ?", missionIDInt, soldier.ID).
+				Order("capture_frame ASC").
+				Find(&firedEvents).Error
 			if err != nil {
-				return err
+				return fmt.Errorf("error getting fired events: %w", err)
 			}
 
+			framesFired := []any{}
 			for _, event := range firedEvents {
-				var thisFiredFrame []interface{}
-				thisFiredFrame = append(thisFiredFrame, event.CaptureFrame)
-				endPos := event.EndPosition
-				endPosCoords, _ := endPos.Coordinates()
-				endPosArr := []float64{endPosCoords.X, endPosCoords.Y, endPosCoords.Z}
-				thisFiredFrame = append(thisFiredFrame, endPosArr)
-
-				jsonSoldier["framesFired"] = append(jsonSoldier["framesFired"].([]interface{}), thisFiredFrame)
+				startCoord, _ := event.StartPosition.Coordinates()
+				endCoord, _ := event.EndPosition.Coordinates()
+				frameFired := []any{
+					event.CaptureFrame,
+					[]float64{endCoord.XY.X, endCoord.XY.Y},
+					[]float64{startCoord.XY.X, startCoord.XY.Y},
+					event.Weapon,
+					event.Magazine,
+					event.FiringMode,
+				}
+				framesFired = append(framesFired, frameFired)
 			}
+			entity["framesFired"] = framesFired
 
-			ocapMission["entities"] = append(ocapMission["entities"].([]interface{}), jsonSoldier)
+			entities = append(entities, entity)
 		}
 
-		fmt.Printf("Processed soldier data in %s\n", time.Since(txStart))
-
-		// process vehicle entities
-		txStart = time.Now()
-		var missionVehicles []model.Vehicle
-
-		err = DB.Model(&mission).Association("Vehicles").Find(&missionVehicles)
+		vehicles := []model.Vehicle{}
+		err = DB.Model(&model.Vehicle{}).Where("mission_id = ?", missionIDInt).Find(&vehicles).Error
 		if err != nil {
-			return err
+			return fmt.Errorf("error getting vehicles: %w", err)
 		}
+		for _, vehicle := range vehicles {
+			entity := map[string]any{}
+			entity["id"] = vehicle.OcapID
+			entity["name"] = vehicle.DisplayName
+			entity["class"] = vehicle.ClassName
+			entity["side"] = "UNKNOWN"
+			entity["type"] = vehicle.OcapType
+			entity["startFrameNum"] = vehicle.JoinFrame
 
-		fmt.Printf("Found %d vehicles in mission in %s\n", len(missionVehicles), time.Since(txStart))
-
-		// process vehicle data and states into json
-		txStart = time.Now()
-		for _, dbVehicle := range missionVehicles {
-			// preprocess vehicle data into an object
-			jsonVehicle := make(map[string]interface{})
-			jsonVehicle["id"] = dbVehicle.OcapID
-			jsonVehicle["name"] = dbVehicle.DisplayName
-			jsonVehicle["class"] = dbVehicle.OcapType
-			jsonVehicle["startFrameNum"] = dbVehicle.JoinFrame
-			jsonVehicle["framesFired"] = make([]interface{}, 0)
-			jsonVehicle["positions"] = make([]interface{}, 0)
-
-			// get vehicle states
-			var vehicleStates []model.VehicleState
-			err = DB.Model(&dbVehicle).Order("capture_frame ASC").Association("VehicleStates").Find(&vehicleStates)
+			vehicleStates := []model.VehicleState{}
+			err = DB.Model(&model.VehicleState{}).
+				Where("mission_id = ? AND vehicle_id = ?", missionIDInt, vehicle.ID).
+				Order("capture_frame ASC").
+				Find(&vehicleStates).Error
 			if err != nil {
-				return err
+				return fmt.Errorf("error getting vehicle states: %w", err)
 			}
-			// get custom position arrays
-			lastState := make([]interface{}, 0)
-			frameIndex := 0
-			usedCaptureFrames := make(map[uint]bool)
+
+			positions := []any{}
 			for _, state := range vehicleStates {
-				var thisPosition []interface{}
-
-				// check if a record was already written for this capture frame
-				if usedCaptureFrames[state.CaptureFrame] {
-					continue
+				coord, _ := state.Position.Coordinates()
+				position := []any{
+					[]float64{coord.XY.X, coord.XY.Y},
+					state.Bearing,
+					state.IsAlive,
+					state.Crew,
 				}
-
-				pos := state.Position
-				coords, _ := pos.Coordinates()
-				posArr := []float64{coords.X, coords.Y, coords.Z}
-				thisPosition = append(thisPosition, posArr)
-				thisPosition = append(thisPosition, state.Bearing)
-				thisPosition = append(thisPosition, state.IsAlive)
-				crewArr := make([]int, 0)
-				var crewStr string = state.Crew
-				if crewStr != "" {
-					crewStrs := strings.Split(crewStr, ",")
-					for _, crew := range crewStrs {
-						crewInt, err := strconv.Atoi(crew)
-						if err != nil {
-							return err
-						}
-						crewArr = append(crewArr, crewInt)
-					}
-				}
-				thisPosition = append(thisPosition, crewArr)
-
-				// the latest web code allows for a vehicle to be in the same position for multiple frames, denoted by the 5th element in the array, while only taking up a single element in the positions array to save space
-				// if the position is the same as the last one, we just increment the frame count of the last one
-				// select the first 3 elements of the position array to compare
-				thisPosition = append(thisPosition, []uint{
-					state.CaptureFrame,
-					state.CaptureFrame,
-				})
-				if len(lastState) > 0 && reflect.DeepEqual(thisPosition[:3], lastState[:3]) {
-					// if the position is the same, we just increment the frame count of the last one
-					if len(lastState[4].([]uint)) != 2 {
-						lastState[4] = []interface{}{
-							lastState[4].([]uint)[0],
-							lastState[4].([]uint)[0] + 1,
-						}
-					} else {
-						lastState[4].([]uint)[1]++
-					}
-					// and ensure the positions array is up to date
-					jsonVehicle["positions"].([]interface{})[frameIndex-1] = lastState
-					// and add the capture frame to the used frames map
-					usedCaptureFrames[state.CaptureFrame] = true
-				} else {
-					// we need to account for gaps in the capture frames, where the vehicle's last entry doesn't have [4][1] < captureFrame - 1
-					// if the last state is not empty
-					// and the last entry's end frame is less than the current state's capture frame - 1
-					// then we need to add a new position to the positions array & also update the last state
-					// first we need to update the last state's end frame
-					if len(lastState) >= 5 &&
-						lastState[4].([]uint)[1] < state.CaptureFrame-1 {
-						lastState[4].([]uint)[1] = state.CaptureFrame - 1
-						jsonVehicle["positions"].([]interface{})[frameIndex-1].([]interface{})[4] = lastState[4]
-					}
-					// then we add a new position to the positions array
-					thisPosition[4] = []uint{state.CaptureFrame, state.CaptureFrame}
-					// and add the capture frame to the used frames map
-					usedCaptureFrames[state.CaptureFrame] = true
-					// and update the last state and frame index
-					lastState = thisPosition
-					frameIndex++
-					jsonVehicle["positions"] = append(jsonVehicle["positions"].([]interface{}), thisPosition)
-				}
+				positions = append(positions, position)
 			}
+			entity["positions"] = positions
+			entity["framesFired"] = []any{}
 
-			ocapMission["entities"] = append(ocapMission["entities"].([]interface{}), jsonVehicle)
+			entities = append(entities, entity)
 		}
 
-		fmt.Printf("Processed vehicle data in %s\n", time.Since(txStart))
+		ocapMission["entities"] = entities
 
-		// process markers
-		txStart = time.Now()
-		var missionMarkers []model.Marker
-		err = DB.Where("mission_id = ?", mission.ID).Order("capture_frame ASC").Find(&missionMarkers).Error
+		// Compute endFrame from the maximum capture_frame across all states
+		var endFrame uint
+		DB.Model(&model.SoldierState{}).Where("mission_id = ?", missionIDInt).Select("COALESCE(MAX(capture_frame), 0)").Scan(&endFrame)
+		ocapMission["endFrame"] = endFrame
+
+		fmt.Println("Got mission data in ", time.Since(txStart))
+
+		ocapMissionJSON, err := json.Marshal(ocapMission)
 		if err != nil {
-			return err
-		}
-		fmt.Printf("Found %d markers in mission in %s\n", len(missionMarkers), time.Since(txStart))
-
-		// process marker data into json
-		txStart = time.Now()
-		markersJson := make([]interface{}, 0)
-		for _, dbMarker := range missionMarkers {
-			// Get marker states for this marker
-			var markerStates []model.MarkerState
-			err = DB.Where("marker_id = ?", dbMarker.ID).Order("capture_frame ASC").Find(&markerStates).Error
-			if err != nil {
-				Logger.Warn().Err(err).Msgf("Error getting states for marker %s", dbMarker.MarkerName)
-			}
-
-			// Build marker JSON structure matching OCAP2 web format
-			// Format: [name, [positions...], type, text, color, size, side, shape, brush, alpha, direction]
-			// where positions = [[frame, [x,y,z], dir, alpha], ...]
-
-			jsonMarker := make([]interface{}, 0)
-			jsonMarker = append(jsonMarker, dbMarker.MarkerName)
-
-			// Build positions array - initial position plus all state changes
-			positions := make([]interface{}, 0)
-
-			// Add initial creation position
-			initialPos := dbMarker.Position
-			initialCoords, _ := initialPos.Coordinates()
-			initialPosArr := []interface{}{
-				dbMarker.CaptureFrame,
-				[]float64{initialCoords.X, initialCoords.Y, 0},
-				dbMarker.Direction,
-				dbMarker.Alpha,
-			}
-			positions = append(positions, initialPosArr)
-
-			// Add state changes
-			for _, state := range markerStates {
-				pos := state.Position
-				coords, _ := pos.Coordinates()
-				statePos := []interface{}{
-					state.CaptureFrame,
-					[]float64{coords.X, coords.Y, 0},
-					state.Direction,
-					state.Alpha,
-				}
-				positions = append(positions, statePos)
-			}
-			jsonMarker = append(jsonMarker, positions)
-
-			// Add marker properties
-			jsonMarker = append(jsonMarker, dbMarker.MarkerType)
-			jsonMarker = append(jsonMarker, dbMarker.Text)
-			jsonMarker = append(jsonMarker, dbMarker.Color)
-			jsonMarker = append(jsonMarker, dbMarker.Size)
-			jsonMarker = append(jsonMarker, dbMarker.Side)
-			jsonMarker = append(jsonMarker, dbMarker.Shape)
-			jsonMarker = append(jsonMarker, dbMarker.Brush)
-			jsonMarker = append(jsonMarker, dbMarker.Alpha)
-			jsonMarker = append(jsonMarker, dbMarker.Direction)
-
-			markersJson = append(markersJson, jsonMarker)
-		}
-		ocapMission["Markers"] = markersJson
-		fmt.Printf("Processed marker data in %s\n", time.Since(txStart))
-
-		// process events
-		txStart = time.Now()
-
-		allEvents := [][]interface{}{}
-		generalEvents := []model.GeneralEvent{}
-		hitEvents := []model.HitEvent{}
-		killEvents := []model.KillEvent{}
-		if err = DB.Model(&mission).Order("capture_frame ASC, time ASC").Association("GeneralEvents").Find(&generalEvents); err != nil {
-			return err
+			return fmt.Errorf("error marshalling mission data: %w", err)
 		}
 
-		if err = DB.Model(&mission).Order("capture_frame ASC, time ASC").Association("HitEvents").Find(&hitEvents); err != nil {
-			return err
-		}
-
-		if err = DB.Model(&mission).Order("capture_frame ASC, time ASC").Association("KillEvents").Find(&killEvents); err != nil {
-			return err
-		}
-
-		for _, generalEvent := range generalEvents {
-			// preprocess event data into an object
-			jsonEvent := make([]interface{}, 3)
-			jsonEvent[0] = generalEvent.CaptureFrame
-			jsonEvent[1] = generalEvent.Name
-			if generalEvent.Name == "endMission" {
-				// get json data from ExtraData
-				var extraData map[string]interface{}
-				if err = json.Unmarshal([]byte(generalEvent.ExtraData), &extraData); err != nil {
-					return err
-				}
-				jsonEvent[2] = make([]string, 2)
-				jsonEvent[2].([]string)[0] = extraData["winSide"].(string)
-				jsonEvent[2].([]string)[1] = extraData["message"].(string)
-			} else {
-				jsonEvent[2] = generalEvent.Message
-			}
-
-			allEvents = append(allEvents, jsonEvent)
-		}
-
-		for _, hitEvent := range hitEvents {
-			// preprocess event data into an object
-			jsonEvent := make([]interface{}, 5)
-			jsonEvent[0] = hitEvent.CaptureFrame
-			jsonEvent[1] = "hit"
-			// VictimVehicleID or VictimSoldierID, whichever is not empty
-			victimID := uint(0)
-
-			// get soldier ocap_id
-			err = DB.Model(&model.Soldier{}).Where("id = ?", hitEvent.VictimSoldierID).Pluck(
-				"ocap_id", &victimID,
-			).Error
-			if err != nil && err != gorm.ErrRecordNotFound {
-				return err
-			} else if err == nil {
-				// if soldier ocap_id found, use it
-				jsonEvent[2] = victimID
-			} else {
-				// get vehicle ocap_id
-				err = DB.Model(&model.Vehicle{}).Where("id = ?", hitEvent.VictimVehicleID).Pluck(
-					"ocap_id", &victimID,
-				).Error
-				if err != nil && err != gorm.ErrRecordNotFound {
-					return err
-				} else if err == nil {
-					// if vehicle ocap_id found, use it
-					jsonEvent[2] = victimID
-				} else {
-					// if neither found, skip this event
-					continue
-				}
-			}
-
-			// causedby info
-			causedBy := make([]interface{}, 2)
-			causedByID := uint(0)
-			// get soldier ocap_id
-			err = DB.Model(&model.Soldier{}).Where("id = ?", hitEvent.ShooterSoldierID).Pluck(
-				"ocap_id", &causedByID,
-			).Error
-			if err != nil && err != gorm.ErrRecordNotFound {
-				return err
-			} else if err == nil {
-				// if soldier ocap_id found, use it
-			} else {
-				// get vehicle ocap_id
-				err = DB.Model(&model.Vehicle{}).Where("id = ?", hitEvent.ShooterVehicleID).Pluck(
-					"ocap_id", &causedByID,
-				).Error
-				if err != nil && err != gorm.ErrRecordNotFound {
-					return err
-				} else if err == nil {
-					// if vehicle ocap_id found, use it
-				} else {
-					// if neither found, skip this event
-					continue
-				}
-			}
-
-			causedByText := hitEvent.EventText
-			causedBy[0] = causedByID
-			causedBy[1] = causedByText
-			jsonEvent[3] = causedBy
-
-			// distance
-			jsonEvent[4] = hitEvent.Distance
-
-			allEvents = append(allEvents, jsonEvent)
-		}
-
-		for _, killEvent := range killEvents {
-			// preprocess event data into an object
-			jsonEvent := make([]interface{}, 5)
-			jsonEvent[0] = killEvent.CaptureFrame
-			jsonEvent[1] = "killed"
-			// victimIDVehicle or victimIDSoldier, whichever is not empty
-			victimID := uint(0)
-
-			// get soldier ocap_id
-			err = DB.Model(&model.Soldier{}).Where("id = ?", killEvent.VictimIDSoldier).Pluck(
-				"ocap_id", &victimID,
-			).Error
-			if err != nil && err != gorm.ErrRecordNotFound {
-				return err
-			} else if err == nil {
-				// if soldier ocap_id found, use it
-				jsonEvent[2] = victimID
-			} else {
-				// get vehicle ocap_id
-				err = DB.Model(&model.Vehicle{}).Where("id = ?", killEvent.VictimIDVehicle).Pluck(
-					"ocap_id", &victimID,
-				).Error
-				if err != nil && err != gorm.ErrRecordNotFound {
-					return err
-				} else if err == nil {
-					// if vehicle ocap_id found, use it
-					jsonEvent[2] = victimID
-				} else {
-					// if neither found, skip this event
-					continue
-				}
-			}
-
-			// causedby info
-			causedBy := make([]interface{}, 2)
-			var causedByID uint16
-			// get soldier ocap_id
-			err = DB.Model(&model.Soldier{}).Where("id = ?", killEvent.KillerIDSoldier).Pluck(
-				"ocap_id", &causedByID,
-			).Error
-			if err != nil && err != gorm.ErrRecordNotFound {
-				return err
-			} else if err == nil {
-				// if soldier ocap_id found, use it
-			} else {
-				// get vehicle ocap_id
-				err = DB.Model(&model.Vehicle{}).Where("id = ?", killEvent.KillerIDVehicle).Pluck(
-					"ocap_id", &causedByID,
-				).Error
-				if err != nil && err != gorm.ErrRecordNotFound {
-					return err
-				} else if err == nil {
-					// if vehicle ocap_id found, use it
-				} else {
-					// if neither found, skip this event
-					continue
-				}
-			}
-
-			causedByText := killEvent.EventText
-			causedBy[0] = causedByID
-			causedBy[1] = causedByText
-			jsonEvent[3] = causedBy
-
-			// distance
-			jsonEvent[4] = killEvent.Distance
-
-			allEvents = append(allEvents, jsonEvent)
-		}
-
-		ocapMission["events"] = allEvents
-
-		fmt.Printf("Processed event data in %s\n", time.Since(txStart))
-
-		// now we need to get the mission object in json format
-		txStart = time.Now()
-		missionJSON, err := json.Marshal(ocapMission)
-		// missionJSON, err := json.MarshalIndent(ocapMission, "", "  ")
+		fileName := fmt.Sprintf("%s_%s.json.gz", mission.MissionName, mission.StartTime.Format("20060102_150405"))
+		fileName = strings.ReplaceAll(fileName, " ", "_")
+		fileName = strings.ReplaceAll(fileName, ":", "_")
+		f, err := os.Create(fileName)
 		if err != nil {
-			return err
+			return fmt.Errorf("error creating file: %w", err)
 		}
+		defer f.Close()
 
-		// write to gzipped json file
-		filename := fmt.Sprintf("mission_%s_%s.json.gz", missionID, ocapMission["missionName"])
-		filename = strings.ReplaceAll(filename, " ", "_")
-		gzipFile, err := os.Create(filename)
-		defer func() {
-			err := gzipFile.Close()
-			if err != nil {
-				panic(err)
-			}
-		}()
+		gzWriter := gzip.NewWriter(f)
+		defer gzWriter.Close()
+		_, err = gzWriter.Write(ocapMissionJSON)
 		if err != nil {
-			return err
+			return fmt.Errorf("error writing to gzip: %w", err)
 		}
 
-		gzipWriter := gzip.NewWriter(gzipFile)
-		defer func() {
-			err := gzipWriter.Close()
-			if err != nil {
-				panic(err)
-			}
-		}()
-		bytes, err := gzipWriter.Write(missionJSON)
-		if err != nil {
-			return err
-		}
-
-		fmt.Printf("Wrote %d bytes for missionId %s in %s\n", bytes, missionID, time.Since(txStart))
-
-		// add sqlite query to add to operations table
-		queries = append(queries, fmt.Sprintf(
-			`
-INSERT INTO operations
-(world_name, mission_name, mission_duration, filename, date, tag)
-VALUES
-('%s', '%s', %d, '%s', '%s', '%s');
-			`,
-			ocapMission["worldName"],
-			ocapMission["missionName"],
-			ocapMission["endFrame"],
-			strings.Replace(filename, ".gz", "", 1),
-			time.Now().Format("2006-01-02"),
-			ocapMission["tags"],
-		))
-		fmt.Println()
+		fmt.Println("Wrote mission data to ", fileName)
 	}
 
-	fmt.Println("JSON data written for all missionIds")
-
-	fmt.Println("To insert rows into your OCAP database, open the SQLite file in a proper client & run the following queries:")
-	for _, query := range queries {
-		fmt.Println(query)
-	}
-
-	fmt.Println()
-	fmt.Println("Finished processing, press enter to exit.")
 	return nil
 }
 
 func reduceMission(missionIDs []string) (err error) {
-	fmt.Println("Reducing mission IDs: ", missionIDs)
-
 	for _, missionID := range missionIDs {
-
-		// get missionIdInt
 		missionIDInt, err := strconv.Atoi(missionID)
 		if err != nil {
 			return err
 		}
 
-		// get mission data
 		txStart := time.Now()
 		var mission model.Mission
 		err = DB.Model(&model.Mission{}).Where("id = ?", missionIDInt).First(&mission).Error
@@ -4611,10 +1482,6 @@ func reduceMission(missionIDs []string) (err error) {
 			return fmt.Errorf("error getting mission: %w", err)
 		}
 
-		// we want to reduce the number of soldier states by a factor of 5, so that we can still see the general movement of the soldiers, but not have to store every single frame
-		// we'll be left with 1 state every 5 frames, plus the first and last states
-
-		// get soldier states to remove
 		soldierStatesToDelete := []model.SoldierState{}
 		err = DB.Model(&model.SoldierState{}).Where(
 			"mission_id = ? AND capture_frame % 5 != 0",
@@ -4642,7 +1509,6 @@ func reduceMission(missionIDs []string) (err error) {
 	fmt.Println("")
 	fmt.Println("Finished reducing soldier states, running VACUUM to recover space...")
 	txStart := time.Now()
-	// get tables to vacuum
 	tables := []string{}
 	err = DB.Raw(
 		`SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE'`,
@@ -4651,7 +1517,6 @@ func reduceMission(missionIDs []string) (err error) {
 		return fmt.Errorf("error getting tables to vacuum: %w", err)
 	}
 
-	// run vacuum on each table
 	for _, table := range tables {
 		err = DB.Raw(fmt.Sprintf("VACUUM (FULL) %s", table)).Error
 		if err != nil {
@@ -4660,7 +1525,6 @@ func reduceMission(missionIDs []string) (err error) {
 	}
 
 	fmt.Println("Finished VACUUM in ", time.Since(txStart))
-
 	fmt.Println("Finished reducing, press enter to exit.")
 
 	return nil
@@ -4706,38 +1570,13 @@ order by s.ocap_id,
   ss.capture_frame;
 `
 
-	// get rows
 	frameData := []model.FrameData{}
 	err = DB.Raw(query, 4, 0, 100).Scan(&frameData).Error
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
-	// create json data
-	// jsonData := make(map[string]interface{})
 
-	// for rows.Next() {
-
-	// 	rowData := model.FrameData{}
-	// 	err = DB.ScanRows(rows, &rowData)
-	// 	if err != nil {
-	// 		fmt.Println(err)
-	// 		return
-	// 	}
-
-	// 	soldierId := strconv.Itoa(int(rowData.OcapId))
-	// 	captureFrame := strconv.Itoa(int(rowData.CaptureFrame))
-
-	// 	// check if soldier exists in jsonData
-	// 	if jsonData[soldierId] == nil {
-	// 		jsonData[soldierId] = make(map[string]interface{})
-	// 	}
-	// 	// add frameData to jsonData
-	// 	jsonData[soldierId].(map[string]interface{})[captureFrame] = rowData
-	// }
-
-	// marshal and write data to file
-	// jsonBytes, err := json.MarshalIndent(frameData, "", "  ")
 	jsonBytes, err := json.Marshal(frameData)
 	if err != nil {
 		return err
@@ -4754,7 +1593,6 @@ order by s.ocap_id,
 func main() {
 	var err error
 	Logger.Info().Msg("Starting up...")
-	// connect to DB
 	Logger.Info().Msg("Connecting to DB...")
 	err = initDB()
 	if err != nil {
@@ -4763,7 +1601,6 @@ func main() {
 	Logger.Info().Msg("DB connect/migrate complete.")
 	initExtension()
 
-	// get arguments
 	args := os.Args[1:]
 	if len(args) > 0 {
 		if strings.ToLower(args[0]) == "demo" {
@@ -4772,7 +1609,6 @@ func main() {
 			demoStart := time.Now()
 			populateDemoData()
 			Logger.Info().Dur("duration", time.Duration(time.Since(demoStart).Seconds())).Msg("Demo data populated.")
-			// wait input
 			fmt.Println("Press enter to exit.")
 		}
 		if strings.ToLower(args[0]) == "setupdb" {

--- a/internal/cache/marker.go
+++ b/internal/cache/marker.go
@@ -1,0 +1,45 @@
+package cache
+
+import "sync"
+
+// MarkerCache maps marker names to their database IDs for the current mission
+type MarkerCache struct {
+	mu      sync.RWMutex
+	markers map[string]uint
+}
+
+// NewMarkerCache creates a new MarkerCache
+func NewMarkerCache() *MarkerCache {
+	return &MarkerCache{
+		markers: make(map[string]uint),
+	}
+}
+
+// Get retrieves a marker ID by name
+func (c *MarkerCache) Get(name string) (uint, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	id, ok := c.markers[name]
+	return id, ok
+}
+
+// Set stores a marker ID by name
+func (c *MarkerCache) Set(name string, id uint) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.markers[name] = id
+}
+
+// Delete removes a marker by name
+func (c *MarkerCache) Delete(name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.markers, name)
+}
+
+// Reset clears all markers from the cache
+func (c *MarkerCache) Reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.markers = make(map[string]uint)
+}

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -1,0 +1,1559 @@
+package handlers
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/OCAP2/extension/internal/cache"
+	"github.com/OCAP2/extension/internal/geo"
+	"github.com/OCAP2/extension/internal/logging"
+	"github.com/OCAP2/extension/internal/model"
+	"github.com/OCAP2/extension/internal/util"
+	"github.com/OCAP2/extension/pkg/a3interface"
+
+	geom "github.com/peterstace/simplefeatures/geom"
+	"github.com/rs/zerolog"
+	"gorm.io/gorm"
+)
+
+// MissionContext holds the current mission and world state
+type MissionContext struct {
+	mu      sync.RWMutex
+	Mission *model.Mission
+	World   *model.World
+}
+
+// NewMissionContext creates a new MissionContext with default values
+func NewMissionContext() *MissionContext {
+	return &MissionContext{
+		Mission: &model.Mission{MissionName: "No mission loaded"},
+		World:   &model.World{WorldName: "No world loaded"},
+	}
+}
+
+// GetMission returns the current mission
+func (mc *MissionContext) GetMission() *model.Mission {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+	return mc.Mission
+}
+
+// GetWorld returns the current world
+func (mc *MissionContext) GetWorld() *model.World {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+	return mc.World
+}
+
+// SetMission sets the current mission and world
+func (mc *MissionContext) SetMission(mission *model.Mission, world *model.World) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	mc.Mission = mission
+	mc.World = world
+}
+
+// Dependencies holds all dependencies needed by handlers
+type Dependencies struct {
+	DB            *gorm.DB
+	EntityCache   *cache.EntityCache
+	MarkerCache   *cache.MarkerCache
+	LogManager    *logging.Manager
+	ExtensionName string
+	AddonVersion  string
+}
+
+// Service provides handler methods for processing game data
+type Service struct {
+	deps    Dependencies
+	ctx     *MissionContext
+	writeLogFunc func(functionName, data, level string)
+}
+
+// NewService creates a new handler service
+func NewService(deps Dependencies, ctx *MissionContext) *Service {
+	s := &Service{
+		deps: deps,
+		ctx:  ctx,
+	}
+	// Default writeLog function uses the logging manager
+	s.writeLogFunc = func(functionName, data, level string) {
+		if deps.LogManager != nil {
+			deps.LogManager.WriteLog(functionName, data, level)
+		}
+	}
+	return s
+}
+
+// GetMissionContext returns the mission context
+func (s *Service) GetMissionContext() *MissionContext {
+	return s.ctx
+}
+
+// SetWriteLogFunc allows setting a custom writeLog function
+func (s *Service) SetWriteLogFunc(fn func(functionName, data, level string)) {
+	s.writeLogFunc = fn
+}
+
+func (s *Service) writeLog(functionName, data, level string) {
+	s.writeLogFunc(functionName, data, level)
+}
+
+// LogNewMission logs a new mission to the database
+func (s *Service) LogNewMission(data []string) error {
+	functionName := ":NEW:MISSION:"
+
+	// fix received data
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	world := model.World{}
+	mission := model.Mission{}
+	// unmarshal data[0]
+	err := json.Unmarshal([]byte(data[0]), &world)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf(`Error unmarshalling world data: %v`, err), "ERROR")
+		return err
+	}
+
+	// preprocess the world 'location' to geopoint
+	worldLocation, err := geo.Coords3857From4326(
+		float64(world.Longitude),
+		float64(world.Latitude),
+	)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf(`Error converting world location to geopoint: %v`, err), "ERROR")
+		return err
+	}
+	world.Location = worldLocation
+
+	// unmarshal data[1]
+	// unmarshal to temp object too to extract addons
+	missionTemp := map[string]interface{}{}
+	if err = json.Unmarshal([]byte(data[1]), &missionTemp); err != nil {
+		s.writeLog(functionName, fmt.Sprintf(`Error unmarshalling mission data: %v`, err), "ERROR")
+		return err
+	}
+
+	// add addons
+	addons := []model.Addon{}
+	for _, addon := range missionTemp["addons"].([]interface{}) {
+		thisAddon := model.Addon{
+			Name: addon.([]interface{})[0].(string),
+		}
+		// if addon[1] workshopId is int, convert to string
+		if reflect.TypeOf(addon.([]interface{})[1]).Kind() == reflect.Float64 {
+			thisAddon.WorkshopID = strconv.Itoa(int(addon.([]interface{})[1].(float64)))
+		} else {
+			thisAddon.WorkshopID = addon.([]interface{})[1].(string)
+		}
+
+		// if addon doesn't exist, insert it
+		err = s.deps.DB.Where("name = ?", thisAddon.Name).First(&thisAddon).Error
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			s.writeLog(functionName, fmt.Sprintf(`Error checking if addon exists: %v`, err), "ERROR")
+			return err
+		}
+		if thisAddon.ID == 0 {
+			// addon does not exist, create it
+			if err = s.deps.DB.Create(&thisAddon).Error; err != nil {
+				s.writeLog(functionName, fmt.Sprintf(`Error creating addon: %v`, err), "ERROR")
+				return err
+			}
+			addons = append(addons, thisAddon)
+		} else {
+			// addon exists, append it
+			addons = append(addons, thisAddon)
+		}
+	}
+	mission.Addons = addons
+
+	mission.StartTime = time.Now()
+
+	mission.CaptureDelay = float32(missionTemp["captureDelay"].(float64))
+	mission.MissionNameSource = missionTemp["missionNameSource"].(string)
+	mission.MissionName = missionTemp["missionName"].(string)
+	mission.BriefingName = missionTemp["briefingName"].(string)
+	mission.ServerName = missionTemp["serverName"].(string)
+	mission.ServerProfile = missionTemp["serverProfile"].(string)
+	mission.OnLoadName = missionTemp["onLoadName"].(string)
+	mission.Author = missionTemp["author"].(string)
+	mission.Tag = missionTemp["tag"].(string)
+
+	// playableSlots
+	playableSlotsJSON := missionTemp["playableSlots"].([]interface{})
+	mission.PlayableSlots.East = uint8(playableSlotsJSON[0].(float64))
+	mission.PlayableSlots.West = uint8(playableSlotsJSON[1].(float64))
+	mission.PlayableSlots.Independent = uint8(playableSlotsJSON[2].(float64))
+	mission.PlayableSlots.Civilian = uint8(playableSlotsJSON[3].(float64))
+	mission.PlayableSlots.Logic = uint8(playableSlotsJSON[4].(float64))
+
+	// sideFriendly
+	sideFriendlyJSON := missionTemp["sideFriendly"].([]interface{})
+	mission.SideFriendly.EastWest = sideFriendlyJSON[0].(bool)
+	mission.SideFriendly.EastIndependent = sideFriendlyJSON[1].(bool)
+	mission.SideFriendly.WestIndependent = sideFriendlyJSON[2].(bool)
+
+	// received at extension init and saved to local memory
+	mission.AddonVersion = s.deps.AddonVersion
+
+	// get or insert world
+	created, err := world.GetOrInsert(s.deps.DB)
+	if err != nil {
+		s.deps.LogManager.Logger.Error().Err(err).Msgf("Failed to get or insert world")
+		return err
+	}
+	if created {
+		s.deps.LogManager.Logger.Debug().Msgf("New world inserted: %s", world.WorldName)
+	} else {
+		s.deps.LogManager.Logger.Debug().Msgf("World already exists: %s", world.WorldName)
+	}
+
+	// always write new mission
+	mission.World = world
+	err = s.deps.DB.Create(&mission).Error
+	if err != nil {
+		s.deps.LogManager.Logger.Error().Err(err).Msgf("Failed to insert new mission")
+		return err
+	} else {
+		s.deps.LogManager.Logger.Debug().Msgf("New mission inserted: %s", mission.MissionName)
+	}
+
+	// set current world and mission
+	s.ctx.SetMission(&mission, &world)
+
+	// Clear marker cache for new mission
+	s.deps.MarkerCache.Reset()
+
+	// write to log
+	s.writeLog(functionName, `New mission logged`, "INFO")
+
+	s.deps.LogManager.Logger.Debug().Dict("worldData", zerolog.Dict().
+		Str("worldName", world.WorldName).
+		Str("displayName", world.DisplayName),
+	).Send()
+	s.deps.LogManager.Logger.Debug().Dict(
+		"missionData", zerolog.Dict().
+			Str("missionName", mission.MissionName).
+			Str("briefingName", mission.BriefingName).
+			Str("serverName", mission.ServerName).
+			Str("serverProfile", mission.ServerProfile).
+			Str("onLoadName", mission.OnLoadName).
+			Str("author", mission.Author).
+			Str("tag", mission.Tag),
+	).Send()
+
+	// callback to addon to begin sending data
+	a3interface.WriteArmaCallback(s.deps.ExtensionName, `:MISSION:OK:`, "OK")
+	return nil
+}
+
+// LogNewSoldier parses soldier data and returns a Soldier model
+func (s *Service) LogNewSoldier(data []string) (model.Soldier, error) {
+	functionName := ":NEW:SOLDIER:"
+	var soldier model.Soldier
+
+	// fix received data
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	// get frame
+	frameStr := data[0]
+	capframe, err := strconv.ParseInt(frameStr, 10, 64)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf(`Error converting capture frame to int: %s`, err), "ERROR")
+		return soldier, err
+	}
+
+	// parse array
+	soldier.MissionID = s.ctx.GetMission().ID
+	soldier.JoinFrame = uint(capframe)
+
+	// timestamp will always be appended as the last element of data, in unixnano format as a string
+	timestampStr := data[len(data)-1]
+	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf(`Error converting timestamp to int: %v`, err), "ERROR")
+		return soldier, err
+	}
+	soldier.JoinTime = time.Unix(0, timestampInt)
+
+	ocapID, err := strconv.ParseUint(data[1], 10, 64)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf(`Error converting ocapId to uint: %v`, err), "ERROR")
+		return soldier, err
+	}
+	soldier.OcapID = uint16(ocapID)
+	soldier.UnitName = data[2]
+	soldier.GroupID = data[3]
+	soldier.Side = data[4]
+	soldier.IsPlayer, err = strconv.ParseBool(data[5])
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf(`Error converting isPlayer to bool: %v`, err), "ERROR")
+		return soldier, err
+	}
+	soldier.RoleDescription = data[6]
+	soldier.ClassName = data[7]
+	soldier.DisplayName = data[8]
+	// player uid
+	soldier.PlayerUID = data[9]
+
+	// marshal squadparams
+	squadParams := data[10]
+	err = json.Unmarshal([]byte(squadParams), &soldier.SquadParams)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf(`Error unmarshalling squadParams: %v`, err), "ERROR")
+		return soldier, err
+	}
+
+	return soldier, nil
+}
+
+// LogSoldierState parses soldier state data and returns a SoldierState model
+func (s *Service) LogSoldierState(data []string) (model.SoldierState, error) {
+	functionName := ":NEW:SOLDIER:STATE:"
+	var soldierState model.SoldierState
+
+	// fix received data
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	soldierState.MissionID = s.ctx.GetMission().ID
+
+	frameStr := data[8]
+	capframe, err := strconv.ParseInt(frameStr, 10, 64)
+	if err != nil {
+		return soldierState, fmt.Errorf(`error converting capture frame to int: %s`, err)
+	}
+	soldierState.CaptureFrame = uint(capframe)
+
+	// parse data in array
+	ocapID, err := strconv.ParseUint(data[0], 10, 64)
+	if err != nil {
+		return soldierState, fmt.Errorf(`error converting ocapId to uint: %v`, err)
+	}
+
+	// try and find soldier in DB to associate
+	soldier, ok := s.deps.EntityCache.GetSoldier(uint16(ocapID))
+	if !ok {
+		return soldierState, fmt.Errorf("soldier %d not found in cache", ocapID)
+	}
+
+	soldierState.SoldierID = soldier.ID
+
+	// timestamp will always be appended as the last element of data, in unixnano format as a string
+	timestampStr := data[len(data)-1]
+	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf(`Error converting timestamp to int: %v`, err), "ERROR")
+		return soldierState, err
+	}
+	soldierState.Time = time.Unix(0, timestampInt)
+
+	// parse pos from an arma string
+	pos := data[1]
+	pos = strings.TrimPrefix(pos, "[")
+	pos = strings.TrimSuffix(pos, "]")
+	point, elev, err := geo.Coord3857FromString(pos)
+	if err != nil {
+		jsonData, _ := json.Marshal(data)
+		s.writeLog(functionName, fmt.Sprintf("Error converting position to Point:\n%s\n%v", jsonData, err), "ERROR")
+		return soldierState, err
+	}
+	soldierState.Position = point
+	soldierState.ElevationASL = float32(elev)
+
+	// bearing
+	bearing, _ := strconv.Atoi(data[2])
+	soldierState.Bearing = uint16(bearing)
+	// lifestate
+	lifeState, _ := strconv.Atoi(data[3])
+	soldierState.Lifestate = uint8(lifeState)
+	// in vehicle
+	soldierState.InVehicle, _ = strconv.ParseBool(data[4])
+	// name
+	soldierState.UnitName = data[5]
+	// is player
+	isPlayer, err := strconv.ParseBool(data[6])
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf(`Error converting isPlayer to bool: %v`, err), "ERROR")
+		return soldierState, err
+	}
+	soldierState.IsPlayer = isPlayer
+	// current role
+	soldierState.CurrentRole = data[7]
+
+	// parse ace3/medical data, is true/false default for vanilla
+	// has stable vitals
+	hasStableVitals, _ := strconv.ParseBool(data[9])
+	soldierState.HasStableVitals = hasStableVitals
+	// is dragged/carried
+	isDraggedCarried, _ := strconv.ParseBool(data[10])
+	soldierState.IsDraggedCarried = isDraggedCarried
+
+	// player scores come in as an array
+	if isPlayer {
+		scoresStr := data[11]
+		scoresArr := strings.Split(scoresStr, ",")
+		scoresInt := make([]uint8, len(scoresArr))
+		for i, v := range scoresArr {
+			num, _ := strconv.Atoi(v)
+			scoresInt[i] = uint8(num)
+		}
+
+		soldierState.Scores = model.SoldierScores{
+			InfantryKills: scoresInt[0],
+			VehicleKills:  scoresInt[1],
+			ArmorKills:    scoresInt[2],
+			AirKills:      scoresInt[3],
+			Deaths:        scoresInt[4],
+			TotalScore:    scoresInt[5],
+		}
+	}
+
+	// seat in vehicle
+	soldierState.VehicleRole = data[12]
+
+	// InVehicleObjectID, if -1 not in a vehicle
+	inVehicleID, _ := strconv.Atoi(data[13])
+	if inVehicleID == -1 {
+		soldierState.InVehicleObjectID = sql.NullInt32{
+			Int32: 0,
+			Valid: false,
+		}
+	} else {
+		soldierState.InVehicleObjectID = sql.NullInt32{
+			Int32: int32(inVehicleID),
+			Valid: true,
+		}
+	}
+
+	// stance
+	soldierState.Stance = data[14]
+
+	return soldierState, nil
+}
+
+// LogNewVehicle parses vehicle data and returns a Vehicle model
+func (s *Service) LogNewVehicle(data []string) (model.Vehicle, error) {
+	functionName := ":NEW:VEHICLE:"
+	var vehicle model.Vehicle
+
+	// fix received data
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	// get frame
+	frameStr := data[0]
+	capframe, err := strconv.ParseInt(frameStr, 10, 64)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf(`Error converting capture frame to int: %s`, err), "ERROR")
+		return vehicle, err
+	}
+
+	// timestamp will always be appended as the last element of data, in unixnano format as a string
+	timestampStr := data[len(data)-1]
+	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf(`Error converting timestamp to int: %v`, err), "ERROR")
+		return vehicle, err
+	}
+	vehicle.JoinTime = time.Unix(0, timestampInt)
+
+	// parse array
+	vehicle.MissionID = s.ctx.GetMission().ID
+	vehicle.JoinFrame = uint(capframe)
+	ocapID, err := strconv.ParseUint(data[1], 10, 64)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf(`Error converting ocapID to uint: %v`, err), "ERROR")
+		return vehicle, err
+	}
+	vehicle.OcapID = uint16(ocapID)
+	vehicle.OcapType = data[2]
+	vehicle.DisplayName = data[3]
+	vehicle.ClassName = data[4]
+	vehicle.Customization = data[5]
+
+	return vehicle, nil
+}
+
+// LogVehicleState parses vehicle state data and returns a VehicleState model
+func (s *Service) LogVehicleState(data []string) (model.VehicleState, error) {
+	functionName := ":NEW:VEHICLE:STATE:"
+	var vehicleState model.VehicleState
+
+	// fix received data
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	vehicleState.MissionID = s.ctx.GetMission().ID
+
+	// get frame
+	frameStr := data[5]
+	capframe, err := strconv.ParseInt(frameStr, 10, 64)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf(`Error converting capture frame to int: %s`, err), "ERROR")
+		return vehicleState, err
+	}
+	vehicleState.CaptureFrame = uint(capframe)
+
+	// parse data in array
+	ocapID, err := strconv.ParseUint(data[0], 10, 64)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf(`Error converting ocapId to uint: %v`, err), "ERROR")
+		return vehicleState, err
+	}
+
+	// try and find vehicle in DB to associate
+	vehicle, ok := s.deps.EntityCache.GetVehicle(uint16(ocapID))
+	if !ok {
+		return vehicleState, fmt.Errorf("vehicle %d not found in cache", ocapID)
+	}
+	vehicleState.VehicleID = vehicle.ID
+
+	// timestamp will always be appended as the last element of data, in unixnano format as a string
+	timestampStr := data[len(data)-1]
+	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf(`Error converting timestamp to int: %v`, err), "ERROR")
+		return vehicleState, err
+	}
+	vehicleState.Time = time.Unix(0, timestampInt)
+
+	// parse pos from an arma string
+	pos := data[1]
+	pos = strings.TrimPrefix(pos, "[")
+	pos = strings.TrimSuffix(pos, "]")
+	point, elev, err := geo.Coord3857FromString(pos)
+	if err != nil {
+		jsonData, _ := json.Marshal(data)
+		s.writeLog(functionName, fmt.Sprintf("Error converting position to Point:\n%s\n%v", jsonData, err), "ERROR")
+		return vehicleState, err
+	}
+	vehicleState.Position = point
+	vehicleState.ElevationASL = float32(elev)
+
+	// bearing
+	bearing, _ := strconv.Atoi(data[2])
+	vehicleState.Bearing = uint16(bearing)
+	// is alive
+	isAlive, _ := strconv.ParseBool(data[3])
+	vehicleState.IsAlive = isAlive
+	// parse crew, which is an array of ocap ids of soldiers
+	crew := data[4]
+	crew = strings.TrimPrefix(crew, "[")
+	crew = strings.TrimSuffix(crew, "]")
+	vehicleState.Crew = crew
+
+	// fuel
+	fuel, err := strconv.ParseFloat(data[6], 32)
+	if err != nil {
+		return vehicleState, fmt.Errorf(`error converting fuel to float: %v`, err)
+	}
+	vehicleState.Fuel = float32(fuel)
+
+	// damage
+	damage, err := strconv.ParseFloat(data[7], 32)
+	if err != nil {
+		return vehicleState, fmt.Errorf(`error converting damage to float: %v`, err)
+	}
+	vehicleState.Damage = float32(damage)
+
+	// isEngineOn
+	isEngineOn, err := strconv.ParseBool(data[8])
+	if err != nil {
+		return vehicleState, fmt.Errorf(`error converting isEngineOn to bool: %v`, err)
+	}
+	vehicleState.EngineOn = isEngineOn
+
+	// locked
+	locked, err := strconv.ParseBool(data[9])
+	if err != nil {
+		return vehicleState, fmt.Errorf(`error converting locked to bool: %v`, err)
+	}
+	vehicleState.Locked = locked
+
+	vehicleState.Side = data[10]
+
+	vehicleState.VectorDir = data[11]
+	vehicleState.VectorUp = data[12]
+
+	turretAzimuth, err := strconv.ParseFloat(data[13], 32)
+	if err != nil {
+		return vehicleState, fmt.Errorf(`error converting turretAzimuth to float: %v`, err)
+	}
+	vehicleState.TurretAzimuth = float32(turretAzimuth)
+
+	turretElevation, err := strconv.ParseFloat(data[14], 32)
+	if err != nil {
+		return vehicleState, fmt.Errorf(`error converting turretElevation to float: %v`, err)
+	}
+	vehicleState.TurretElevation = float32(turretElevation)
+
+	return vehicleState, nil
+}
+
+// LogFiredEvent parses fired event data and returns a FiredEvent model
+func (s *Service) LogFiredEvent(data []string) (model.FiredEvent, error) {
+	functionName := ":FIRED:"
+	var firedEvent model.FiredEvent
+
+	// fix received data
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	firedEvent.MissionID = s.ctx.GetMission().ID
+
+	// get frame
+	frameStr := data[1]
+	capframe, err := strconv.ParseInt(frameStr, 10, 64)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf(`Error converting capture frame to int: %s`, err), "ERROR")
+		return firedEvent, err
+	}
+	firedEvent.CaptureFrame = uint(capframe)
+
+	// parse data in array
+	ocapID, err := strconv.ParseUint(data[0], 10, 64)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf(`Error converting ocapID to uint: %v`, err), "ERROR")
+		return firedEvent, err
+	}
+
+	// try and find soldier in DB to associate
+	soldier, ok := s.deps.EntityCache.GetSoldier(uint16(ocapID))
+	if !ok {
+		return firedEvent, fmt.Errorf("soldier %d not found in cache", ocapID)
+	}
+	firedEvent.SoldierID = soldier.ID
+
+	// timestamp will always be appended as the last element of data, in unixnano format as a string
+	timestampStr := data[len(data)-1]
+	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf(`Error converting timestamp to int: %v`, err), "ERROR")
+		return firedEvent, err
+	}
+	firedEvent.Time = time.Unix(0, timestampInt)
+
+	// parse BULLET END POS from an arma string
+	endpos := data[2]
+	endpoint, endelev, err := geo.Coord3857FromString(endpos)
+	if err != nil {
+		jsonData, _ := json.Marshal(data)
+		s.writeLog(functionName, fmt.Sprintf("Error converting position to Point:\n%s\n%v", jsonData, err), "ERROR")
+		return firedEvent, err
+	}
+	firedEvent.EndPosition = endpoint
+	firedEvent.EndElevationASL = float32(endelev)
+
+	// parse BULLET START POS from an arma string
+	startpos := data[3]
+	startpoint, startelev, err := geo.Coord3857FromString(startpos)
+	if err != nil {
+		jsonData, _ := json.Marshal(data)
+		s.writeLog(functionName, fmt.Sprintf("Error converting position to Point:\n%s\n%v", jsonData, err), "ERROR")
+		return firedEvent, err
+	}
+	firedEvent.StartPosition = startpoint
+	firedEvent.StartElevationASL = float32(startelev)
+
+	// weapon name
+	firedEvent.Weapon = data[4]
+	// magazine name
+	firedEvent.Magazine = data[5]
+	// firing mode
+	firedEvent.FiringMode = data[6]
+
+	return firedEvent, nil
+}
+
+// LogProjectileEvent parses projectile event data and returns a ProjectileEvent model
+func (s *Service) LogProjectileEvent(data []string) (model.ProjectileEvent, error) {
+	var projectileEvent model.ProjectileEvent
+
+	// fix received data
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	projectileEvent.MissionID = s.ctx.GetMission().ID
+
+	s.deps.LogManager.Logger.Trace().Msgf("Projectile data: %v", data[0])
+
+	var rawJsonData map[string]interface{}
+	err := json.Unmarshal([]byte(data[0]), &rawJsonData)
+	if err != nil {
+		return projectileEvent, fmt.Errorf(`error unmarshalling json data: %v`, err)
+	}
+
+	s.deps.LogManager.Logger.Trace().Msg("Processing time and frame")
+	firedTime := rawJsonData["firedTime"].(string)
+	firedTimeInt, err := strconv.ParseInt(firedTime, 10, 64)
+	if err != nil {
+		return projectileEvent, fmt.Errorf(`error converting firedTime to int: %v`, err)
+	}
+	projectileEvent.Time = time.Unix(0, firedTimeInt)
+	projectileEvent.CaptureFrame = uint(rawJsonData["firedFrame"].(float64))
+
+	s.deps.LogManager.Logger.Trace().Msg("Processing soldierFired")
+	soldierFired, ok := s.deps.EntityCache.GetSoldier(uint16(rawJsonData["firerID"].(float64)))
+	if !ok {
+		return projectileEvent, fmt.Errorf("soldier %d not found in cache", uint16(rawJsonData["firerID"].(float64)))
+	}
+	projectileEvent.FirerID = soldierFired.ID
+
+	s.deps.LogManager.Logger.Trace().Msg("Processing actualFirer")
+	actualFirer, ok := s.deps.EntityCache.GetSoldier(uint16(rawJsonData["remoteControllerID"].(float64)))
+	if !ok {
+		return projectileEvent, fmt.Errorf("soldier %d not found in cache", uint16(rawJsonData["remoteControllerID"].(float64)))
+	}
+	projectileEvent.ActualFirerID = actualFirer.ID
+
+	s.deps.LogManager.Logger.Trace().Msg("Processing vehicleID")
+	vehicleID := rawJsonData["vehicleID"].(float64)
+	vehicle, ok := s.deps.EntityCache.GetVehicle(uint16(vehicleID))
+	if ok {
+		projectileEvent.VehicleID = sql.NullInt32{
+			Int32: int32(vehicle.ID),
+			Valid: true,
+		}
+	} else {
+		projectileEvent.VehicleID = sql.NullInt32{
+			Int32: 0,
+			Valid: false,
+		}
+	}
+
+	// for Positions parsing, we need to create a Linestring with XYZM dimensions
+	s.deps.LogManager.Logger.Trace().Msgf("Projectile positions: %v", rawJsonData["positions"])
+	positionSequence := []float64{}
+	for _, v := range rawJsonData["positions"].([]interface{}) {
+		posArr := v.([]interface{})
+
+		s.deps.LogManager.Logger.Trace().Msgf("Projectile posArr: %v", posArr)
+
+		// process time as posArr[0]
+		unixTimeNano := posArr[0].(string)
+		unixTimeNanoFloat, err := strconv.ParseFloat(unixTimeNano, 64)
+		if err != nil {
+			jsonData, _ := json.Marshal(posArr)
+			s.deps.LogManager.Logger.Error().Err(err).Str("json", string(jsonData)).Msg("Error converting timestamp to float64")
+			return projectileEvent, err
+		}
+
+		// process actual position xyz as posArr[2]
+		pos := posArr[2].(string)
+		point, _, err := geo.Coord3857FromString(pos)
+		if err != nil {
+			jsonData, _ := json.Marshal(posArr)
+			s.deps.LogManager.Logger.Error().Err(err).Str("json", string(jsonData)).Msg("Error converting position to Point")
+			return projectileEvent, err
+		}
+		coords, _ := point.Coordinates()
+
+		positionSequence = append(
+			positionSequence,
+			coords.XY.X,
+			coords.XY.Y,
+			coords.Z,
+			unixTimeNanoFloat,
+		)
+	}
+
+	// create the linestring
+	posSeq := geom.NewSequence(positionSequence, geom.DimXYZM)
+	ls, err := geom.NewLineString(posSeq)
+	if err != nil {
+		jsonData, _ := json.Marshal(posSeq)
+		s.deps.LogManager.Logger.Error().Err(err).Str("json", string(jsonData)).Msg("Error creating linestring")
+		return projectileEvent, err
+	}
+
+	s.deps.LogManager.Logger.Trace().
+		Interface("sequence", posSeq).
+		Interface("linestring", ls).
+		Interface("wkt", ls.AsText()).
+		Interface("wkb", ls.AsBinary()).
+		Msg("Created linestring")
+
+	projectileEvent.Positions = ls.AsGeometry()
+
+	s.deps.LogManager.Logger.Trace().Msg("Processing hit events")
+	// hit events
+	projectileEvent.HitSoldiers = []model.ProjectileHitsSoldier{}
+	projectileEvent.HitVehicles = []model.ProjectileHitsVehicle{}
+	for _, event := range rawJsonData["hitParts"].([]interface{}) {
+		eventArr := event.([]interface{})
+
+		s.deps.LogManager.Logger.Trace().Interface("eventArr", eventArr).Msg("Processing hit event")
+
+		// [1] is []string containing hit components
+		hitComponents := []string{}
+		for _, v := range eventArr[1].([]interface{}) {
+			hitComponents = append(hitComponents, v.(string))
+		}
+
+		// [2] is string with positionASL
+		hitPos := eventArr[2].(string)
+		hitPoint, _, err := geo.Coord3857FromString(hitPos)
+		if err != nil {
+			jsonData, _ := json.Marshal(eventArr)
+			s.deps.LogManager.Logger.Error().Err(err).Str("json", string(jsonData)).Msg("Error converting hit position to Point")
+			return projectileEvent, err
+		}
+
+		// [3] is uint capture frame
+		hitFrame := eventArr[3].(float64)
+
+		// marshal hit components to json array
+		hitComponentsJSON, err := json.Marshal(hitComponents)
+		if err != nil {
+			s.deps.LogManager.Logger.Error().Err(err).Msg("Error marshalling hit components to json")
+			return projectileEvent, err
+		}
+
+		s.deps.LogManager.Logger.Trace().Interface("hitComponents", hitComponents).Msg("Processed hit components")
+
+		// [0] is the hit entity ocap id
+		hitEntityID := eventArr[0].(float64)
+		hitEntity, ok := s.deps.EntityCache.GetSoldier(uint16(hitEntityID))
+		if ok {
+			projectileEvent.HitSoldiers = append(
+				projectileEvent.HitSoldiers,
+				model.ProjectileHitsSoldier{
+					SoldierID:     hitEntity.ID,
+					ComponentsHit: hitComponentsJSON,
+					CaptureFrame:  uint(hitFrame),
+					Position:      hitPoint,
+				},
+			)
+		} else {
+			hitVehicle, ok := s.deps.EntityCache.GetVehicle(uint16(hitEntityID))
+			if ok {
+				projectileEvent.HitVehicles = append(
+					projectileEvent.HitVehicles,
+					model.ProjectileHitsVehicle{
+						VehicleID:     hitVehicle.ID,
+						ComponentsHit: hitComponentsJSON,
+						CaptureFrame:  uint(hitFrame),
+						Position:      hitPoint,
+					},
+				)
+			} else {
+				s.deps.LogManager.Logger.Warn().Msgf("Hit entity %d not found in cache", uint16(hitEntityID))
+			}
+		}
+	}
+
+	s.deps.LogManager.Logger.Trace().Msg("Processing other properties")
+
+	projectileEvent.VehicleRole = rawJsonData["vehicleRole"].(string)
+	projectileEvent.Weapon = rawJsonData["weapon"].(string)
+	projectileEvent.WeaponDisplay = rawJsonData["weaponDisplay"].(string)
+	projectileEvent.Magazine = rawJsonData["magazine"].(string)
+	projectileEvent.MagazineDisplay = rawJsonData["magazineDisplay"].(string)
+	projectileEvent.Muzzle = rawJsonData["muzzle"].(string)
+	projectileEvent.MuzzleDisplay = rawJsonData["muzzleDisplay"].(string)
+	projectileEvent.Ammo = rawJsonData["ammo"].(string)
+	projectileEvent.Mode = rawJsonData["fireMode"].(string)
+	projectileEvent.InitialVelocity = rawJsonData["initialVelocity"].(string)
+
+	return projectileEvent, nil
+}
+
+// LogGeneralEvent parses general event data and returns a GeneralEvent model
+func (s *Service) LogGeneralEvent(data []string) (model.GeneralEvent, error) {
+	functionName := ":EVENT:"
+	var thisEvent model.GeneralEvent
+
+	// fix received data
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	// get frame
+	frameStr := data[0]
+	capframe, err := strconv.ParseInt(frameStr, 10, 64)
+	if err != nil {
+		s.writeLog("processEvent", fmt.Sprintf(`Error converting capture frame to int: %s`, err), "ERROR")
+		return thisEvent, err
+	}
+
+	// timestamp will always be appended as the last element of data, in unixnano format as a string
+	timestampStr := data[len(data)-1]
+	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf(`Error converting timestamp to int: %v`, err), "ERROR")
+		return thisEvent, err
+	}
+	thisEvent.Time = time.Unix(0, timestampInt)
+
+	thisEvent.Mission = *s.ctx.GetMission()
+
+	// get event type
+	thisEvent.CaptureFrame = uint(capframe)
+
+	// get event type
+	thisEvent.Name = data[1]
+
+	// get event message
+	thisEvent.Message = data[2]
+
+	// get extra event data
+	if len(data) > 3 {
+		err = json.Unmarshal([]byte(data[3]), &thisEvent.ExtraData)
+		if err != nil {
+			s.writeLog(functionName, fmt.Sprintf(`Error unmarshalling extra data: %s`, err), "ERROR")
+			return thisEvent, err
+		}
+	}
+
+	return thisEvent, nil
+}
+
+// LogHitEvent parses hit event data and returns a HitEvent model
+func (s *Service) LogHitEvent(data []string) (model.HitEvent, error) {
+	var hitEvent model.HitEvent
+
+	// fix received data
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	// get frame
+	frameStr := data[0]
+	capframe, err := strconv.ParseInt(frameStr, 10, 64)
+	if err != nil {
+		return hitEvent, fmt.Errorf(`error converting capture frame to int: %s`, err)
+	}
+
+	hitEvent.CaptureFrame = uint(capframe)
+	hitEvent.Mission = *s.ctx.GetMission()
+
+	// timestamp will always be appended as the last element of data, in unixnano format as a string
+	timestampStr := data[len(data)-1]
+	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
+	if err != nil {
+		return hitEvent, fmt.Errorf(`error converting timestamp to int: %v`, err)
+	}
+	hitEvent.Time = time.Unix(0, timestampInt)
+
+	// parse data in array
+	victimOcapID, err := strconv.ParseUint(data[1], 10, 64)
+	if err != nil {
+		return hitEvent, fmt.Errorf(`error converting victim ocap id to uint: %v`, err)
+	}
+
+	// try and find victim in DB to associate
+	victimSoldier, ok := s.deps.EntityCache.GetSoldier(uint16(victimOcapID))
+	if ok {
+		hitEvent.VictimSoldier = victimSoldier
+	} else {
+		victimVehicle, ok := s.deps.EntityCache.GetVehicle(uint16(victimOcapID))
+		if ok {
+			hitEvent.VictimVehicle = victimVehicle
+		} else {
+			return hitEvent, fmt.Errorf(`victim ocap id not found in cache: %d`, victimOcapID)
+		}
+	}
+
+	// now look for the shooter
+	shooterOcapID, err := strconv.ParseUint(data[2], 10, 64)
+	if err != nil {
+		return hitEvent, fmt.Errorf(`error converting shooter ocap id to uint: %v`, err)
+	}
+
+	// try and find shooter in DB to associate
+	shooterSoldier, ok := s.deps.EntityCache.GetSoldier(uint16(shooterOcapID))
+	if ok {
+		hitEvent.ShooterSoldier = shooterSoldier
+	} else {
+		shooterVehicle, ok := s.deps.EntityCache.GetVehicle(uint16(shooterOcapID))
+		if ok {
+			hitEvent.ShooterVehicle = shooterVehicle
+		} else {
+			return hitEvent, fmt.Errorf(`shooter ocap id not found in cache: %d`, shooterOcapID)
+		}
+	}
+
+	// get event text
+	hitEvent.EventText = data[3]
+
+	// get event distance
+	distance, err := strconv.ParseFloat(data[4], 64)
+	if err != nil {
+		return hitEvent, fmt.Errorf(`error converting distance to float: %v`, err)
+	}
+	hitEvent.Distance = float32(distance)
+
+	return hitEvent, nil
+}
+
+// LogKillEvent parses kill event data and returns a KillEvent model
+func (s *Service) LogKillEvent(data []string) (model.KillEvent, error) {
+	var killEvent model.KillEvent
+
+	// fix received data
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	// get frame
+	frameStr := data[0]
+	capframe, err := strconv.ParseInt(frameStr, 10, 64)
+	if err != nil {
+		return killEvent, fmt.Errorf(`error converting capture frame to int: %s`, err)
+	}
+
+	// timestamp will always be appended as the last element of data, in unixnano format as a string
+	timestampStr := data[len(data)-1]
+	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
+	if err != nil {
+		return killEvent, fmt.Errorf(`error converting timestamp to int: %v`, err)
+	}
+	killEvent.Time = time.Unix(0, timestampInt)
+
+	killEvent.CaptureFrame = uint(capframe)
+	killEvent.Mission = *s.ctx.GetMission()
+
+	// parse data in array
+	victimOcapID, err := strconv.ParseUint(data[1], 10, 64)
+	if err != nil {
+		return killEvent, fmt.Errorf(`error converting victim ocap id to uint: %v`, err)
+	}
+
+	// try and find victim in DB to associate
+	victimSoldier, ok := s.deps.EntityCache.GetSoldier(uint16(victimOcapID))
+	if ok {
+		killEvent.VictimSoldier = victimSoldier
+	} else {
+		victimVehicle, ok := s.deps.EntityCache.GetVehicle(uint16(victimOcapID))
+		if ok {
+			killEvent.VictimVehicle = victimVehicle
+		} else {
+			return killEvent, fmt.Errorf(`victim ocap id not found in cache: %d`, victimOcapID)
+		}
+	}
+
+	// now look for the killer
+	killerOcapID, err := strconv.ParseUint(data[2], 10, 64)
+	if err != nil {
+		return killEvent, fmt.Errorf(`error converting killer ocap id to uint: %v`, err)
+	}
+
+	// try and find killer in DB to associate
+	killerSoldier, ok := s.deps.EntityCache.GetSoldier(uint16(killerOcapID))
+	if ok {
+		killEvent.KillerSoldier = killerSoldier
+	} else {
+		killerVehicle, ok := s.deps.EntityCache.GetVehicle(uint16(killerOcapID))
+		if ok {
+			killEvent.KillerVehicle = killerVehicle
+		} else {
+			return killEvent, fmt.Errorf(`killer ocap id not found in cache: %d`, killerOcapID)
+		}
+	}
+
+	// get event text
+	killEvent.EventText = data[3]
+
+	// get event distance
+	distance, err := strconv.ParseFloat(data[4], 64)
+	if err != nil {
+		return killEvent, fmt.Errorf(`error converting distance to float: %v`, err)
+	}
+	killEvent.Distance = float32(distance)
+
+	return killEvent, nil
+}
+
+// LogChatEvent parses chat event data and returns a ChatEvent model
+func (s *Service) LogChatEvent(data []string) (model.ChatEvent, error) {
+	var chatEvent model.ChatEvent
+
+	// fix received data
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	// get frame
+	frameStr := data[0]
+	capframe, err := strconv.ParseInt(frameStr, 10, 64)
+	if err != nil {
+		return chatEvent, fmt.Errorf(`error converting capture frame to int: %s`, err)
+	}
+
+	// timestamp will always be appended as the last element of data, in unixnano format as a string
+	timestampStr := data[len(data)-1]
+	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
+	if err != nil {
+		return chatEvent, fmt.Errorf(`error converting timestamp to int: %v`, err)
+	}
+	chatEvent.Time = time.Unix(0, timestampInt)
+
+	chatEvent.CaptureFrame = uint(capframe)
+	chatEvent.Mission = *s.ctx.GetMission()
+
+	// parse data in array
+	senderOcapID, err := strconv.ParseInt(data[1], 10, 64)
+	if err != nil {
+		return chatEvent, fmt.Errorf(`error converting sender ocap id to uint: %v`, err)
+	}
+
+	// try and find sender soldier in DB to associate if not -1
+	if senderOcapID > -1 {
+		sendSoldier, ok := s.deps.EntityCache.GetSoldier(uint16(senderOcapID))
+		if ok {
+			chatEvent.Soldier = sendSoldier
+		} else {
+			return chatEvent, fmt.Errorf(`sender ocap id not found in cache: %d`, senderOcapID)
+		}
+	}
+
+	// channel is the 3rd element, compare against map
+	channelInt, err := strconv.ParseInt(data[2], 10, 64)
+	if err != nil {
+		return chatEvent, fmt.Errorf(`error converting channel to int: %v`, err)
+	}
+	channelName, ok := model.ChatChannels[int(channelInt)]
+	if ok {
+		chatEvent.Channel = channelName
+	} else {
+		if channelInt > 5 && channelInt < 16 {
+			chatEvent.Channel = "Custom"
+		} else {
+			chatEvent.Channel = "System"
+		}
+	}
+
+	// next is from (formatted as the game message)
+	chatEvent.FromName = data[3]
+
+	// next is actual name
+	chatEvent.SenderName = data[4]
+
+	// next is message
+	chatEvent.Message = data[5]
+
+	// next is playerUID
+	chatEvent.PlayerUID = data[6]
+
+	return chatEvent, nil
+}
+
+// LogRadioEvent parses radio event data and returns a RadioEvent model
+func (s *Service) LogRadioEvent(data []string) (model.RadioEvent, error) {
+	var radioEvent model.RadioEvent
+
+	// fix received data
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	// get frame
+	frameStr := data[0]
+	capframe, err := strconv.ParseInt(frameStr, 10, 64)
+	if err != nil {
+		return radioEvent, fmt.Errorf(`error converting capture frame to int: %s`, err)
+	}
+
+	// timestamp will always be appended as the last element of data, in unixnano format as a string
+	timestampStr := data[len(data)-1]
+	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
+	if err != nil {
+		return radioEvent, fmt.Errorf(`error converting timestamp to int: %v`, err)
+	}
+	radioEvent.Time = time.Unix(0, timestampInt)
+
+	radioEvent.CaptureFrame = uint(capframe)
+	radioEvent.Mission = *s.ctx.GetMission()
+
+	// parse data in array
+	senderOcapID, err := strconv.ParseInt(data[1], 10, 64)
+	if err != nil {
+		return radioEvent, fmt.Errorf(`error converting sender ocap id to uint: %v`, err)
+	}
+
+	// try and find sender soldier in DB to associate if not -1
+	if senderOcapID > -1 {
+		senderSoldier, ok := s.deps.EntityCache.GetSoldier(uint16(senderOcapID))
+		if !ok {
+			return radioEvent, fmt.Errorf(`sender ocap id not found in cache: %d`, senderOcapID)
+		}
+		radioEvent.Soldier = senderSoldier
+	}
+
+	// radio
+	radioEvent.Radio = data[2]
+	// radio type (SW or LR)
+	radioEvent.RadioType = data[3]
+	// transmission type (start/end)
+	radioEvent.StartEnd = data[4]
+	// channel on radio (1-8) int8
+	channelInt, err := strconv.ParseInt(data[5], 10, 64)
+	if err != nil {
+		return radioEvent, fmt.Errorf(`error converting channel to int: %v`, err)
+	}
+	radioEvent.Channel = int8(channelInt)
+	// is primary or additional channel
+	isAddtl, err := strconv.ParseBool(data[6])
+	if err != nil {
+		return radioEvent, fmt.Errorf(`error converting isAddtl to bool: %v`, err)
+	}
+	radioEvent.IsAdditional = isAddtl
+
+	// frequency
+	freq, err := strconv.ParseFloat(data[7], 64)
+	if err != nil {
+		return radioEvent, fmt.Errorf(`error converting freq to float: %v`, err)
+	}
+	radioEvent.Frequency = float32(freq)
+
+	radioEvent.Code = data[8]
+
+	return radioEvent, nil
+}
+
+// LogFpsEvent parses FPS event data and returns a ServerFpsEvent model
+func (s *Service) LogFpsEvent(data []string) (model.ServerFpsEvent, error) {
+	var fpsEvent model.ServerFpsEvent
+
+	// fix received data
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	// get frame
+	frameStr := data[0]
+	capframe, err := strconv.ParseInt(frameStr, 10, 64)
+	if err != nil {
+		return fpsEvent, fmt.Errorf(`error converting capture frame to int: %s`, err)
+	}
+
+	// timestamp will always be appended as the last element of data, in unixnano format as a string
+	timestampStr := data[len(data)-1]
+	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
+	if err != nil {
+		return fpsEvent, fmt.Errorf(`error converting timestamp to int: %v`, err)
+	}
+
+	fpsEvent.CaptureFrame = uint(capframe)
+	fpsEvent.Time = time.Unix(0, timestampInt)
+	fpsEvent.Mission = *s.ctx.GetMission()
+
+	// parse data in array
+	fps, err := strconv.ParseFloat(data[1], 64)
+	if err != nil {
+		return fpsEvent, fmt.Errorf(`error converting fps to float: %v`, err)
+	}
+	fpsEvent.FpsAverage = float32(fps)
+
+	fpsMin, err := strconv.ParseFloat(data[2], 64)
+	if err != nil {
+		return fpsEvent, fmt.Errorf(`error converting fpsMin to float: %v`, err)
+	}
+	fpsEvent.FpsMin = float32(fpsMin)
+
+	return fpsEvent, nil
+}
+
+// LogAce3DeathEvent parses ACE3 death event data and returns an Ace3DeathEvent model
+func (s *Service) LogAce3DeathEvent(data []string) (model.Ace3DeathEvent, error) {
+	var deathEvent model.Ace3DeathEvent
+
+	// fix received data
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	// get frame
+	frameStr := data[0]
+	capframe, err := strconv.ParseInt(frameStr, 10, 64)
+	if err != nil {
+		return deathEvent, fmt.Errorf(`error converting capture frame to int: %s`, err)
+	}
+
+	// timestamp will always be appended as the last element of data, in unixnano format as a string
+	timestampStr := data[len(data)-1]
+	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
+	if err != nil {
+		return deathEvent, fmt.Errorf(`error converting timestamp to int: %v`, err)
+	}
+	deathEvent.Time = time.Unix(0, timestampInt)
+
+	deathEvent.CaptureFrame = uint(capframe)
+	deathEvent.Mission = *s.ctx.GetMission()
+
+	// parse data in array
+	victimOcapID, err := strconv.ParseUint(data[1], 10, 64)
+	if err != nil {
+		return deathEvent, fmt.Errorf(`error converting victim ocap id to uint: %v`, err)
+	}
+
+	// try and find victim in DB to associate
+	soldier, ok := s.deps.EntityCache.GetSoldier(uint16(victimOcapID))
+	if ok {
+		deathEvent.Soldier = soldier
+	} else {
+		return deathEvent, fmt.Errorf(`victim ocap id not found in cache: %d`, victimOcapID)
+	}
+
+	deathEvent.Reason = data[2]
+
+	// get last damage source id [3]
+	lastDamageSourceID, err := strconv.ParseInt(data[3], 10, 64)
+	if err != nil {
+		return deathEvent, fmt.Errorf(`error converting last damage source id to uint: %v`, err)
+	}
+
+	if lastDamageSourceID > -1 {
+		lastDamageSource, ok := s.deps.EntityCache.GetSoldier(uint16(lastDamageSourceID))
+		if !ok {
+			return deathEvent, fmt.Errorf(`last damage source id not found in cache: %d`, lastDamageSourceID)
+		}
+		deathEvent.LastDamageSourceID = sql.NullInt32{Int32: int32(lastDamageSource.ID), Valid: true}
+	}
+
+	return deathEvent, nil
+}
+
+// LogAce3UnconsciousEvent parses ACE3 unconscious event data and returns an Ace3UnconsciousEvent model
+func (s *Service) LogAce3UnconsciousEvent(data []string) (model.Ace3UnconsciousEvent, error) {
+	var unconsciousEvent model.Ace3UnconsciousEvent
+
+	// fix received data
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	// get frame
+	frameStr := data[0]
+	capframe, err := strconv.ParseInt(frameStr, 10, 64)
+	if err != nil {
+		return unconsciousEvent, fmt.Errorf(`error converting capture frame to int: %s`, err)
+	}
+
+	unconsciousEvent.CaptureFrame = uint(capframe)
+	unconsciousEvent.Mission = *s.ctx.GetMission()
+
+	// parse data in array
+	ocapID, err := strconv.ParseUint(data[1], 10, 64)
+	if err != nil {
+		return unconsciousEvent, fmt.Errorf(`error converting ocap id to uint: %v`, err)
+	}
+
+	// try and find soldier in DB to associate
+	soldier, ok := s.deps.EntityCache.GetSoldier(uint16(ocapID))
+	if !ok {
+		return unconsciousEvent, fmt.Errorf("soldier %d not found in cache", ocapID)
+	}
+	unconsciousEvent.Soldier = soldier
+
+	isAwake, err := strconv.ParseBool(data[2])
+	if err != nil {
+		return unconsciousEvent, fmt.Errorf(`error converting isAwake to bool: %v`, err)
+	}
+	unconsciousEvent.IsAwake = isAwake
+
+	return unconsciousEvent, nil
+}
+
+// LogMarkerCreate parses marker create data and returns a Marker model
+func (s *Service) LogMarkerCreate(data []string) (model.Marker, error) {
+	functionName := ":MARKER:CREATE:"
+	var marker model.Marker
+
+	// fix received data
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	marker.MissionID = s.ctx.GetMission().ID
+
+	// markerName
+	marker.MarkerName = data[0]
+
+	// direction
+	dir, err := strconv.ParseFloat(data[1], 32)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf("Error parsing direction: %v", err), "ERROR")
+		return marker, err
+	}
+	marker.Direction = float32(dir)
+
+	// type
+	marker.MarkerType = data[2]
+
+	// text
+	marker.Text = data[3]
+
+	// frameNo
+	frameStr := data[4]
+	capframe, err := strconv.ParseInt(frameStr, 10, 64)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf("Error parsing capture frame: %v", err), "ERROR")
+		return marker, err
+	}
+	marker.CaptureFrame = uint(capframe)
+
+	// data[5] is -1, skip
+
+	// ownerId
+	ownerId, err := strconv.Atoi(data[6])
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf("Error parsing ownerId: %v", err), "WARN")
+		ownerId = -1
+	}
+	marker.OwnerID = ownerId
+
+	// color
+	marker.Color = data[7]
+
+	// size (stored as string "[w,h]")
+	marker.Size = data[8]
+
+	// side
+	marker.Side = data[9]
+
+	// position - parse from arma string "[x,y,z]"
+	pos := data[10]
+	pos = strings.TrimPrefix(pos, "[")
+	pos = strings.TrimSuffix(pos, "]")
+	point, _, err := geo.Coord3857FromString(pos)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf("Error parsing position: %v", err), "ERROR")
+		return marker, err
+	}
+	marker.Position = point
+
+	// shape
+	marker.Shape = data[11]
+
+	// alpha
+	alpha, err := strconv.ParseFloat(data[12], 32)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf("Error parsing alpha: %v", err), "WARN")
+		alpha = 1.0
+	}
+	marker.Alpha = float32(alpha)
+
+	// brush
+	marker.Brush = data[13]
+
+	// timestamp
+	timestampStr := data[len(data)-1]
+	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf("Error parsing timestamp: %v", err), "ERROR")
+		return marker, err
+	}
+	marker.Time = time.Unix(0, timestampInt)
+
+	marker.IsDeleted = false
+
+	return marker, nil
+}
+
+// LogMarkerMove parses marker move data and returns a MarkerState model
+func (s *Service) LogMarkerMove(data []string) (model.MarkerState, error) {
+	functionName := ":MARKER:MOVE:"
+	var markerState model.MarkerState
+
+	// fix received data
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	markerState.MissionID = s.ctx.GetMission().ID
+
+	// markerName - look up marker ID from cache
+	markerName := data[0]
+	markerID, ok := s.deps.MarkerCache.Get(markerName)
+	if !ok {
+		return markerState, fmt.Errorf("marker %s not found in cache", markerName)
+	}
+	markerState.MarkerID = markerID
+
+	// frameNo
+	frameStr := data[1]
+	capframe, err := strconv.ParseInt(frameStr, 10, 64)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf("Error parsing capture frame: %v", err), "ERROR")
+		return markerState, err
+	}
+	markerState.CaptureFrame = uint(capframe)
+
+	// position
+	pos := data[2]
+	pos = strings.TrimPrefix(pos, "[")
+	pos = strings.TrimSuffix(pos, "]")
+	point, _, err := geo.Coord3857FromString(pos)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf("Error parsing position: %v", err), "ERROR")
+		return markerState, err
+	}
+	markerState.Position = point
+
+	// direction
+	dir, err := strconv.ParseFloat(data[3], 32)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf("Error parsing direction: %v", err), "WARN")
+		dir = 0
+	}
+	markerState.Direction = float32(dir)
+
+	// alpha
+	alpha, err := strconv.ParseFloat(data[4], 32)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf("Error parsing alpha: %v", err), "WARN")
+		alpha = 1.0
+	}
+	markerState.Alpha = float32(alpha)
+
+	// timestamp
+	timestampStr := data[len(data)-1]
+	timestampInt, err := strconv.ParseInt(timestampStr, 10, 64)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf("Error parsing timestamp: %v", err), "ERROR")
+		return markerState, err
+	}
+	markerState.Time = time.Unix(0, timestampInt)
+
+	return markerState, nil
+}
+
+// LogMarkerDelete parses marker delete data and returns the marker name and frame number
+func (s *Service) LogMarkerDelete(data []string) (string, uint, error) {
+	functionName := ":MARKER:DELETE:"
+
+	// fix received data
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	markerName := data[0]
+
+	// frameNo
+	frameStr := data[1]
+	capframe, err := strconv.ParseInt(frameStr, 10, 64)
+	if err != nil {
+		s.writeLog(functionName, fmt.Sprintf("Error parsing capture frame: %v", err), "ERROR")
+		return markerName, 0, err
+	}
+
+	return markerName, uint(capframe), nil
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,216 @@
+package logging
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Graylog2/go-gelf/gelf"
+	"github.com/rs/zerolog"
+)
+
+// Config holds logging configuration
+type Config struct {
+	LogLevel       string
+	LogsDir        string
+	CurrentMission string
+	MissionID      uint
+	UsingLocalDB   bool
+}
+
+// Manager manages all logging operations
+type Manager struct {
+	Logger      zerolog.Logger
+	JSONLogger  zerolog.Logger
+	TraceSample zerolog.Logger
+
+	logIoConn     net.Conn
+	graylogWriter *gelf.Writer
+	config        *Config
+	nullByte      byte
+
+	// Callbacks for dynamic state
+	GetMissionName    func() string
+	GetMissionID      func() uint
+	IsUsingLocalDB    func() bool
+	IsStatusRunning   func() bool
+}
+
+// NewManager creates a new logging manager
+func NewManager() *Manager {
+	return &Manager{
+		nullByte: 0x00,
+		config:   &Config{},
+		// Default callbacks return empty/false values
+		GetMissionName:  func() string { return "" },
+		GetMissionID:    func() uint { return 0 },
+		IsUsingLocalDB:  func() bool { return false },
+		IsStatusRunning: func() bool { return false },
+	}
+}
+
+// Setup initializes the logging system
+func (m *Manager) Setup(file *os.File, logLevel string) {
+	// get log level
+	var logLevelActual zerolog.Level
+	switch strings.ToUpper(logLevel) {
+	case "DEBUG":
+		logLevelActual = zerolog.DebugLevel
+	case "INFO":
+		logLevelActual = zerolog.InfoLevel
+	case "WARN":
+		logLevelActual = zerolog.WarnLevel
+	case "ERROR":
+		logLevelActual = zerolog.ErrorLevel
+	case "TRACE":
+		logLevelActual = zerolog.TraceLevel
+	default:
+		logLevelActual = zerolog.InfoLevel
+	}
+
+	// set up logging
+	zerolog.SetGlobalLevel(logLevelActual)
+	zerolog.TimestampFunc = func() time.Time {
+		return time.Now().UTC()
+	}
+
+	// set up multi-level writer
+	mlw := zerolog.MultiLevelWriter(
+		// write console format with colors to console
+		zerolog.ConsoleWriter{
+			Out:        os.Stdout,
+			TimeFormat: time.RFC3339,
+		},
+		// write console format without colors to file
+		zerolog.ConsoleWriter{
+			Out:        file,
+			TimeFormat: time.RFC3339,
+			NoColor:    true,
+		},
+	)
+
+	m.Logger = zerolog.New(mlw).With().Timestamp().Logger().
+		Hook(
+			zerolog.HookFunc(
+				func(e *zerolog.Event, level zerolog.Level, msg string) {
+					// add current mission
+					// add runtime info
+					e.Bool("usingLocalDB", m.IsUsingLocalDB()).
+						Str("currentMission", m.GetMissionName()).
+						Uint("currentMissionID", m.GetMissionID()).
+						Bool("statusMonitorActive", m.IsStatusRunning())
+				}))
+
+	m.TraceSample = m.Logger.With().
+		Bool("sampled", true).Logger().Sample(&zerolog.BurstSampler{
+		// allow max 5 entries per 10 seconds
+		// once reached, sample 1 in 100
+		Burst:       5,
+		Period:      10 * time.Second,
+		NextSampler: &zerolog.BasicSampler{N: 100},
+	})
+
+	m.Logger.Info().Str("loglevel", m.Logger.GetLevel().String()).Msg("Logging set up")
+}
+
+// SetupJSONLogger configures the JSON logger with the provided writer
+func (m *Manager) SetupJSONLogger(writer *zerolog.Logger) {
+	m.JSONLogger = *writer
+}
+
+// SetLogIoConn sets the log.io connection
+func (m *Manager) SetLogIoConn(conn net.Conn) {
+	m.logIoConn = conn
+}
+
+// SetGraylogWriter sets the Graylog GELF writer
+func (m *Manager) SetGraylogWriter(writer *gelf.Writer) {
+	m.graylogWriter = writer
+}
+
+// WriteToLogIo sends a log message to the log.io service
+func (m *Manager) WriteToLogIo(level zerolog.Level, msg string) {
+	if m.logIoConn == nil {
+		return
+	}
+	data := make([]byte, 0)
+	message := fmt.Sprintf(
+		`%s %s %s`,
+		time.Now().UTC().Format(time.RFC3339),
+		level.String(),
+		msg,
+	)
+	data = append(data, []byte(
+		"+msg|ocap2|ocap_recorder|"+message,
+	)...)
+	data = append(data, m.nullByte)
+
+	_, err := m.logIoConn.Write(data)
+	if err != nil {
+		m.Logger.Debug().Err(err).Msg("Failed to send log to log.io")
+	}
+}
+
+// RemoveOldLogs removes .log and .jsonl files older than daysDelta days
+func (m *Manager) RemoveOldLogs(path string, daysDelta int) {
+	files, err := os.ReadDir(path)
+	if err != nil {
+		m.Logger.Warn().Err(err).Msg("Failed to read logs dir")
+		return
+	}
+
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+		// get file info
+		r, err := f.Info()
+		if err != nil {
+			m.Logger.Warn().Err(err).Msg("Failed to get file info")
+			continue
+		}
+		// check if file is a log file and if it's older than daysDelta days
+		if filepath.Ext(f.Name()) == ".log" || filepath.Ext(f.Name()) == ".jsonl" {
+			if time.Since(r.ModTime()).Hours() > float64(daysDelta*24) {
+				os.Remove(filepath.Join(path, f.Name()))
+			}
+		}
+	}
+}
+
+// WriteLog writes a log entry with the specified function name, data, and level
+func (m *Manager) WriteLog(functionName string, data string, level string) {
+	var logLevelActual zerolog.Level
+	switch level {
+	case "DEBUG":
+		logLevelActual = zerolog.DebugLevel
+	case "INFO":
+		logLevelActual = zerolog.InfoLevel
+	case "WARN":
+		logLevelActual = zerolog.WarnLevel
+	case "ERROR":
+		logLevelActual = zerolog.ErrorLevel
+	case "FATAL":
+		logLevelActual = zerolog.FatalLevel
+	}
+
+	// debug limits configured in global defs based on config
+	m.Logger.WithLevel(logLevelActual).
+		Str("function", functionName).
+		Msg(data)
+
+	m.JSONLogger.WithLevel(logLevelActual).
+		Str("function", functionName).
+		Msg(data)
+}
+
+// Close cleans up logging resources
+func (m *Manager) Close() error {
+	if m.logIoConn != nil {
+		return m.logIoConn.Close()
+	}
+	return nil
+}

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -1,0 +1,355 @@
+package monitor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/OCAP2/extension/internal/handlers"
+	"github.com/OCAP2/extension/internal/logging"
+	"github.com/OCAP2/extension/internal/model"
+	"github.com/OCAP2/extension/internal/worker"
+
+	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
+	influxdb2_write "github.com/influxdata/influxdb-client-go/v2/api/write"
+	"gorm.io/gorm"
+)
+
+// InfluxWriter is a function type for writing to InfluxDB
+type InfluxWriter func(ctx context.Context, bucket string, point *influxdb2_write.Point) error
+
+// ChannelLengthGetter returns the length of a channel by name
+type ChannelLengthGetter func(name string) int
+
+// Dependencies holds all dependencies for the monitor service
+type Dependencies struct {
+	DB                *gorm.DB
+	LogManager        *logging.Manager
+	HandlerService    *handlers.Service
+	WorkerManager     *worker.Manager
+	Queues            *worker.Queues
+	AddonFolder       string
+	IsDatabaseValid   func() bool
+	GetChannelLength  ChannelLengthGetter
+}
+
+// Service manages status monitoring
+type Service struct {
+	deps      Dependencies
+	isRunning bool
+	mu        sync.RWMutex
+	stopChan  chan struct{}
+
+	// Optional InfluxDB integration
+	influxWriter  InfluxWriter
+	influxEnabled func() bool
+	influxDBURL   func() string
+}
+
+// NewService creates a new monitor service
+func NewService(deps Dependencies) *Service {
+	return &Service{
+		deps:          deps,
+		stopChan:      make(chan struct{}),
+		influxEnabled: func() bool { return false },
+		influxDBURL:   func() string { return "" },
+	}
+}
+
+// SetInfluxIntegration sets up InfluxDB integration
+func (s *Service) SetInfluxIntegration(writer InfluxWriter, enabledFn func() bool, dbURLFn func() string) {
+	s.influxWriter = writer
+	s.influxEnabled = enabledFn
+	s.influxDBURL = dbURLFn
+}
+
+// IsRunning returns whether the status monitor is running
+func (s *Service) IsRunning() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.isRunning
+}
+
+// GetProgramStatus returns the current program status
+func (s *Service) GetProgramStatus(
+	rawBuffers bool,
+	writeQueues bool,
+	lastWrite bool,
+) (output []string, perfModel model.OcapPerformance) {
+	mission := s.deps.HandlerService.GetMissionContext().GetMission()
+
+	buffersObj := model.BufferLengths{
+		Soldiers:              uint16(s.deps.GetChannelLength(":NEW:SOLDIER:")),
+		Vehicles:              uint16(s.deps.GetChannelLength(":NEW:VEHICLE:")),
+		SoldierStates:         uint16(s.deps.GetChannelLength(":NEW:SOLDIER:STATE:")),
+		VehicleStates:         uint16(s.deps.GetChannelLength(":NEW:VEHICLE:STATE:")),
+		FiredEvents:           uint16(s.deps.GetChannelLength(":FIRED:")),
+		GeneralEvents:         uint16(s.deps.GetChannelLength(":EVENT:")),
+		HitEvents:             uint16(s.deps.GetChannelLength(":HIT:")),
+		KillEvents:            uint16(s.deps.GetChannelLength(":KILL:")),
+		ChatEvents:            uint16(s.deps.GetChannelLength(":CHAT:")),
+		RadioEvents:           uint16(s.deps.GetChannelLength(":RADIO:")),
+		ServerFpsEvents:       uint16(s.deps.GetChannelLength(":FPS:")),
+		Ace3DeathEvents:       uint16(s.deps.GetChannelLength(":ACE3:DEATH:")),
+		Ace3UnconsciousEvents: uint16(s.deps.GetChannelLength(":ACE3:UNCONSCIOUS:")),
+		MarkerCreates:         uint16(s.deps.GetChannelLength(":MARKER:CREATE:")),
+		MarkerMoves:           uint16(s.deps.GetChannelLength(":MARKER:MOVE:")),
+		MarkerDeletes:         uint16(s.deps.GetChannelLength(":MARKER:DELETE:")),
+	}
+
+	writeQueuesObj := model.WriteQueueLengths{
+		Soldiers:              uint16(s.deps.Queues.Soldiers.Len()),
+		Vehicles:              uint16(s.deps.Queues.Vehicles.Len()),
+		SoldierStates:         uint16(s.deps.Queues.SoldierStates.Len()),
+		VehicleStates:         uint16(s.deps.Queues.VehicleStates.Len()),
+		FiredEvents:           uint16(s.deps.Queues.FiredEvents.Len()),
+		GeneralEvents:         uint16(s.deps.Queues.GeneralEvents.Len()),
+		HitEvents:             uint16(s.deps.Queues.HitEvents.Len()),
+		KillEvents:            uint16(s.deps.Queues.KillEvents.Len()),
+		ChatEvents:            uint16(s.deps.Queues.ChatEvents.Len()),
+		RadioEvents:           uint16(s.deps.Queues.RadioEvents.Len()),
+		ServerFpsEvents:       uint16(s.deps.Queues.FpsEvents.Len()),
+		Ace3DeathEvents:       uint16(s.deps.Queues.Ace3DeathEvents.Len()),
+		Ace3UnconsciousEvents: uint16(s.deps.Queues.Ace3UnconsciousEvents.Len()),
+		Markers:               uint16(s.deps.Queues.Markers.Len()),
+		MarkerStates:          uint16(s.deps.Queues.MarkerStates.Len()),
+	}
+
+	perf := model.OcapPerformance{
+		Time:              time.Now(),
+		Mission:           *mission,
+		BufferLengths:     buffersObj,
+		WriteQueueLengths: writeQueuesObj,
+		LastWriteDurationMs: float32(s.deps.WorkerManager.GetLastDBWriteDuration().Milliseconds()),
+	}
+
+	if rawBuffers {
+		rawBuffersStr, err := json.MarshalIndent(buffersObj, "", "  ")
+		if err != nil {
+			rawBuffersStr = []byte(fmt.Sprintf(`{"error": "%s"}`, err))
+		}
+		output = append(output, string(rawBuffersStr))
+	}
+	if writeQueues {
+		writeQueuesStr, err := json.MarshalIndent(writeQueuesObj, "", "  ")
+		if err != nil {
+			writeQueuesStr = []byte(fmt.Sprintf(`{"error": "%s"}`, err))
+		}
+		output = append(output, string(writeQueuesStr))
+	}
+	if lastWrite {
+		lastWriteStr, err := json.MarshalIndent(perf.LastWriteDurationMs, "", "  ")
+		if err != nil {
+			lastWriteStr = []byte(fmt.Sprintf(`{"error": "%s"}`, err))
+		}
+		output = append(output, string(lastWriteStr))
+	}
+
+	return output, perf
+}
+
+// ValidateHypertables validates and creates TimescaleDB hypertables
+func (s *Service) ValidateHypertables(tables map[string][]string) error {
+	functionName := "validateHypertables"
+
+	all := []any{}
+	s.deps.DB.Exec(`SELECT x.* FROM timescaledb_information.hypertables`).Scan(&all)
+	for _, row := range all {
+		s.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`hypertable row: %v`, row), "DEBUG")
+	}
+
+	for table := range tables {
+		hypertable := any(nil)
+		s.deps.DB.Exec(`SELECT x.* FROM timescaledb_information.hypertables WHERE hypertable_name = ?`, table).Scan(&hypertable)
+		if hypertable != nil {
+			s.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Table %s is already configured`, table), "INFO")
+			continue
+		}
+
+		queryCreateHypertable := fmt.Sprintf(`
+				SELECT create_hypertable('%s', 'time', chunk_time_interval => interval '1 day', if_not_exists => true);
+			`, table)
+		err := s.deps.DB.Exec(queryCreateHypertable).Error
+		if err != nil {
+			s.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Failed to create hypertable for %s. Err: %s`, table, err), "ERROR")
+			return err
+		}
+		s.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Created hypertable for %s`, table), "INFO")
+
+		queryCompressHypertable := fmt.Sprintf(`
+				ALTER TABLE %s SET (
+					timescaledb.compress,
+					timescaledb.compress_segmentby = ?);
+			`, table)
+		err = s.deps.DB.Exec(
+			queryCompressHypertable,
+			strings.Join(tables[table], ","),
+		).Error
+		if err != nil {
+			s.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Failed to enable compression for %s. Err: %s`, table, err), "ERROR")
+			return err
+		}
+		s.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Enabled hypertable compression for %s`, table), "INFO")
+
+		queryCompressAfterHypertable := fmt.Sprintf(`
+				SELECT add_compression_policy(
+					'%s',
+					compress_after => interval '14 day');
+			`, table)
+		err = s.deps.DB.Exec(queryCompressAfterHypertable).Error
+		if err != nil {
+			s.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Failed to set compress_after for %s. Err: %s`, table, err), "ERROR")
+			return err
+		}
+		s.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Set compress_after for %s`, table), "INFO")
+	}
+	return nil
+}
+
+// Start starts the status monitor goroutine
+func (s *Service) Start() error {
+	s.mu.Lock()
+	if s.isRunning {
+		s.mu.Unlock()
+		return nil
+	}
+	s.isRunning = true
+	s.stopChan = make(chan struct{})
+	s.mu.Unlock()
+
+	go func() {
+		defer func() {
+			s.mu.Lock()
+			s.isRunning = false
+			s.mu.Unlock()
+		}()
+
+		s.deps.LogManager.Logger.Debug().
+			Str("function", "startStatusMonitor").
+			Msg("Starting status monitor goroutine")
+
+		statusFile, err := os.Create(s.deps.AddonFolder + "/status.txt")
+		if err != nil {
+			s.deps.LogManager.Logger.Error().Err(err).Msg("Error creating status file")
+		}
+		defer statusFile.Close()
+
+		for {
+			select {
+			case <-s.stopChan:
+				return
+			default:
+				time.Sleep(1000 * time.Millisecond)
+
+				mission := s.deps.HandlerService.GetMissionContext().GetMission()
+				if mission.ID == 0 {
+					continue
+				}
+
+				statusStr, perfModel := s.GetProgramStatus(true, true, true)
+
+				if statusFile != nil {
+					statusFile.Truncate(0)
+					statusFile.Seek(0, 0)
+					for _, line := range statusStr {
+						statusFile.WriteString(line + "\n")
+					}
+				}
+
+				// write model to Postgres
+				if s.deps.IsDatabaseValid() {
+					err = s.deps.DB.Create(&perfModel).Error
+					if err != nil {
+						s.deps.LogManager.Logger.Error().Err(err).Msg("Error writing perf model to Postgres")
+					}
+				}
+
+				// write to influxDB
+				if s.influxEnabled() && s.influxWriter != nil {
+					// write buffer lengths
+					p := influxdb2.NewPointWithMeasurement(
+						"ext_buffer_lengths",
+					).
+						AddTag("db_url", s.influxDBURL()).
+						AddTag("mission_name", perfModel.Mission.MissionName).
+						AddTag("mission_id", fmt.Sprintf("%d", perfModel.Mission.ID)).
+						AddField("soldiers", perfModel.BufferLengths.Soldiers).
+						AddField("vehicles", perfModel.BufferLengths.Vehicles).
+						AddField("soldier_states", perfModel.BufferLengths.SoldierStates).
+						AddField("vehicle_states", perfModel.BufferLengths.VehicleStates).
+						AddField("general_events", perfModel.BufferLengths.GeneralEvents).
+						AddField("hit_events", perfModel.BufferLengths.HitEvents).
+						AddField("kill_events", perfModel.BufferLengths.KillEvents).
+						AddField("fired_events", perfModel.BufferLengths.FiredEvents).
+						AddField("chat_events", perfModel.BufferLengths.ChatEvents).
+						AddField("radio_events", perfModel.BufferLengths.RadioEvents).
+						AddField("server_fps_events", perfModel.BufferLengths.ServerFpsEvents).
+						SetTime(time.Now())
+
+					s.influxWriter(
+						context.Background(),
+						"ocap_performance",
+						p,
+					)
+
+					// write db write queue lengths
+					p = influxdb2.NewPointWithMeasurement(
+						"ext_db_queue_lengths",
+					).
+						AddTag("db_url", s.influxDBURL()).
+						AddTag("mission_name", perfModel.Mission.MissionName).
+						AddTag("mission_id", fmt.Sprintf("%d", perfModel.Mission.ID)).
+						AddField("soldiers", perfModel.WriteQueueLengths.Soldiers).
+						AddField("vehicles", perfModel.WriteQueueLengths.Vehicles).
+						AddField("soldier_states", perfModel.WriteQueueLengths.SoldierStates).
+						AddField("vehicle_states", perfModel.WriteQueueLengths.VehicleStates).
+						AddField("general_events", perfModel.WriteQueueLengths.GeneralEvents).
+						AddField("hit_events", perfModel.WriteQueueLengths.HitEvents).
+						AddField("kill_events", perfModel.WriteQueueLengths.KillEvents).
+						AddField("fired_events", perfModel.WriteQueueLengths.FiredEvents).
+						AddField("chat_events", perfModel.WriteQueueLengths.ChatEvents).
+						AddField("radio_events", perfModel.WriteQueueLengths.RadioEvents).
+						AddField("server_fps_events", perfModel.WriteQueueLengths.ServerFpsEvents).
+						SetTime(time.Now())
+
+					s.influxWriter(
+						context.Background(),
+						"ocap_performance",
+						p,
+					)
+
+					// write last write duration
+					p = influxdb2.NewPointWithMeasurement(
+						"ext_db_lastwrite_duration_ms",
+					).
+						AddTag("db_url", s.influxDBURL()).
+						AddTag("mission_name", perfModel.Mission.MissionName).
+						AddTag("mission_id", fmt.Sprintf("%d", perfModel.Mission.ID)).
+						AddField("value", perfModel.LastWriteDurationMs).
+						SetTime(time.Now())
+
+					s.influxWriter(
+						context.Background(),
+						"ocap_performance",
+						p,
+					)
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+// Stop stops the status monitor
+func (s *Service) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.isRunning {
+		close(s.stopChan)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1,0 +1,710 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/OCAP2/extension/internal/cache"
+	"github.com/OCAP2/extension/internal/handlers"
+	"github.com/OCAP2/extension/internal/logging"
+	"github.com/OCAP2/extension/internal/model"
+	"github.com/OCAP2/extension/internal/queue"
+
+	influxdb2_write "github.com/influxdata/influxdb-client-go/v2/api/write"
+	"gorm.io/gorm"
+)
+
+// ErrTooEarlyForStateAssociation is returned when state data arrives before entity is registered
+var ErrTooEarlyForStateAssociation = fmt.Errorf("too early for state association")
+
+// Queues holds all the write queues
+type Queues struct {
+	Soldiers              *queue.SoldiersQueue
+	SoldierStates         *queue.SoldierStatesQueue
+	Vehicles              *queue.VehiclesQueue
+	VehicleStates         *queue.VehicleStatesQueue
+	FiredEvents           *queue.FiredEventsQueue
+	ProjectileEvents      *queue.ProjectileEventsQueue
+	GeneralEvents         *queue.GeneralEventsQueue
+	HitEvents             *queue.HitEventsQueue
+	KillEvents            *queue.KillEventsQueue
+	ChatEvents            *queue.ChatEventsQueue
+	RadioEvents           *queue.RadioEventsQueue
+	FpsEvents             *queue.FpsEventsQueue
+	Ace3DeathEvents       *queue.Ace3DeathEventsQueue
+	Ace3UnconsciousEvents *queue.Ace3UnconsciousEventsQueue
+	Markers               *queue.MarkersQueue
+	MarkerStates          *queue.MarkerStatesQueue
+}
+
+// NewQueues creates all write queues
+func NewQueues() *Queues {
+	return &Queues{
+		Soldiers:              &queue.SoldiersQueue{},
+		SoldierStates:         &queue.SoldierStatesQueue{},
+		Vehicles:              &queue.VehiclesQueue{},
+		VehicleStates:         &queue.VehicleStatesQueue{},
+		FiredEvents:           &queue.FiredEventsQueue{},
+		ProjectileEvents:      &queue.ProjectileEventsQueue{},
+		GeneralEvents:         &queue.GeneralEventsQueue{},
+		HitEvents:             &queue.HitEventsQueue{},
+		KillEvents:            &queue.KillEventsQueue{},
+		ChatEvents:            &queue.ChatEventsQueue{},
+		RadioEvents:           &queue.RadioEventsQueue{},
+		FpsEvents:             &queue.FpsEventsQueue{},
+		Ace3DeathEvents:       &queue.Ace3DeathEventsQueue{},
+		Ace3UnconsciousEvents: &queue.Ace3UnconsciousEventsQueue{},
+		Markers:               &queue.MarkersQueue{},
+		MarkerStates:          &queue.MarkerStatesQueue{},
+	}
+}
+
+// Dependencies holds all dependencies for the worker manager
+type Dependencies struct {
+	DB               *gorm.DB
+	EntityCache      *cache.EntityCache
+	MarkerCache      *cache.MarkerCache
+	LogManager       *logging.Manager
+	HandlerService   *handlers.Service
+	IsDatabaseValid  func() bool
+	ShouldSaveLocal  func() bool
+	DBInsertsPaused  func() bool
+}
+
+// InfluxWriter is a function type for writing to InfluxDB
+type InfluxWriter func(ctx context.Context, bucket string, point *influxdb2_write.Point) error
+
+// MetricProcessor is a function type for processing metric data
+type MetricProcessor func(data []string) (bucket string, point *influxdb2_write.Point, err error)
+
+// Manager manages worker goroutines
+type Manager struct {
+	deps                Dependencies
+	queues              *Queues
+	channels            map[string]chan []string
+	lastDBWriteDuration time.Duration
+
+	// Optional InfluxDB integration
+	influxWriter     InfluxWriter
+	metricProcessor  MetricProcessor
+	influxEnabled    func() bool
+}
+
+// NewManager creates a new worker manager
+func NewManager(deps Dependencies, queues *Queues, channels map[string]chan []string) *Manager {
+	return &Manager{
+		deps:     deps,
+		queues:   queues,
+		channels: channels,
+		influxEnabled: func() bool { return false },
+	}
+}
+
+// SetInfluxIntegration sets up InfluxDB integration
+func (m *Manager) SetInfluxIntegration(writer InfluxWriter, processor MetricProcessor, enabledFn func() bool) {
+	m.influxWriter = writer
+	m.metricProcessor = processor
+	m.influxEnabled = enabledFn
+}
+
+// GetLastDBWriteDuration returns the duration of the last DB write cycle
+func (m *Manager) GetLastDBWriteDuration() time.Duration {
+	return m.lastDBWriteDuration
+}
+
+// StartAsyncProcessors starts all async data processors
+func (m *Manager) StartAsyncProcessors() {
+	functionName := ":DATA:PROCESSOR:"
+
+	// process new soldiers
+	go func() {
+		for v := range m.channels[":NEW:SOLDIER:"] {
+			if !m.deps.IsDatabaseValid() {
+				continue
+			}
+
+			obj, err := m.deps.HandlerService.LogNewSoldier(v)
+			if err == nil {
+				m.queues.Soldiers.Push([]model.Soldier{obj})
+			} else {
+				m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Failed to log new soldier. Err: %s`, err), "ERROR")
+			}
+		}
+	}()
+
+	// process new vehicles
+	go func() {
+		for v := range m.channels[":NEW:VEHICLE:"] {
+			if !m.deps.IsDatabaseValid() {
+				continue
+			}
+
+			obj, err := m.deps.HandlerService.LogNewVehicle(v)
+			if err == nil {
+				m.queues.Vehicles.Push([]model.Vehicle{obj})
+			} else {
+				m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Failed to log new vehicle. Err: %s`, err), "ERROR")
+			}
+		}
+	}()
+
+	// process soldier states
+	go func() {
+		for v := range m.channels[":NEW:SOLDIER:STATE:"] {
+			if !m.deps.IsDatabaseValid() {
+				continue
+			}
+
+			obj, err := m.deps.HandlerService.LogSoldierState(v)
+			if err == nil {
+				m.queues.SoldierStates.Push([]model.SoldierState{obj})
+			} else {
+				if err == ErrTooEarlyForStateAssociation {
+					continue
+				}
+				m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Failed to log soldier state. Err: %s`, err), "ERROR")
+			}
+		}
+	}()
+
+	// process vehicle states
+	go func() {
+		for v := range m.channels[":NEW:VEHICLE:STATE:"] {
+			if !m.deps.IsDatabaseValid() {
+				continue
+			}
+
+			obj, err := m.deps.HandlerService.LogVehicleState(v)
+			if err == nil {
+				m.queues.VehicleStates.Push([]model.VehicleState{obj})
+			} else {
+				if err == ErrTooEarlyForStateAssociation {
+					continue
+				}
+				m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Failed to log vehicle state. Err: %s`, err), "ERROR")
+			}
+		}
+	}()
+
+	// process fired events
+	go func() {
+		for v := range m.channels[":FIRED:"] {
+			if !m.deps.IsDatabaseValid() {
+				continue
+			}
+
+			obj, err := m.deps.HandlerService.LogFiredEvent(v)
+			if err == nil {
+				m.queues.FiredEvents.Push([]model.FiredEvent{obj})
+			} else {
+				if err == ErrTooEarlyForStateAssociation {
+					continue
+				}
+				m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Failed to log fired event. Err: %s`, err), "ERROR")
+			}
+		}
+	}()
+
+	// process projectile events
+	go func() {
+		for v := range m.channels[":PROJECTILE:"] {
+			// new projectile events use linestringzm geo format, which is not supported by SQLite
+			if !m.deps.IsDatabaseValid() || m.deps.ShouldSaveLocal() {
+				continue
+			}
+
+			obj, err := m.deps.HandlerService.LogProjectileEvent(v)
+			if err == nil {
+				m.queues.ProjectileEvents.Push([]model.ProjectileEvent{obj})
+			} else {
+				if err == ErrTooEarlyForStateAssociation {
+					continue
+				}
+				m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Failed to log projectile event. Err: %s`, err), "ERROR")
+			}
+		}
+	}()
+
+	// process general events
+	go func() {
+		for v := range m.channels[":EVENT:"] {
+			if !m.deps.IsDatabaseValid() {
+				continue
+			}
+
+			obj, err := m.deps.HandlerService.LogGeneralEvent(v)
+			if err == nil {
+				m.queues.GeneralEvents.Push([]model.GeneralEvent{obj})
+			} else {
+				m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Failed to log general event. Err: %s`, err), "ERROR")
+			}
+		}
+	}()
+
+	// process hit events
+	go func() {
+		for v := range m.channels[":HIT:"] {
+			if !m.deps.IsDatabaseValid() {
+				continue
+			}
+
+			obj, err := m.deps.HandlerService.LogHitEvent(v)
+			if err == nil {
+				m.queues.HitEvents.Push([]model.HitEvent{obj})
+			} else {
+				if err == ErrTooEarlyForStateAssociation {
+					continue
+				}
+				m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Failed to log hit event. Err: %s`, err), "ERROR")
+			}
+		}
+	}()
+
+	// process kill events
+	go func() {
+		for v := range m.channels[":KILL:"] {
+			if !m.deps.IsDatabaseValid() {
+				continue
+			}
+
+			obj, err := m.deps.HandlerService.LogKillEvent(v)
+			if err == nil {
+				m.queues.KillEvents.Push([]model.KillEvent{obj})
+			} else {
+				if err == ErrTooEarlyForStateAssociation {
+					continue
+				}
+				m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Failed to log kill event. Err: %s`, err), "ERROR")
+			}
+		}
+	}()
+
+	// process chat events
+	go func() {
+		for v := range m.channels[":CHAT:"] {
+			if !m.deps.IsDatabaseValid() {
+				continue
+			}
+
+			obj, err := m.deps.HandlerService.LogChatEvent(v)
+			if err == nil {
+				m.queues.ChatEvents.Push([]model.ChatEvent{obj})
+			} else {
+				if err == ErrTooEarlyForStateAssociation {
+					continue
+				}
+				m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Failed to log chat event. Err: %s`, err), "ERROR")
+			}
+		}
+	}()
+
+	// process radio events
+	go func() {
+		for v := range m.channels[":RADIO:"] {
+			if !m.deps.IsDatabaseValid() {
+				continue
+			}
+
+			obj, err := m.deps.HandlerService.LogRadioEvent(v)
+			if err == nil {
+				m.queues.RadioEvents.Push([]model.RadioEvent{obj})
+			} else {
+				if err == ErrTooEarlyForStateAssociation {
+					continue
+				}
+				m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Failed to log radio event. Err: %s`, err), "ERROR")
+			}
+		}
+	}()
+
+	// process fps events
+	go func() {
+		for v := range m.channels[":FPS:"] {
+			if !m.deps.IsDatabaseValid() {
+				continue
+			}
+
+			obj, err := m.deps.HandlerService.LogFpsEvent(v)
+			if err == nil {
+				m.queues.FpsEvents.Push([]model.ServerFpsEvent{obj})
+			} else {
+				if err == ErrTooEarlyForStateAssociation {
+					continue
+				}
+				m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Failed to log fps event. Err: %s`, err), "ERROR")
+			}
+		}
+	}()
+
+	// process ace3 death events
+	go func() {
+		for v := range m.channels[":ACE3:DEATH:"] {
+			if !m.deps.IsDatabaseValid() {
+				continue
+			}
+
+			obj, err := m.deps.HandlerService.LogAce3DeathEvent(v)
+			if err == nil {
+				m.queues.Ace3DeathEvents.Push([]model.Ace3DeathEvent{obj})
+			} else {
+				if err == ErrTooEarlyForStateAssociation {
+					continue
+				}
+				m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Failed to log ace3 death event. Err: %s`, err), "ERROR")
+			}
+		}
+	}()
+
+	// process ace3 unconscious events
+	go func() {
+		for v := range m.channels[":ACE3:UNCONSCIOUS:"] {
+			if !m.deps.IsDatabaseValid() {
+				continue
+			}
+
+			obj, err := m.deps.HandlerService.LogAce3UnconsciousEvent(v)
+			if err == nil {
+				m.queues.Ace3UnconsciousEvents.Push([]model.Ace3UnconsciousEvent{obj})
+			} else {
+				m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Failed to log ace3 unconscious event. Err: %s`, err), "ERROR")
+			}
+		}
+	}()
+
+	// process metric data
+	go func() {
+		for data := range m.channels[":METRIC:"] {
+			if m.influxWriter == nil || m.metricProcessor == nil || !m.influxEnabled() {
+				continue
+			}
+
+			bucket, point, err := m.metricProcessor(data)
+			if err != nil {
+				m.deps.LogManager.Logger.Error().Err(err).Msg("error processing metric data")
+				continue
+			}
+
+			err = m.influxWriter(context.Background(), bucket, point)
+			if err != nil {
+				m.deps.LogManager.Logger.Error().Err(err).Msg("error writing influx point")
+				continue
+			}
+		}
+	}()
+
+	// process marker create events
+	go func() {
+		for data := range m.channels[":MARKER:CREATE:"] {
+			if !m.deps.IsDatabaseValid() {
+				continue
+			}
+
+			marker, err := m.deps.HandlerService.LogMarkerCreate(data)
+			if err != nil {
+				m.deps.LogManager.Logger.Error().Err(err).Msg("Error processing marker create")
+				continue
+			}
+			m.queues.Markers.Push([]model.Marker{marker})
+		}
+	}()
+
+	// process marker move events
+	go func() {
+		for data := range m.channels[":MARKER:MOVE:"] {
+			if !m.deps.IsDatabaseValid() {
+				continue
+			}
+
+			markerState, err := m.deps.HandlerService.LogMarkerMove(data)
+			if err != nil {
+				m.deps.LogManager.Logger.Warn().Err(err).Msg("Error processing marker move")
+				continue
+			}
+			m.queues.MarkerStates.Push([]model.MarkerState{markerState})
+		}
+	}()
+
+	// process marker delete events
+	go func() {
+		for data := range m.channels[":MARKER:DELETE:"] {
+			if !m.deps.IsDatabaseValid() {
+				continue
+			}
+
+			markerName, frameNo, err := m.deps.HandlerService.LogMarkerDelete(data)
+			if err != nil {
+				m.deps.LogManager.Logger.Error().Err(err).Msg("Error processing marker delete")
+				continue
+			}
+
+			// Look up marker and mark as deleted
+			markerID, ok := m.deps.MarkerCache.Get(markerName)
+			if ok {
+				// Create a marker state marking deletion
+				deleteState := model.MarkerState{
+					MissionID:    m.deps.HandlerService.GetMissionContext().GetMission().ID,
+					MarkerID:     markerID,
+					CaptureFrame: frameNo,
+					Time:         time.Now(),
+					Alpha:        0, // Zero alpha indicates deletion
+				}
+				m.queues.MarkerStates.Push([]model.MarkerState{deleteState})
+
+				// Update marker as deleted in DB
+				m.deps.DB.Model(&model.Marker{}).Where("id = ?", markerID).Update("is_deleted", true)
+			}
+		}
+	}()
+}
+
+// StartDBWriters starts the database writer goroutine
+func (m *Manager) StartDBWriters() {
+	functionName := ":DB:WRITER:"
+
+	go func() {
+		for {
+			if !m.deps.IsDatabaseValid() {
+				time.Sleep(1 * time.Second)
+				continue
+			}
+
+			if m.deps.DBInsertsPaused() {
+				time.Sleep(1 * time.Second)
+				continue
+			}
+
+			writeStart := time.Now()
+
+			// write new soldiers
+			if !m.queues.Soldiers.Empty() {
+				tx := m.deps.DB.Begin()
+				toWrite := m.queues.Soldiers.GetAndEmpty()
+				err := tx.Create(&toWrite).Error
+				if err != nil {
+					m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Error creating soldiers: %v`, err), "ERROR")
+					tx.Rollback()
+				} else {
+					tx.Commit()
+					for _, v := range toWrite {
+						m.deps.EntityCache.AddSoldier(v)
+					}
+				}
+			}
+
+			// write soldier states
+			if !m.queues.SoldierStates.Empty() {
+				tx := m.deps.DB.Begin()
+				toWrite := m.queues.SoldierStates.GetAndEmpty()
+				err := tx.Create(&toWrite).Error
+				if err != nil {
+					m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Error creating soldier states: %v`, err), "ERROR")
+					tx.Rollback()
+				} else {
+					tx.Commit()
+				}
+			}
+
+			// write new vehicles
+			if !m.queues.Vehicles.Empty() {
+				tx := m.deps.DB.Begin()
+				toWrite := m.queues.Vehicles.GetAndEmpty()
+				err := tx.Create(&toWrite).Error
+				if err != nil {
+					m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Error creating vehicles: %v`, err), "ERROR")
+					tx.Rollback()
+				} else {
+					tx.Commit()
+					for _, v := range toWrite {
+						m.deps.EntityCache.AddVehicle(v)
+					}
+				}
+			}
+
+			// write vehicle states
+			if !m.queues.VehicleStates.Empty() {
+				tx := m.deps.DB.Begin()
+				toWrite := m.queues.VehicleStates.GetAndEmpty()
+				err := tx.Create(&toWrite).Error
+				if err != nil {
+					m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Error creating vehicle states: %v`, err), "ERROR")
+					stmt := tx.Statement.SQL.String()
+					m.deps.LogManager.WriteLog(functionName, stmt, "ERROR")
+					tx.Rollback()
+				} else {
+					tx.Commit()
+				}
+			}
+
+			// write fired events
+			if !m.queues.FiredEvents.Empty() {
+				tx := m.deps.DB.Begin()
+				toWrite := m.queues.FiredEvents.GetAndEmpty()
+				err := tx.Create(&toWrite).Error
+				if err != nil {
+					m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Error creating fired events: %v`, err), "ERROR")
+					stmt := tx.Statement.SQL.String()
+					m.deps.LogManager.WriteLog(functionName, stmt, "ERROR")
+					tx.Rollback()
+				} else {
+					tx.Commit()
+				}
+			}
+
+			// write projectile events
+			if !m.queues.ProjectileEvents.Empty() {
+				tx := m.deps.DB.Begin()
+				toWrite := m.queues.ProjectileEvents.GetAndEmpty()
+				err := tx.Create(&toWrite).Error
+				if err != nil {
+					m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Error creating projectile events: %v`, err), "ERROR")
+					stmt := tx.Statement.SQL.String()
+					m.deps.LogManager.WriteLog(functionName, stmt, "ERROR")
+					tx.Rollback()
+				} else {
+					tx.Commit()
+				}
+			}
+
+			// write general events
+			if !m.queues.GeneralEvents.Empty() {
+				tx := m.deps.DB.Begin()
+				toWrite := m.queues.GeneralEvents.GetAndEmpty()
+				err := tx.Create(&toWrite).Error
+				if err != nil {
+					m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Error creating general events: %v`, err), "ERROR")
+					tx.Rollback()
+				} else {
+					tx.Commit()
+				}
+			}
+
+			// write hit events
+			if !m.queues.HitEvents.Empty() {
+				tx := m.deps.DB.Begin()
+				toWrite := m.queues.HitEvents.GetAndEmpty()
+				err := tx.Create(&toWrite).Error
+				if err != nil {
+					m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Error creating hit events: %v`, err), "ERROR")
+					tx.Rollback()
+				} else {
+					tx.Commit()
+				}
+			}
+
+			// write kill events
+			if !m.queues.KillEvents.Empty() {
+				tx := m.deps.DB.Begin()
+				toWrite := m.queues.KillEvents.GetAndEmpty()
+				err := tx.Create(&toWrite).Error
+				if err != nil {
+					m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Error creating killed events: %v`, err), "ERROR")
+					tx.Rollback()
+				} else {
+					tx.Commit()
+				}
+			}
+
+			// write chat events
+			if !m.queues.ChatEvents.Empty() {
+				tx := m.deps.DB.Begin()
+				toWrite := m.queues.ChatEvents.GetAndEmpty()
+				err := tx.Create(&toWrite).Error
+				if err != nil {
+					m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Error creating chat events: %v`, err), "ERROR")
+					tx.Rollback()
+				} else {
+					tx.Commit()
+				}
+			}
+
+			// write radio events
+			if !m.queues.RadioEvents.Empty() {
+				tx := m.deps.DB.Begin()
+				toWrite := m.queues.RadioEvents.GetAndEmpty()
+				err := tx.Create(&toWrite).Error
+				if err != nil {
+					m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Error creating radio events: %v`, err), "ERROR")
+					tx.Rollback()
+				} else {
+					tx.Commit()
+				}
+			}
+
+			// write serverfps events
+			if !m.queues.FpsEvents.Empty() {
+				tx := m.deps.DB.Begin()
+				toWrite := m.queues.FpsEvents.GetAndEmpty()
+				err := tx.Create(&toWrite).Error
+				if err != nil {
+					m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Error creating serverfps events: %v`, err), "ERROR")
+					tx.Rollback()
+				} else {
+					tx.Commit()
+				}
+			}
+
+			// write ace3 death events
+			if !m.queues.Ace3DeathEvents.Empty() {
+				tx := m.deps.DB.Begin()
+				toWrite := m.queues.Ace3DeathEvents.GetAndEmpty()
+				err := tx.Create(&toWrite).Error
+				if err != nil {
+					m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Error creating ace3 death events: %v`, err), "ERROR")
+					tx.Rollback()
+				} else {
+					tx.Commit()
+				}
+			}
+
+			// write ace3 unconscious events
+			if !m.queues.Ace3UnconsciousEvents.Empty() {
+				tx := m.deps.DB.Begin()
+				toWrite := m.queues.Ace3UnconsciousEvents.GetAndEmpty()
+				err := tx.Create(&toWrite).Error
+				if err != nil {
+					m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Error creating ace3 unconscious events: %v`, err), "ERROR")
+					tx.Rollback()
+				} else {
+					tx.Commit()
+				}
+			}
+
+			// write markers
+			if !m.queues.Markers.Empty() {
+				tx := m.deps.DB.Begin()
+				toWrite := m.queues.Markers.GetAndEmpty()
+				err := tx.Create(&toWrite).Error
+				if err != nil {
+					m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Error creating markers: %v`, err), "ERROR")
+					tx.Rollback()
+				} else {
+					tx.Commit()
+					for _, marker := range toWrite {
+						if marker.ID != 0 {
+							m.deps.MarkerCache.Set(marker.MarkerName, marker.ID)
+						}
+					}
+				}
+			}
+
+			// write marker states
+			if !m.queues.MarkerStates.Empty() {
+				tx := m.deps.DB.Begin()
+				toWrite := m.queues.MarkerStates.GetAndEmpty()
+				err := tx.Create(&toWrite).Error
+				if err != nil {
+					m.deps.LogManager.WriteLog(functionName, fmt.Sprintf(`Error creating marker states: %v`, err), "ERROR")
+					tx.Rollback()
+				} else {
+					tx.Commit()
+				}
+			}
+
+			m.lastDBWriteDuration = time.Since(writeStart)
+
+			// sleep
+			time.Sleep(2 * time.Second)
+		}
+	}()
+}


### PR DESCRIPTION
## Summary

- Extract ~3,200 lines from `cmd/ocap_recorder/main.go` into focused internal packages
- Reduces main.go from ~4,825 lines to ~1,660 lines (~66% reduction)
- Uses dependency injection pattern for service wiring

### New Packages

| Package | File | Lines | Purpose |
|---------|------|-------|---------|
| `internal/logging` | logging.go | ~200 | Log manager with zerolog, Graylog, log.io support |
| `internal/cache` | marker.go | ~40 | Thread-safe marker cache |
| `internal/handlers` | handlers.go | ~1,200 | 18 handler functions for game events |
| `internal/worker` | worker.go | ~500 | Async processors and DB writers |
| `internal/monitor` | monitor.go | ~300 | Status monitoring and InfluxDB metrics |

### What Remains in main.go

- CGo exports and RVExtension interface
- Database setup and connection management
- Channel creation and service wiring
- Demo data generation
- OCAP JSON export (`getOcapRecording`)
- SQLite migration (`migrateBackupsSqlite`)

## Test plan

- [x] Build x64 DLL successfully with `docker run --rm -v ${PWD}:/go/work -w /go/work x1unix/go-mingw:1.24 go build -buildvcs=false -o dist/ocap_recorder_x64.dll -buildmode=c-shared ./cmd/ocap_recorder`
- [ ] Deploy and test with ArmA 3 server