### PR TITLE
fix: use status-wrapped response format

### DIFF
--- a/pkg/a3interface/rvextension.go
+++ b/pkg/a3interface/rvextension.go
@@ -108,24 +108,25 @@ func parseArgsFromC(argv **C.char, argc C.int) []string {
 	return data
 }
 
-// formatDispatchResponse formats the dispatcher result for ArmA
+// formatDispatchResponse formats the dispatcher result for ArmA.
+// Format: ["ok", result] for success, ["error", "message"] for errors.
+// Uses JSON encoding for proper SQF-compatible array/object formatting.
 func formatDispatchResponse(command string, result any, err error) string {
 	if err != nil {
-		return fmt.Sprintf(`["error", "%s", "%s"]`, command, err.Error())
+		return fmt.Sprintf(`["error", "%s"]`, err.Error())
 	}
 	if result == nil {
-		return fmt.Sprintf(`["ok", "%s"]`, command)
+		return `["ok"]`
 	}
-	// For complex types (arrays, maps), use JSON encoding to get proper SQF-compatible format
-	switch result.(type) {
+	switch v := result.(type) {
 	case string:
-		return fmt.Sprintf(`["ok", "%s", "%s"]`, command, result)
+		return fmt.Sprintf(`["ok", "%s"]`, v)
 	default:
 		jsonBytes, jsonErr := json.Marshal(result)
 		if jsonErr != nil {
-			return fmt.Sprintf(`["error", "%s", "failed to encode result: %s"]`, command, jsonErr.Error())
+			return fmt.Sprintf(`["error", "failed to encode: %s"]`, jsonErr.Error())
 		}
-		return fmt.Sprintf(`["ok", "%s", %s]`, command, string(jsonBytes))
+		return fmt.Sprintf(`["ok", %s]`, string(jsonBytes))
 	}
 }
 

--- a/pkg/a3interface/rvextension.go
+++ b/pkg/a3interface/rvextension.go
@@ -68,7 +68,7 @@ func RVExtension(output *C.char, outputsize C.size_t, input *C.char) {
 	}
 
 	// No handler found
-	replyToSyncArmaCall(fmt.Sprintf(`["error", "%s", "no handler registered"]`, command), output, outputsize)
+	replyToSyncArmaCall(fmt.Sprintf(`["error", "no handler registered for %s"]`, command), output, outputsize)
 }
 
 // called by Arma when in the format of: "extensionName" callExtension ["command", ["data"]]
@@ -94,7 +94,7 @@ func RVExtensionArgs(output *C.char, outputsize C.size_t, input *C.char, argv **
 	}
 
 	// No handler found
-	replyToSyncArmaCall(fmt.Sprintf(`["error", "%s", "no handler registered"]`, command), output, outputsize)
+	replyToSyncArmaCall(fmt.Sprintf(`["error", "no handler registered for %s"]`, command), output, outputsize)
 }
 
 // parseArgsFromC converts C argv array to Go string slice
@@ -134,7 +134,7 @@ func formatDispatchResponse(command string, result any, err error) string {
 // This prevents the game from crashing due to unhandled Go panics.
 func recoverPanic(funcName string, output *C.char, outputsize C.size_t) {
 	if r := recover(); r != nil {
-		errMsg := fmt.Sprintf(`["error", "%s", "panic recovered: %v"]`, funcName, r)
+		errMsg := fmt.Sprintf(`["error", "panic in %s: %v"]`, funcName, r)
 		replyToSyncArmaCall(errMsg, output, outputsize)
 	}
 }

--- a/pkg/a3interface/rvextension_test.go
+++ b/pkg/a3interface/rvextension_test.go
@@ -1,0 +1,112 @@
+package a3interface
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestFormatDispatchResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		command  string
+		result   any
+		err      error
+		expected string
+	}{
+		{
+			name:     "success with string array (VERSION)",
+			command:  ":VERSION:",
+			result:   []string{"0.0.1", "2026-02-01"},
+			err:      nil,
+			expected: `["ok", ["0.0.1","2026-02-01"]]`,
+		},
+		{
+			name:     "success with simple string",
+			command:  ":INIT:",
+			result:   "ok",
+			err:      nil,
+			expected: `["ok", "ok"]`,
+		},
+		{
+			name:     "success with path string",
+			command:  ":GETDIR:ARMA:",
+			result:   `C:\Program Files\Arma 3`,
+			err:      nil,
+			expected: `["ok", "C:\Program Files\Arma 3"]`,
+		},
+		{
+			name:     "success with nil result",
+			command:  ":SOME:CMD:",
+			result:   nil,
+			err:      nil,
+			expected: `["ok"]`,
+		},
+		{
+			name:     "error response",
+			command:  ":LOG:",
+			result:   nil,
+			err:      errors.New("no handler registered"),
+			expected: `["error", "no handler registered"]`,
+		},
+		{
+			name:     "success with int array",
+			command:  ":DATA:",
+			result:   []int{1, 2, 3},
+			err:      nil,
+			expected: `["ok", [1,2,3]]`,
+		},
+		{
+			name:     "success with nested array",
+			command:  ":NESTED:",
+			result:   [][]string{{"a", "b"}, {"c", "d"}},
+			err:      nil,
+			expected: `["ok", [["a","b"],["c","d"]]]`,
+		},
+		{
+			name:     "success with map",
+			command:  ":MAP:",
+			result:   map[string]int{"count": 42},
+			err:      nil,
+			expected: `["ok", {"count":42}]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatDispatchResponse(tt.command, tt.result, tt.err)
+			if got != tt.expected {
+				t.Errorf("formatDispatchResponse() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestResponseFormatConsistency(t *testing.T) {
+	// Test that all responses follow the ["ok", result] or ["error", message] format
+
+	t.Run("success responses start with ok", func(t *testing.T) {
+		responses := []struct {
+			result any
+		}{
+			{result: "simple string"},
+			{result: []string{"a", "b"}},
+			{result: nil},
+			{result: 42},
+		}
+
+		for _, r := range responses {
+			got := formatDispatchResponse(":TEST:", r.result, nil)
+			if len(got) < 5 || got[:5] != `["ok"` {
+				t.Errorf("success response should start with [\"ok\", got %q", got)
+			}
+		}
+	})
+
+	t.Run("error responses start with error", func(t *testing.T) {
+		got := formatDispatchResponse(":TEST:", nil, errors.New("test error"))
+		expected := `["error", "test error"]`
+		if got != expected {
+			t.Errorf("error response = %q, want %q", got, expected)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Change extension response format to include a status indicator for easier error handling.

## Response Format
```
Success: ["ok", <result>]
Error:   ["error", "<message>"]
```

## Examples
| Command | Response |
|---------|----------|
| `:VERSION:` | `["ok", ["0.0.1", "2026-02-02"]]` |
| `:GETDIR:ARMA:` | `["ok", "C:\\path\\to\\arma"]` |
| Error | `["error", "no handler registered"]` |

## Breaking Change
**Requires addon update** - `fnc_sendData.sqf` must be updated to:
1. Parse response with `parseSimpleArray`
2. Check if `result#0` is `"ok"` or `"error"`
3. Return `result#1` (the actual data) on success
4. Handle error case appropriately

## Benefits
- Clear success/error indication
- Consistent format across all commands
- Easier error handling in addon code

## Test plan
- [ ] Update addon `fnc_sendData.sqf` to handle new format
- [ ] Test `:VERSION:` returns correctly parsed array
- [ ] Test error cases are properly detected