### PR TITLE
refactor: adopt package-level OTel pattern

### DIFF
--- a/cmd/ocap_recorder/main.go
+++ b/cmd/ocap_recorder/main.go
@@ -307,6 +307,21 @@ func initDB() (err error) {
 
 func setupA3Interface() (err error) {
 	a3interface.SetVersion(CurrentExtensionVersion)
+
+	// Create early dispatcher for commands that don't need DB/workers
+	// This ensures :VERSION:, :INIT:, etc. work immediately when the DLL loads
+	dispatcherLogger := logging.NewDispatcherLogger(Logger)
+	earlyDispatcher, err := dispatcher.New(dispatcherLogger)
+	if err != nil {
+		return fmt.Errorf("failed to create early dispatcher: %w", err)
+	}
+
+	// Register early handlers
+	registerLifecycleHandlers(earlyDispatcher)
+	a3interface.SetDispatcher(earlyDispatcher)
+	eventDispatcher = earlyDispatcher
+
+	Logger.Info("Early dispatcher initialized with lifecycle handlers")
 	return nil
 }
 
@@ -514,25 +529,10 @@ func startGoroutines() (err error) {
 		Logger.Info("Memory storage backend initialized")
 	}
 
-	// Initialize event dispatcher
-	Logger.Debug("Initializing event dispatcher")
-	dispatcherLogger := logging.NewDispatcherLogger(Logger)
-	var meter = OTelProvider.Meter("ocap-recorder")
-	eventDispatcher, err = dispatcher.New(dispatcherLogger, meter)
-	if err != nil {
-		Logger.Error("Failed to create event dispatcher", "error", err)
-		return fmt.Errorf("failed to create dispatcher: %w", err)
-	}
-
-	// Register handlers with dispatcher
+	// Register worker handlers with the early dispatcher (created in setupA3Interface)
+	Logger.Debug("Registering worker handlers with dispatcher")
 	workerManager.RegisterHandlers(eventDispatcher)
-
-	// Register lifecycle/system handlers
-	registerLifecycleHandlers(eventDispatcher)
-
-	// Set dispatcher on a3interface
-	a3interface.SetDispatcher(eventDispatcher)
-	Logger.Info("Event dispatcher initialized and registered")
+	Logger.Info("Worker handlers registered with dispatcher")
 
 	// Start DB writers (processes queues filled by dispatcher handlers)
 	Logger.Debug("Starting DB writers")

--- a/internal/dispatcher/dispatcher_test.go
+++ b/internal/dispatcher/dispatcher_test.go
@@ -6,8 +6,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"go.opentelemetry.io/otel/metric/noop"
 )
 
 // testLogger implements Logger for testing
@@ -36,9 +34,8 @@ func (l *testLogger) Error(msg string, keysAndValues ...any) {
 
 func newTestDispatcher(t *testing.T) (*Dispatcher, *testLogger) {
 	logger := &testLogger{}
-	meter := noop.NewMeterProvider().Meter("test")
 
-	d, err := New(logger, meter)
+	d, err := New(logger)
 	if err != nil {
 		t.Fatalf("failed to create dispatcher: %v", err)
 	}

--- a/internal/dispatcher/otel.go
+++ b/internal/dispatcher/otel.go
@@ -1,0 +1,12 @@
+package dispatcher
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const instrumentationName = "github.com/OCAP2/extension/v5/internal/dispatcher"
+
+func meter() metric.Meter {
+	return otel.Meter(instrumentationName)
+}

--- a/internal/otel/provider.go
+++ b/internal/otel/provider.go
@@ -6,11 +6,8 @@ import (
 	"io"
 	"time"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	"go.opentelemetry.io/otel/exporters/stdout/stdoutlog"
-	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/noop"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
@@ -111,12 +108,6 @@ func (p *Provider) LoggerProvider() *sdklog.LoggerProvider {
 	return p.logProvider
 }
 
-// Meter returns a meter with the given name for creating metrics.
-// Returns a no-op meter since we're using file-based logging primarily.
-func (p *Provider) Meter(name string) metric.Meter {
-	return noop.Meter{}
-}
-
 // Flush forces a flush of all pending logs.
 // Use this during mission save to ensure all data is exported.
 func (p *Provider) Flush(ctx context.Context) error {
@@ -153,6 +144,3 @@ func (p *Provider) Shutdown(ctx context.Context) error {
 func (p *Provider) Enabled() bool {
 	return p.config.Enabled
 }
-
-// ensure otel import is used
-var _ = otel.Version

--- a/internal/worker/dispatch_test.go
+++ b/internal/worker/dispatch_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/OCAP2/extension/v5/internal/dispatcher"
 	"github.com/OCAP2/extension/v5/internal/model"
 	"github.com/OCAP2/extension/v5/internal/model/core"
-
-	"go.opentelemetry.io/otel/metric/noop"
 )
 
 // mockLogger implements dispatcher.Logger for testing
@@ -434,9 +432,8 @@ func (h *mockHandlerService) LogMarkerDelete(args []string) (string, int, error)
 
 func newTestDispatcher(t *testing.T) (*dispatcher.Dispatcher, *mockLogger) {
 	logger := &mockLogger{}
-	meter := noop.NewMeterProvider().Meter("test")
 
-	d, err := dispatcher.New(logger, meter)
+	d, err := dispatcher.New(logger)
 	if err != nil {
 		t.Fatalf("failed to create dispatcher: %v", err)
 	}


### PR DESCRIPTION
## Summary
Adopt the OTel pattern where each package has its own `otel.go` file with a package-specific instrumentation name.

## Changes
- **New file**: `internal/dispatcher/otel.go` - package-level `meter()` function
- **dispatcher.New()**: No longer takes a meter parameter, uses local `meter()` 
- **otel.Provider**: Removed `Meter()` method (each package has its own)
- **Early dispatcher**: Created in `setupA3Interface()` for immediate command handling
- **startGoroutines()**: Now just registers worker handlers with existing dispatcher

## Pattern Benefits
```go
// Before - passing meters around, nil checks needed
d, err := dispatcher.New(logger, meter)  // meter could be nil
if d.processed != nil {                   // nil check everywhere
    d.processed.Add(...)
}

// After - global OTel API, safe by default
d, err := dispatcher.New(logger)          // uses otel.Meter() internally
d.processed.Add(...)                      // always safe (no-op if not configured)
```

## Why This Pattern
1. **No nil checks** - Global OTel returns no-op implementations when not configured
2. **Cleaner API** - No need to pass meters around
3. **Per-package filtering** - Each package has unique instrumentation name
4. **Immediate availability** - Dispatcher ready when DLL loads (fixes race condition)

## Test plan
- [ ] Build DLL successfully
- [ ] Load in ArmA 3
- [ ] Verify :VERSION: and other commands work immediately on load
- [ ] Verify no crashes (previous nil pointer issue fixed)