### PR TITLE
feat: rename initDB to initStorage and support memory-only mode

### DIFF
--- a/cmd/ocap_recorder/main.go
+++ b/cmd/ocap_recorder/main.go
@@ -291,18 +291,33 @@ func initExtension() {
 	a3interface.WriteArmaCallback(ExtensionName, ":VERSION:", CurrentExtensionVersion)
 }
 
-func initDB() (err error) {
-	Logger.Debug("Received :INIT:DB: call")
-	loadConfig()
-	functionName := ":INIT:DB:"
-	DB, err = getDB()
-	if err != nil || DB == nil {
-		// if we couldn't connect to the database, send a callback to the addon to let it know
-		SlogManager.WriteLog(functionName, fmt.Sprintf(`Error connecting to database: %v`, err), "ERROR")
-		a3interface.WriteArmaCallback(ExtensionName, ":DB:ERROR:", err.Error())
-	} else {
-		a3interface.WriteArmaCallback(ExtensionName, ":DB:OK:", DB.Dialector.Name())
+func initStorage() error {
+	Logger.Debug("Received :INIT:STORAGE: call")
+	// Config is already loaded in init()
+	functionName := ":INIT:STORAGE:"
+
+	storageCfg := config.GetStorageConfig()
+	if storageCfg.Type == "memory" {
+		Logger.Info("Memory storage mode initialized")
+		a3interface.WriteArmaCallback(ExtensionName, ":STORAGE:OK:", "memory")
+		return nil
 	}
+
+	// Database storage mode
+	var err error
+	DB, err = getDB()
+	if err != nil {
+		SlogManager.WriteLog(functionName, fmt.Sprintf(`Error connecting to database: %v`, err), "ERROR")
+		a3interface.WriteArmaCallback(ExtensionName, ":STORAGE:ERROR:", err.Error())
+		return err
+	}
+	if DB == nil {
+		err = fmt.Errorf("database connection is nil")
+		SlogManager.WriteLog(functionName, err.Error(), "ERROR")
+		a3interface.WriteArmaCallback(ExtensionName, ":STORAGE:ERROR:", err.Error())
+		return err
+	}
+	a3interface.WriteArmaCallback(ExtensionName, ":STORAGE:OK:", DB.Dialector.Name())
 	return nil
 }
 
@@ -775,8 +790,12 @@ func registerLifecycleHandlers(d *dispatcher.Dispatcher) {
 		return "ok", nil
 	})
 
-	d.Register(":INIT:DB:", func(e dispatcher.Event) (any, error) {
-		go initDB()
+	d.Register(":INIT:STORAGE:", func(e dispatcher.Event) (any, error) {
+		go func() {
+			if err := initStorage(); err != nil {
+				Logger.Error("Storage initialization failed", "error", err)
+			}
+		}()
 		return "ok", nil
 	})
 
@@ -1568,12 +1587,13 @@ order by s.ocap_id,
 func main() {
 	var err error
 	Logger.Info("Starting up...")
-	Logger.Info("Connecting to DB...")
-	err = initDB()
+
+	Logger.Info("Initializing storage...")
+	err = initStorage()
 	if err != nil {
 		panic(err)
 	}
-	Logger.Info("DB connect/migrate complete.")
+	Logger.Info("Storage initialization complete.")
 	initExtension()
 
 	args := os.Args[1:]

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -1,0 +1,227 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/OCAP2/extension/v5/internal/cache"
+	"github.com/OCAP2/extension/v5/internal/logging"
+	"github.com/OCAP2/extension/v5/internal/model/core"
+	"github.com/OCAP2/extension/v5/internal/storage"
+)
+
+// mockBackend implements storage.Backend for testing
+type mockBackend struct {
+	missionStarted bool
+	missionEnded   bool
+	startedMission *core.Mission
+	startedWorld   *core.World
+}
+
+func (b *mockBackend) Init() error                                         { return nil }
+func (b *mockBackend) Close() error                                        { return nil }
+func (b *mockBackend) AddSoldier(s *core.Soldier) error                    { return nil }
+func (b *mockBackend) AddVehicle(v *core.Vehicle) error                    { return nil }
+func (b *mockBackend) AddMarker(m *core.Marker) error                      { return nil }
+func (b *mockBackend) RecordSoldierState(s *core.SoldierState) error       { return nil }
+func (b *mockBackend) RecordVehicleState(v *core.VehicleState) error       { return nil }
+func (b *mockBackend) RecordMarkerState(s *core.MarkerState) error         { return nil }
+func (b *mockBackend) RecordFiredEvent(e *core.FiredEvent) error           { return nil }
+func (b *mockBackend) RecordGeneralEvent(e *core.GeneralEvent) error       { return nil }
+func (b *mockBackend) RecordHitEvent(e *core.HitEvent) error               { return nil }
+func (b *mockBackend) RecordKillEvent(e *core.KillEvent) error             { return nil }
+func (b *mockBackend) RecordChatEvent(e *core.ChatEvent) error             { return nil }
+func (b *mockBackend) RecordRadioEvent(e *core.RadioEvent) error           { return nil }
+func (b *mockBackend) RecordServerFpsEvent(e *core.ServerFpsEvent) error   { return nil }
+func (b *mockBackend) RecordAce3DeathEvent(e *core.Ace3DeathEvent) error   { return nil }
+func (b *mockBackend) RecordAce3UnconsciousEvent(e *core.Ace3UnconsciousEvent) error {
+	return nil
+}
+func (b *mockBackend) GetSoldierByOcapID(ocapID uint16) (*core.Soldier, bool) { return nil, false }
+func (b *mockBackend) GetVehicleByOcapID(ocapID uint16) (*core.Vehicle, bool) { return nil, false }
+func (b *mockBackend) GetMarkerByName(name string) (*core.Marker, bool)       { return nil, false }
+
+func (b *mockBackend) StartMission(mission *core.Mission, world *core.World) error {
+	b.missionStarted = true
+	b.startedMission = mission
+	b.startedWorld = world
+	return nil
+}
+
+func (b *mockBackend) EndMission() error {
+	b.missionEnded = true
+	return nil
+}
+
+var _ storage.Backend = (*mockBackend)(nil)
+
+func newTestService() *Service {
+	logManager := logging.NewSlogManager()
+	logManager.Setup(nil, "info", nil)
+
+	deps := Dependencies{
+		DB:            nil, // memory-only mode
+		EntityCache:   cache.NewEntityCache(),
+		MarkerCache:   cache.NewMarkerCache(),
+		LogManager:    logManager,
+		ExtensionName: "test",
+		AddonVersion:  "1.0.0",
+	}
+
+	ctx := NewMissionContext()
+	return NewService(deps, ctx)
+}
+
+func TestNewService_NilDB(t *testing.T) {
+	svc := newTestService()
+
+	if svc == nil {
+		t.Fatal("expected service to be created")
+	}
+
+	if svc.deps.DB != nil {
+		t.Error("expected DB to be nil")
+	}
+}
+
+func TestSetBackend(t *testing.T) {
+	svc := newTestService()
+
+	backend := &mockBackend{}
+	svc.SetBackend(backend)
+
+	if svc.backend == nil {
+		t.Error("expected backend to be set")
+	}
+}
+
+func TestLogNewMission_MemoryOnlyMode(t *testing.T) {
+	svc := newTestService()
+	backend := &mockBackend{}
+	svc.SetBackend(backend)
+
+	worldData := `{"worldName":"Altis","displayName":"Altis","worldSize":30720,"latitude":-40.0,"longitude":30.0}`
+	missionData := `{
+		"missionName":"Test Mission",
+		"missionNameSource":"file",
+		"briefingName":"Test Briefing",
+		"serverName":"Test Server",
+		"serverProfile":"TestProfile",
+		"onLoadName":"Loading Test",
+		"author":"Tester",
+		"tag":"TvT",
+		"captureDelay":1.0,
+		"addons":[["addon1","12345"],["addon2",67890]],
+		"playableSlots":[10,10,5,0,2],
+		"sideFriendly":[false,false,true]
+	}`
+
+	err := svc.LogNewMission([]string{worldData, missionData})
+
+	if err != nil {
+		t.Fatalf("LogNewMission failed in memory-only mode: %v", err)
+	}
+
+	// Verify mission context was set
+	mission := svc.ctx.GetMission()
+	if mission.MissionName != "Test Mission" {
+		t.Errorf("expected mission name 'Test Mission', got '%s'", mission.MissionName)
+	}
+
+	world := svc.ctx.GetWorld()
+	if world.WorldName != "Altis" {
+		t.Errorf("expected world name 'Altis', got '%s'", world.WorldName)
+	}
+
+	// Verify backend was called
+	if !backend.missionStarted {
+		t.Error("expected backend.StartMission to be called")
+	}
+
+	if backend.startedMission == nil {
+		t.Error("expected mission to be passed to backend")
+	}
+
+	if backend.startedWorld == nil {
+		t.Error("expected world to be passed to backend")
+	}
+}
+
+func TestLogNewMission_MemoryOnlyMode_NoBackend(t *testing.T) {
+	svc := newTestService()
+	// No backend set
+
+	worldData := `{"worldName":"Stratis","displayName":"Stratis","worldSize":8192,"latitude":-40.0,"longitude":30.0}`
+	missionData := `{
+		"missionName":"No Backend Mission",
+		"missionNameSource":"file",
+		"briefingName":"Test",
+		"serverName":"Server",
+		"serverProfile":"Profile",
+		"onLoadName":"Loading",
+		"author":"Author",
+		"tag":"Coop",
+		"captureDelay":0.5,
+		"addons":[],
+		"playableSlots":[5,5,0,0,0],
+		"sideFriendly":[false,false,false]
+	}`
+
+	err := svc.LogNewMission([]string{worldData, missionData})
+
+	if err != nil {
+		t.Fatalf("LogNewMission failed without backend: %v", err)
+	}
+
+	// Verify mission context was still set
+	mission := svc.ctx.GetMission()
+	if mission.MissionName != "No Backend Mission" {
+		t.Errorf("expected mission name 'No Backend Mission', got '%s'", mission.MissionName)
+	}
+}
+
+func TestLogNewMission_AddonsWithoutDB(t *testing.T) {
+	svc := newTestService()
+
+	worldData := `{"worldName":"Tanoa","displayName":"Tanoa","worldSize":15360,"latitude":-40.0,"longitude":30.0}`
+	missionData := `{
+		"missionName":"Addon Test",
+		"missionNameSource":"file",
+		"briefingName":"Test",
+		"serverName":"Server",
+		"serverProfile":"Profile",
+		"onLoadName":"Loading",
+		"author":"Author",
+		"tag":"TvT",
+		"captureDelay":1.0,
+		"addons":[["CBA_A3","450814997"],["ACE3",463939057],["TFAR","894678801"]],
+		"playableSlots":[10,10,0,0,0],
+		"sideFriendly":[false,false,false]
+	}`
+
+	err := svc.LogNewMission([]string{worldData, missionData})
+
+	if err != nil {
+		t.Fatalf("LogNewMission with addons failed: %v", err)
+	}
+
+	// Verify addons were processed (even without DB)
+	mission := svc.ctx.GetMission()
+	if len(mission.Addons) != 3 {
+		t.Errorf("expected 3 addons, got %d", len(mission.Addons))
+	}
+}
+
+func TestMissionContext_ThreadSafe(t *testing.T) {
+	ctx := NewMissionContext()
+
+	// Should have default values
+	mission := ctx.GetMission()
+	if mission.MissionName != "No mission loaded" {
+		t.Errorf("expected default mission name, got '%s'", mission.MissionName)
+	}
+
+	world := ctx.GetWorld()
+	if world.WorldName != "No world loaded" {
+		t.Errorf("expected default world name, got '%s'", world.WorldName)
+	}
+}

--- a/internal/worker/dispatch.go
+++ b/internal/worker/dispatch.go
@@ -378,7 +378,9 @@ func (m *Manager) handleMarkerDelete(e dispatcher.Event) (any, error) {
 			Alpha:        0,
 		}
 		m.queues.MarkerStates.Push([]model.MarkerState{deleteState})
-		m.deps.DB.Model(&model.Marker{}).Where("id = ?", markerID).Update("is_deleted", true)
+		if m.deps.DB != nil {
+			m.deps.DB.Model(&model.Marker{}).Where("id = ?", markerID).Update("is_deleted", true)
+		}
 	}
 
 	return nil, nil


### PR DESCRIPTION
## Summary
- Rename `initDB()` to `initStorage()` to reflect its broader purpose
- Rename `:INIT:DB:` command to `:INIT:STORAGE:`
- Rename `:DB:OK:`/`:DB:ERROR:` callbacks to `:STORAGE:OK:`/`:STORAGE:ERROR:`
- Support memory-only storage mode that skips database connection entirely
- Add DB nil checks in handlers for memory-only operation

## Breaking Changes (Addon Update Required)

| Before | After |
|--------|-------|
| `:INIT:DB:` | `:INIT:STORAGE:` |
| `:DB:OK:` | `:STORAGE:OK:` |
| `:DB:ERROR:` | `:STORAGE:ERROR:` |

The `:STORAGE:OK:` callback returns the storage engine:
- `"memory"` - Memory-only mode (JSON file output)
- `"postgres"` - PostgreSQL database
- `"sqlite"` - SQLite database (fallback)

## Test plan
- [ ] Configure `storage.type: "memory"` and verify no DB connection attempts
- [ ] Verify `:INIT:STORAGE:` returns correct engine in callback
- [ ] Test mission recording with memory backend
- [ ] Test mission recording with database backend