### PR TITLE
refactor: remove redundant loadConfig call from initDB

### DIFF
--- a/cmd/ocap_recorder/main.go
+++ b/cmd/ocap_recorder/main.go
@@ -293,7 +293,7 @@ func initExtension() {
 
 func initDB() (err error) {
 	Logger.Debug("Received :INIT:DB: call")
-	loadConfig()
+	// Config is already loaded in init()
 	functionName := ":INIT:DB:"
 	DB, err = getDB()
 	if err != nil || DB == nil {


### PR DESCRIPTION
## Summary
- Remove redundant `loadConfig()` call from `initDB()`
- Config is already loaded once in `init()`, no need to reload on every DB initialization

## Test plan
- [ ] Verify application starts correctly
- [ ] Verify DB connection works as expected