### PR TITLE
fix: return VERSION as array with build date

### DIFF
--- a/cmd/ocap_recorder/main.go
+++ b/cmd/ocap_recorder/main.go
@@ -46,9 +46,10 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-// module defs
+// module defs - BuildDate can be set at build time via ldflags
 var (
 	CurrentExtensionVersion string = "0.0.1"
+	BuildDate               string = "unknown"
 
 	Addon         string = "ocap"
 	ExtensionName string = "ocap_recorder"
@@ -781,7 +782,7 @@ func registerLifecycleHandlers(d *dispatcher.Dispatcher) {
 
 	// Simple queries - sync return is sufficient, no callback needed
 	d.Register(":VERSION:", func(e dispatcher.Event) (any, error) {
-		return CurrentExtensionVersion, nil
+		return []string{CurrentExtensionVersion, BuildDate}, nil
 	})
 
 	d.Register(":GETDIR:ARMA:", func(e dispatcher.Event) (any, error) {


### PR DESCRIPTION
## Summary
- Fix :VERSION: command to return array `["version", "buildDate"]` instead of just a string
- Add `BuildDate` variable that can be set via ldflags at build time
- Use JSON encoding for complex return types in rvextension responses

## Problem
The addon expects :VERSION: to return a parseable SQF array with two elements:
```sqf
"Extension version: " + (EGVAR(extension,version) # 0) + " (built " + (EGVAR(extension,version) # 1) + ")"
```

But the extension was returning just `"0.0.1"`, causing parse errors.

## Solution
- Return `[]string{CurrentExtensionVersion, BuildDate}` from the VERSION handler
- Update `formatDispatchResponse()` to JSON-encode complex types (arrays, structs) instead of using `%v` which produces invalid SQF

## Build with custom date
```bash
go build -ldflags "-X 'main.BuildDate=2026-02-02'" ...
```

## Test plan
- [ ] Load DLL in ArmA 3
- [ ] Verify :VERSION: returns `["ok", ":VERSION:", ["0.0.1", "2026-02-02"]]`
- [ ] Verify addon parses version correctly