### PR TITLE
test: improve test coverage for cache, geo, and queue packages

### DIFF
--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,247 @@
+package cache
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/OCAP2/extension/v5/internal/model"
+)
+
+func TestEntityCache_NewEntityCache(t *testing.T) {
+	cache := NewEntityCache()
+
+	if cache == nil {
+		t.Fatal("expected non-nil cache")
+	}
+	if cache.Soldiers == nil {
+		t.Error("expected Soldiers map to be initialized")
+	}
+	if cache.Vehicles == nil {
+		t.Error("expected Vehicles map to be initialized")
+	}
+	if len(cache.Soldiers) != 0 {
+		t.Errorf("expected empty Soldiers map, got %d entries", len(cache.Soldiers))
+	}
+	if len(cache.Vehicles) != 0 {
+		t.Errorf("expected empty Vehicles map, got %d entries", len(cache.Vehicles))
+	}
+}
+
+func TestEntityCache_AddAndGetSoldier(t *testing.T) {
+	cache := NewEntityCache()
+
+	soldier := model.Soldier{
+		OcapID:   42,
+		UnitName: "Test Soldier",
+	}
+
+	cache.AddSoldier(soldier)
+
+	got, ok := cache.GetSoldier(42)
+	if !ok {
+		t.Fatal("expected to find soldier with OcapID 42")
+	}
+	if got.OcapID != 42 {
+		t.Errorf("expected OcapID 42, got %d", got.OcapID)
+	}
+	if got.UnitName != "Test Soldier" {
+		t.Errorf("expected UnitName 'Test Soldier', got %s", got.UnitName)
+	}
+}
+
+func TestEntityCache_GetSoldier_NotFound(t *testing.T) {
+	cache := NewEntityCache()
+
+	_, ok := cache.GetSoldier(999)
+	if ok {
+		t.Error("expected not to find soldier with OcapID 999")
+	}
+}
+
+func TestEntityCache_AddAndGetVehicle(t *testing.T) {
+	cache := NewEntityCache()
+
+	vehicle := model.Vehicle{
+		OcapID:    99,
+		ClassName: "Test_Vehicle",
+	}
+
+	cache.AddVehicle(vehicle)
+
+	got, ok := cache.GetVehicle(99)
+	if !ok {
+		t.Fatal("expected to find vehicle with OcapID 99")
+	}
+	if got.OcapID != 99 {
+		t.Errorf("expected OcapID 99, got %d", got.OcapID)
+	}
+	if got.ClassName != "Test_Vehicle" {
+		t.Errorf("expected className 'Test_Vehicle', got %s", got.ClassName)
+	}
+}
+
+func TestEntityCache_GetVehicle_NotFound(t *testing.T) {
+	cache := NewEntityCache()
+
+	_, ok := cache.GetVehicle(999)
+	if ok {
+		t.Error("expected not to find vehicle with OcapID 999")
+	}
+}
+
+func TestEntityCache_Reset(t *testing.T) {
+	cache := NewEntityCache()
+
+	// Add some data
+	cache.AddSoldier(model.Soldier{OcapID: 1, UnitName: "Soldier 1"})
+	cache.AddSoldier(model.Soldier{OcapID: 2, UnitName: "Soldier 2"})
+	cache.AddVehicle(model.Vehicle{OcapID: 10, ClassName: "Vehicle 1"})
+
+	// Verify data exists
+	if len(cache.Soldiers) != 2 {
+		t.Errorf("expected 2 soldiers before reset, got %d", len(cache.Soldiers))
+	}
+	if len(cache.Vehicles) != 1 {
+		t.Errorf("expected 1 vehicle before reset, got %d", len(cache.Vehicles))
+	}
+
+	// Reset
+	cache.Reset()
+
+	// Verify data is cleared
+	if len(cache.Soldiers) != 0 {
+		t.Errorf("expected 0 soldiers after reset, got %d", len(cache.Soldiers))
+	}
+	if len(cache.Vehicles) != 0 {
+		t.Errorf("expected 0 vehicles after reset, got %d", len(cache.Vehicles))
+	}
+
+	// Verify we can still add data after reset
+	cache.AddSoldier(model.Soldier{OcapID: 3, UnitName: "Soldier 3"})
+	_, ok := cache.GetSoldier(3)
+	if !ok {
+		t.Error("expected to find soldier added after reset")
+	}
+}
+
+func TestEntityCache_LockUnlock(t *testing.T) {
+	cache := NewEntityCache()
+
+	// Test Lock/Unlock don't cause deadlock
+	cache.Lock()
+	// Directly modify the map while holding the lock
+	cache.Soldiers[1] = model.Soldier{OcapID: 1, UnitName: "Direct Add"}
+	cache.Unlock()
+
+	// Verify the data was added
+	got, ok := cache.GetSoldier(1)
+	if !ok {
+		t.Fatal("expected to find soldier added while holding lock")
+	}
+	if got.UnitName != "Direct Add" {
+		t.Errorf("expected UnitName 'Direct Add', got %s", got.UnitName)
+	}
+}
+
+func TestEntityCache_Concurrent(t *testing.T) {
+	cache := NewEntityCache()
+	var wg sync.WaitGroup
+
+	// Concurrent writes
+	for i := uint16(0); i < 100; i++ {
+		wg.Add(2)
+		go func(id uint16) {
+			defer wg.Done()
+			cache.AddSoldier(model.Soldier{OcapID: id, UnitName: "Soldier"})
+		}(i)
+		go func(id uint16) {
+			defer wg.Done()
+			cache.AddVehicle(model.Vehicle{OcapID: id, ClassName: "Vehicle"})
+		}(i)
+	}
+	wg.Wait()
+
+	// Verify counts
+	if len(cache.Soldiers) != 100 {
+		t.Errorf("expected 100 soldiers, got %d", len(cache.Soldiers))
+	}
+	if len(cache.Vehicles) != 100 {
+		t.Errorf("expected 100 vehicles, got %d", len(cache.Vehicles))
+	}
+
+	// Concurrent reads
+	for i := uint16(0); i < 100; i++ {
+		wg.Add(2)
+		go func(id uint16) {
+			defer wg.Done()
+			cache.GetSoldier(id)
+		}(i)
+		go func(id uint16) {
+			defer wg.Done()
+			cache.GetVehicle(id)
+		}(i)
+	}
+	wg.Wait()
+}
+
+// SafeCounter tests
+
+func TestSafeCounter_InitialValue(t *testing.T) {
+	c := &SafeCounter{}
+	if c.Value() != 0 {
+		t.Errorf("expected initial value 0, got %d", c.Value())
+	}
+}
+
+func TestSafeCounter_Set(t *testing.T) {
+	c := &SafeCounter{}
+
+	c.Set(42)
+	if c.Value() != 42 {
+		t.Errorf("expected value 42, got %d", c.Value())
+	}
+
+	c.Set(100)
+	if c.Value() != 100 {
+		t.Errorf("expected value 100, got %d", c.Value())
+	}
+
+	c.Set(0)
+	if c.Value() != 0 {
+		t.Errorf("expected value 0, got %d", c.Value())
+	}
+}
+
+func TestSafeCounter_Inc(t *testing.T) {
+	c := &SafeCounter{}
+
+	c.Inc()
+	if c.Value() != 1 {
+		t.Errorf("expected value 1, got %d", c.Value())
+	}
+
+	c.Inc()
+	c.Inc()
+	if c.Value() != 3 {
+		t.Errorf("expected value 3, got %d", c.Value())
+	}
+}
+
+func TestSafeCounter_Concurrent(t *testing.T) {
+	c := &SafeCounter{}
+	var wg sync.WaitGroup
+
+	// Concurrent increments
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.Inc()
+		}()
+	}
+	wg.Wait()
+
+	if c.Value() != 1000 {
+		t.Errorf("expected value 1000, got %d", c.Value())
+	}
+}

--- a/internal/cache/marker_test.go
+++ b/internal/cache/marker_test.go
@@ -1,0 +1,179 @@
+package cache
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestMarkerCache_NewMarkerCache(t *testing.T) {
+	cache := NewMarkerCache()
+
+	if cache == nil {
+		t.Fatal("expected non-nil cache")
+	}
+	if cache.markers == nil {
+		t.Error("expected markers map to be initialized")
+	}
+}
+
+func TestMarkerCache_SetAndGet(t *testing.T) {
+	cache := NewMarkerCache()
+
+	cache.Set("marker1", 42)
+
+	id, ok := cache.Get("marker1")
+	if !ok {
+		t.Fatal("expected to find marker1")
+	}
+	if id != 42 {
+		t.Errorf("expected id 42, got %d", id)
+	}
+}
+
+func TestMarkerCache_Get_NotFound(t *testing.T) {
+	cache := NewMarkerCache()
+
+	_, ok := cache.Get("nonexistent")
+	if ok {
+		t.Error("expected not to find nonexistent marker")
+	}
+}
+
+func TestMarkerCache_Delete(t *testing.T) {
+	cache := NewMarkerCache()
+
+	cache.Set("marker1", 1)
+	cache.Set("marker2", 2)
+
+	// Verify marker exists
+	_, ok := cache.Get("marker1")
+	if !ok {
+		t.Fatal("expected to find marker1 before delete")
+	}
+
+	// Delete marker
+	cache.Delete("marker1")
+
+	// Verify marker is deleted
+	_, ok = cache.Get("marker1")
+	if ok {
+		t.Error("expected not to find marker1 after delete")
+	}
+
+	// Verify other marker still exists
+	_, ok = cache.Get("marker2")
+	if !ok {
+		t.Error("expected marker2 to still exist")
+	}
+}
+
+func TestMarkerCache_Delete_NonExistent(t *testing.T) {
+	cache := NewMarkerCache()
+
+	// Should not panic when deleting non-existent marker
+	cache.Delete("nonexistent")
+}
+
+func TestMarkerCache_Reset(t *testing.T) {
+	cache := NewMarkerCache()
+
+	cache.Set("marker1", 1)
+	cache.Set("marker2", 2)
+	cache.Set("marker3", 3)
+
+	cache.Reset()
+
+	// Verify all markers are cleared
+	if _, ok := cache.Get("marker1"); ok {
+		t.Error("expected marker1 to be cleared after reset")
+	}
+	if _, ok := cache.Get("marker2"); ok {
+		t.Error("expected marker2 to be cleared after reset")
+	}
+	if _, ok := cache.Get("marker3"); ok {
+		t.Error("expected marker3 to be cleared after reset")
+	}
+
+	// Verify we can still add markers after reset
+	cache.Set("marker4", 4)
+	if _, ok := cache.Get("marker4"); !ok {
+		t.Error("expected to find marker4 after reset")
+	}
+}
+
+func TestMarkerCache_OverwriteExisting(t *testing.T) {
+	cache := NewMarkerCache()
+
+	cache.Set("marker1", 1)
+	cache.Set("marker1", 100)
+
+	id, ok := cache.Get("marker1")
+	if !ok {
+		t.Fatal("expected to find marker1")
+	}
+	if id != 100 {
+		t.Errorf("expected id to be overwritten to 100, got %d", id)
+	}
+}
+
+func TestMarkerCache_Concurrent(t *testing.T) {
+	cache := NewMarkerCache()
+	var wg sync.WaitGroup
+
+	// Concurrent writes
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			cache.Set("marker"+string(rune('A'+id%26)), uint(id))
+		}(i)
+	}
+	wg.Wait()
+
+	// Concurrent reads
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			cache.Get("marker" + string(rune('A'+id%26)))
+		}(i)
+	}
+	wg.Wait()
+
+	// Concurrent deletes
+	for i := 0; i < 26; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			cache.Delete("marker" + string(rune('A'+id)))
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestMarkerCache_ConcurrentReadWrite(t *testing.T) {
+	cache := NewMarkerCache()
+	var wg sync.WaitGroup
+
+	// Mixed concurrent operations
+	for i := 0; i < 100; i++ {
+		wg.Add(3)
+
+		go func(id int) {
+			defer wg.Done()
+			cache.Set("marker", uint(id))
+		}(i)
+
+		go func() {
+			defer wg.Done()
+			cache.Get("marker")
+		}()
+
+		go func() {
+			defer wg.Done()
+			cache.Delete("marker")
+		}()
+	}
+
+	wg.Wait()
+}

--- a/internal/geo/geo_test.go
+++ b/internal/geo/geo_test.go
@@ -1,0 +1,292 @@
+package geo
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCoord3857FromString_ValidWithElevation(t *testing.T) {
+	point, elev, err := Coord3857FromString("100.5,200.25,50.0")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	coords, ok := point.Coordinates()
+	if !ok {
+		t.Fatal("expected valid coordinates")
+	}
+	if coords.X != 100.5 {
+		t.Errorf("expected X=100.5, got %f", coords.X)
+	}
+	if coords.Y != 200.25 {
+		t.Errorf("expected Y=200.25, got %f", coords.Y)
+	}
+	if elev != 50.0 {
+		t.Errorf("expected elevation=50.0, got %f", elev)
+	}
+}
+
+func TestCoord3857FromString_ValidWithoutElevation(t *testing.T) {
+	point, elev, err := Coord3857FromString("100.5,200.25")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	coords, ok := point.Coordinates()
+	if !ok {
+		t.Fatal("expected valid coordinates")
+	}
+	if coords.X != 100.5 {
+		t.Errorf("expected X=100.5, got %f", coords.X)
+	}
+	if coords.Y != 200.25 {
+		t.Errorf("expected Y=200.25, got %f", coords.Y)
+	}
+	if elev != 0 {
+		t.Errorf("expected elevation=0, got %f", elev)
+	}
+}
+
+func TestCoord3857FromString_NegativeCoordinates(t *testing.T) {
+	point, elev, err := Coord3857FromString("-100.5,-200.25,-50.0")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	coords, ok := point.Coordinates()
+	if !ok {
+		t.Fatal("expected valid coordinates")
+	}
+	if coords.X != -100.5 {
+		t.Errorf("expected X=-100.5, got %f", coords.X)
+	}
+	if coords.Y != -200.25 {
+		t.Errorf("expected Y=-200.25, got %f", coords.Y)
+	}
+	if elev != -50.0 {
+		t.Errorf("expected elevation=-50.0, got %f", elev)
+	}
+}
+
+func TestCoord3857FromString_IntegerCoordinates(t *testing.T) {
+	point, _, err := Coord3857FromString("100,200")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	coords, ok := point.Coordinates()
+	if !ok {
+		t.Fatal("expected valid coordinates")
+	}
+	if coords.X != 100 {
+		t.Errorf("expected X=100, got %f", coords.X)
+	}
+	if coords.Y != 200 {
+		t.Errorf("expected Y=200, got %f", coords.Y)
+	}
+}
+
+func TestCoord3857FromString_ZeroCoordinates(t *testing.T) {
+	point, elev, err := Coord3857FromString("0,0,0")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	coords, ok := point.Coordinates()
+	if !ok {
+		t.Fatal("expected valid coordinates")
+	}
+	if coords.X != 0 {
+		t.Errorf("expected X=0, got %f", coords.X)
+	}
+	if coords.Y != 0 {
+		t.Errorf("expected Y=0, got %f", coords.Y)
+	}
+	if elev != 0 {
+		t.Errorf("expected elevation=0, got %f", elev)
+	}
+}
+
+func TestCoord3857FromString_InvalidTooFewComponents(t *testing.T) {
+	_, _, err := Coord3857FromString("100.5")
+
+	if err == nil {
+		t.Fatal("expected error for invalid coordinates")
+	}
+	if !errors.Is(err, ErrInvalidCoordinates) {
+		t.Errorf("expected ErrInvalidCoordinates, got %v", err)
+	}
+}
+
+func TestCoord3857FromString_InvalidEmptyString(t *testing.T) {
+	_, _, err := Coord3857FromString("")
+
+	if err == nil {
+		t.Fatal("expected error for empty string")
+	}
+	if !errors.Is(err, ErrInvalidCoordinates) {
+		t.Errorf("expected ErrInvalidCoordinates, got %v", err)
+	}
+}
+
+func TestCoord3857FromString_InvalidLongitude(t *testing.T) {
+	_, _, err := Coord3857FromString("abc,200.25")
+
+	if err == nil {
+		t.Fatal("expected error for invalid longitude")
+	}
+	if !errors.Is(err, ErrInvalidCoordinates) {
+		t.Errorf("expected ErrInvalidCoordinates, got %v", err)
+	}
+}
+
+func TestCoord3857FromString_InvalidLatitude(t *testing.T) {
+	_, _, err := Coord3857FromString("100.5,xyz")
+
+	if err == nil {
+		t.Fatal("expected error for invalid latitude")
+	}
+	if !errors.Is(err, ErrInvalidCoordinates) {
+		t.Errorf("expected ErrInvalidCoordinates, got %v", err)
+	}
+}
+
+func TestCoord3857FromString_InvalidElevation(t *testing.T) {
+	_, _, err := Coord3857FromString("100.5,200.25,invalid")
+
+	if err == nil {
+		t.Fatal("expected error for invalid elevation")
+	}
+	if !errors.Is(err, ErrInvalidCoordinates) {
+		t.Errorf("expected ErrInvalidCoordinates, got %v", err)
+	}
+}
+
+func TestCoord3857FromString_ExtraComponents(t *testing.T) {
+	// Extra components beyond 3 should be ignored
+	point, elev, err := Coord3857FromString("100.5,200.25,50.0,extra,ignored")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	coords, ok := point.Coordinates()
+	if !ok {
+		t.Fatal("expected valid coordinates")
+	}
+	if coords.X != 100.5 {
+		t.Errorf("expected X=100.5, got %f", coords.X)
+	}
+	if coords.Y != 200.25 {
+		t.Errorf("expected Y=200.25, got %f", coords.Y)
+	}
+	if elev != 50.0 {
+		t.Errorf("expected elevation=50.0, got %f", elev)
+	}
+}
+
+func TestCoord3857FromString_ScientificNotation(t *testing.T) {
+	point, _, err := Coord3857FromString("1e2,2e3")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	coords, ok := point.Coordinates()
+	if !ok {
+		t.Fatal("expected valid coordinates")
+	}
+	if coords.X != 100 {
+		t.Errorf("expected X=100, got %f", coords.X)
+	}
+	if coords.Y != 2000 {
+		t.Errorf("expected Y=2000, got %f", coords.Y)
+	}
+}
+
+func TestCoord3857FromString_LargeCoordinates(t *testing.T) {
+	point, _, err := Coord3857FromString("1000000.123456,2000000.654321")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	coords, ok := point.Coordinates()
+	if !ok {
+		t.Fatal("expected valid coordinates")
+	}
+	if coords.X != 1000000.123456 {
+		t.Errorf("expected X=1000000.123456, got %f", coords.X)
+	}
+	if coords.Y != 2000000.654321 {
+		t.Errorf("expected Y=2000000.654321, got %f", coords.Y)
+	}
+}
+
+func TestCoords3857From4326_ValidCoordinates(t *testing.T) {
+	// Test converting WGS84 (EPSG:4326) to Web Mercator (EPSG:3857)
+	// Approximate coordinates for a point
+	point, err := Coords3857From4326(0, 0)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	coords, ok := point.Coordinates()
+	if !ok {
+		t.Fatal("expected valid coordinates")
+	}
+	// At (0, 0) in 4326, the 3857 coordinates should also be (0, 0)
+	if coords.X != 0 {
+		t.Errorf("expected X=0 at origin, got %f", coords.X)
+	}
+	if coords.Y != 0 {
+		t.Errorf("expected Y=0 at origin, got %f", coords.Y)
+	}
+}
+
+func TestCoords3857From4326_NonZeroCoordinates(t *testing.T) {
+	// Test a point at 10 degrees longitude, 10 degrees latitude
+	point, err := Coords3857From4326(10, 10)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	coords, ok := point.Coordinates()
+	if !ok {
+		t.Fatal("expected valid coordinates")
+	}
+	// In Web Mercator, these should be non-zero positive values
+	if coords.X <= 0 {
+		t.Errorf("expected positive X, got %f", coords.X)
+	}
+	if coords.Y <= 0 {
+		t.Errorf("expected positive Y, got %f", coords.Y)
+	}
+}
+
+func TestCoords3857From4326_NegativeCoordinates(t *testing.T) {
+	// Test a point in the Southern/Western hemisphere
+	point, err := Coords3857From4326(-45, -30)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	coords, ok := point.Coordinates()
+	if !ok {
+		t.Fatal("expected valid coordinates")
+	}
+	if coords.X >= 0 {
+		t.Errorf("expected negative X for western hemisphere, got %f", coords.X)
+	}
+	if coords.Y >= 0 {
+		t.Errorf("expected negative Y for southern hemisphere, got %f", coords.Y)
+	}
+}

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -1,0 +1,523 @@
+package queue
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/OCAP2/extension/v5/internal/model"
+)
+
+// Test ArraysQueue
+
+func TestArraysQueue_Push(t *testing.T) {
+	q := &ArraysQueue{}
+
+	q.Push([][]string{{"a", "b"}, {"c", "d"}})
+
+	if q.Len() != 2 {
+		t.Errorf("expected length 2, got %d", q.Len())
+	}
+}
+
+func TestArraysQueue_Pop(t *testing.T) {
+	q := &ArraysQueue{}
+
+	// Pop from empty queue
+	result := q.Pop()
+	if result != nil {
+		t.Errorf("expected nil from empty queue, got %v", result)
+	}
+
+	// Pop from non-empty queue
+	q.Push([][]string{{"a", "b"}, {"c", "d"}})
+	first := q.Pop()
+	if len(first) != 2 || first[0] != "a" || first[1] != "b" {
+		t.Errorf("expected [a, b], got %v", first)
+	}
+	if q.Len() != 1 {
+		t.Errorf("expected length 1 after pop, got %d", q.Len())
+	}
+}
+
+func TestArraysQueue_Empty(t *testing.T) {
+	q := &ArraysQueue{}
+
+	if !q.Empty() {
+		t.Error("expected empty queue")
+	}
+
+	q.Push([][]string{{"a"}})
+	if q.Empty() {
+		t.Error("expected non-empty queue")
+	}
+}
+
+func TestArraysQueue_Clear(t *testing.T) {
+	q := &ArraysQueue{}
+	q.Push([][]string{{"a"}, {"b"}, {"c"}})
+
+	q.Clear()
+
+	if !q.Empty() {
+		t.Error("expected empty queue after clear")
+	}
+}
+
+func TestArraysQueue_GetAndEmpty(t *testing.T) {
+	q := &ArraysQueue{}
+	q.Push([][]string{{"a"}, {"b"}, {"c"}})
+
+	result := q.GetAndEmpty()
+
+	if len(result) != 3 {
+		t.Errorf("expected 3 items, got %d", len(result))
+	}
+	if !q.Empty() {
+		t.Error("expected empty queue after GetAndEmpty")
+	}
+}
+
+// Test SoldiersQueue
+
+func TestSoldiersQueue_Push(t *testing.T) {
+	q := &SoldiersQueue{}
+
+	q.Push([]model.Soldier{{OcapID: 1}, {OcapID: 2}})
+
+	if q.Len() != 2 {
+		t.Errorf("expected length 2, got %d", q.Len())
+	}
+}
+
+func TestSoldiersQueue_Pop(t *testing.T) {
+	q := &SoldiersQueue{}
+
+	// Pop from empty queue
+	result := q.Pop()
+	if result.OcapID != 0 {
+		t.Errorf("expected empty soldier from empty queue, got OcapID %d", result.OcapID)
+	}
+
+	// Pop from non-empty queue
+	q.Push([]model.Soldier{{OcapID: 1}, {OcapID: 2}})
+	first := q.Pop()
+	if first.OcapID != 1 {
+		t.Errorf("expected OcapID 1, got %d", first.OcapID)
+	}
+	if q.Len() != 1 {
+		t.Errorf("expected length 1 after pop, got %d", q.Len())
+	}
+}
+
+func TestSoldiersQueue_Empty(t *testing.T) {
+	q := &SoldiersQueue{}
+
+	if !q.Empty() {
+		t.Error("expected empty queue")
+	}
+
+	q.Push([]model.Soldier{{OcapID: 1}})
+	if q.Empty() {
+		t.Error("expected non-empty queue")
+	}
+}
+
+func TestSoldiersQueue_LockUnlock(t *testing.T) {
+	q := &SoldiersQueue{}
+
+	locked := q.Lock()
+	if !locked {
+		t.Error("expected Lock() to return true")
+	}
+	// Direct access while holding lock
+	q.Queue = append(q.Queue, model.Soldier{OcapID: 99})
+	q.Unlock()
+
+	if q.Len() != 1 {
+		t.Errorf("expected length 1, got %d", q.Len())
+	}
+}
+
+func TestSoldiersQueue_Clear(t *testing.T) {
+	q := &SoldiersQueue{}
+	q.Push([]model.Soldier{{OcapID: 1}, {OcapID: 2}})
+
+	result := q.Clear()
+
+	if result != 0 {
+		t.Errorf("expected Clear to return 0, got %d", result)
+	}
+	if !q.Empty() {
+		t.Error("expected empty queue after clear")
+	}
+}
+
+func TestSoldiersQueue_GetAndEmpty(t *testing.T) {
+	q := &SoldiersQueue{}
+	q.Push([]model.Soldier{{OcapID: 1}, {OcapID: 2}})
+
+	result := q.GetAndEmpty()
+
+	if len(result) != 2 {
+		t.Errorf("expected 2 items, got %d", len(result))
+	}
+	if !q.Empty() {
+		t.Error("expected empty queue after GetAndEmpty")
+	}
+}
+
+// Test SoldierStatesQueue (representative of state queues)
+
+func TestSoldierStatesQueue_Operations(t *testing.T) {
+	q := &SoldierStatesQueue{}
+
+	// Push
+	q.Push([]model.SoldierState{{SoldierID: 1}, {SoldierID: 2}})
+	if q.Len() != 2 {
+		t.Errorf("expected length 2, got %d", q.Len())
+	}
+
+	// Pop
+	first := q.Pop()
+	if first.SoldierID != 1 {
+		t.Errorf("expected SoldierID 1, got %d", first.SoldierID)
+	}
+
+	// Lock/Unlock
+	q.Lock()
+	q.Queue = append(q.Queue, model.SoldierState{SoldierID: 3})
+	q.Unlock()
+
+	// Clear
+	q.Clear()
+	if !q.Empty() {
+		t.Error("expected empty queue after clear")
+	}
+}
+
+// Test VehiclesQueue
+
+func TestVehiclesQueue_Operations(t *testing.T) {
+	q := &VehiclesQueue{}
+
+	q.Push([]model.Vehicle{{OcapID: 1}, {OcapID: 2}})
+	if q.Len() != 2 {
+		t.Errorf("expected length 2, got %d", q.Len())
+	}
+
+	first := q.Pop()
+	if first.OcapID != 1 {
+		t.Errorf("expected OcapID 1, got %d", first.OcapID)
+	}
+
+	q.Lock()
+	q.Unlock()
+
+	q.Clear()
+	if !q.Empty() {
+		t.Error("expected empty queue after clear")
+	}
+}
+
+// Test VehicleStatesQueue
+
+func TestVehicleStatesQueue_Operations(t *testing.T) {
+	q := &VehicleStatesQueue{}
+
+	q.Push([]model.VehicleState{{VehicleID: 1}, {VehicleID: 2}})
+	if q.Len() != 2 {
+		t.Errorf("expected length 2, got %d", q.Len())
+	}
+
+	first := q.Pop()
+	if first.VehicleID != 1 {
+		t.Errorf("expected VehicleID 1, got %d", first.VehicleID)
+	}
+
+	q.Lock()
+	q.Unlock()
+
+	result := q.GetAndEmpty()
+	if len(result) != 1 {
+		t.Errorf("expected 1 item, got %d", len(result))
+	}
+}
+
+// Test FiredEventsQueue
+
+func TestFiredEventsQueue_Operations(t *testing.T) {
+	q := &FiredEventsQueue{}
+
+	q.Push([]model.FiredEvent{{SoldierID: 1}})
+	if q.Empty() {
+		t.Error("expected non-empty queue")
+	}
+
+	q.Pop()
+	if !q.Empty() {
+		t.Error("expected empty queue after pop")
+	}
+
+	q.Lock()
+	q.Unlock()
+	q.Clear()
+}
+
+// Test GeneralEventsQueue
+
+func TestGeneralEventsQueue_Operations(t *testing.T) {
+	q := &GeneralEventsQueue{}
+
+	q.Push([]model.GeneralEvent{{Name: "test"}})
+	result := q.GetAndEmpty()
+	if len(result) != 1 {
+		t.Errorf("expected 1 item, got %d", len(result))
+	}
+
+	q.Lock()
+	q.Unlock()
+	q.Clear()
+}
+
+// Test SoldierStatesMap
+
+func TestSoldierStatesMap_New(t *testing.T) {
+	m := NewSoldierStatesMap()
+	if m == nil {
+		t.Fatal("expected non-nil map")
+	}
+	if m.Len() != 0 {
+		t.Errorf("expected empty map, got length %d", m.Len())
+	}
+}
+
+func TestSoldierStatesMap_SetAndLen(t *testing.T) {
+	m := NewSoldierStatesMap()
+
+	m.Set(0, []any{"state0"})
+	m.Set(10, []any{"state10"})
+	m.Set(20, []any{"state20"})
+
+	if m.Len() != 3 {
+		t.Errorf("expected length 3, got %d", m.Len())
+	}
+}
+
+func TestSoldierStatesMap_GetStateAtFrame(t *testing.T) {
+	m := NewSoldierStatesMap()
+	m.Set(0, []any{"state0"})
+	m.Set(10, []any{"state10"})
+	m.Set(20, []any{"state20"})
+
+	// Exact frame match
+	state, err := m.GetStateAtFrame(10, 100)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(state) != 1 || state[0] != "state10" {
+		t.Errorf("expected [state10], got %v", state)
+	}
+
+	// No exact match, should find next frame
+	state, err = m.GetStateAtFrame(5, 100)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(state) != 1 || state[0] != "state10" {
+		t.Errorf("expected [state10], got %v", state)
+	}
+
+	// Frame not found
+	_, err = m.GetStateAtFrame(50, 60)
+	if err == nil {
+		t.Error("expected error for missing frame")
+	}
+}
+
+func TestSoldierStatesMap_GetLastState(t *testing.T) {
+	m := NewSoldierStatesMap()
+	m.Set(10, []any{"state10"})
+
+	// Initially nil
+	if m.GetLastState() != nil {
+		t.Error("expected nil last state initially")
+	}
+
+	// After GetStateAtFrame with fallback search
+	m.GetStateAtFrame(5, 100)
+	lastState := m.GetLastState()
+	if len(lastState) != 1 || lastState[0] != "state10" {
+		t.Errorf("expected [state10], got %v", lastState)
+	}
+}
+
+// Test MarkersQueue
+
+func TestMarkersQueue_Operations(t *testing.T) {
+	q := &MarkersQueue{}
+
+	q.Push([]model.Marker{{MarkerName: "marker1"}})
+	if q.Len() != 1 {
+		t.Errorf("expected length 1, got %d", q.Len())
+	}
+
+	first := q.Pop()
+	if first.MarkerName != "marker1" {
+		t.Errorf("expected marker1, got %s", first.MarkerName)
+	}
+
+	q.Lock()
+	q.Unlock()
+	q.Clear()
+	q.GetAndEmpty()
+}
+
+// Test MarkerStatesQueue
+
+func TestMarkerStatesQueue_Operations(t *testing.T) {
+	q := &MarkerStatesQueue{}
+
+	q.Push([]model.MarkerState{{MarkerID: 1}})
+	if q.Empty() {
+		t.Error("expected non-empty queue")
+	}
+
+	q.Pop()
+	q.Lock()
+	q.Unlock()
+	q.Clear()
+	q.GetAndEmpty()
+}
+
+// Test concurrent operations
+
+func TestSoldiersQueue_Concurrent(t *testing.T) {
+	q := &SoldiersQueue{}
+	var wg sync.WaitGroup
+
+	// Concurrent pushes
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(id uint16) {
+			defer wg.Done()
+			q.Push([]model.Soldier{{OcapID: id}})
+		}(uint16(i))
+	}
+	wg.Wait()
+
+	if q.Len() != 100 {
+		t.Errorf("expected 100 items, got %d", q.Len())
+	}
+
+	// Concurrent pops
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			q.Pop()
+		}()
+	}
+	wg.Wait()
+
+	if q.Len() != 50 {
+		t.Errorf("expected 50 items after pops, got %d", q.Len())
+	}
+}
+
+// Test remaining queue types to ensure coverage
+
+func TestProjectileEventsQueue_Operations(t *testing.T) {
+	q := &ProjectileEventsQueue{}
+	q.Push([]model.ProjectileEvent{{}})
+	q.Pop()
+	q.Lock()
+	q.Unlock()
+	q.Empty()
+	q.Len()
+	q.Clear()
+	q.GetAndEmpty()
+}
+
+func TestHitEventsQueue_Operations(t *testing.T) {
+	q := &HitEventsQueue{}
+	q.Push([]model.HitEvent{{}})
+	q.Pop()
+	q.Lock()
+	q.Unlock()
+	q.Empty()
+	q.Len()
+	q.Clear()
+	q.GetAndEmpty()
+}
+
+func TestKillEventsQueue_Operations(t *testing.T) {
+	q := &KillEventsQueue{}
+	q.Push([]model.KillEvent{{}})
+	q.Pop()
+	q.Lock()
+	q.Unlock()
+	q.Empty()
+	q.Len()
+	q.Clear()
+	q.GetAndEmpty()
+}
+
+func TestChatEventsQueue_Operations(t *testing.T) {
+	q := &ChatEventsQueue{}
+	q.Push([]model.ChatEvent{{}})
+	q.Pop()
+	q.Lock()
+	q.Unlock()
+	q.Empty()
+	q.Len()
+	q.Clear()
+	q.GetAndEmpty()
+}
+
+func TestRadioEventsQueue_Operations(t *testing.T) {
+	q := &RadioEventsQueue{}
+	q.Push([]model.RadioEvent{{}})
+	q.Pop()
+	q.Lock()
+	q.Unlock()
+	q.Empty()
+	q.Len()
+	q.Clear()
+	q.GetAndEmpty()
+}
+
+func TestFpsEventsQueue_Operations(t *testing.T) {
+	q := &FpsEventsQueue{}
+	q.Push([]model.ServerFpsEvent{{}})
+	q.Pop()
+	q.Lock()
+	q.Unlock()
+	q.Empty()
+	q.Len()
+	q.Clear()
+	q.GetAndEmpty()
+}
+
+func TestAce3DeathEventsQueue_Operations(t *testing.T) {
+	q := &Ace3DeathEventsQueue{}
+	q.Push([]model.Ace3DeathEvent{{}})
+	q.Pop()
+	q.Lock()
+	q.Unlock()
+	q.Empty()
+	q.Len()
+	q.Clear()
+	q.GetAndEmpty()
+}
+
+func TestAce3UnconsciousEventsQueue_Operations(t *testing.T) {
+	q := &Ace3UnconsciousEventsQueue{}
+	q.Push([]model.Ace3UnconsciousEvent{{}})
+	q.Pop()
+	q.Lock()
+	q.Unlock()
+	q.Empty()
+	q.Len()
+	q.Clear()
+	q.GetAndEmpty()
+}

--- a/internal/worker/dispatch_test.go
+++ b/internal/worker/dispatch_test.go
@@ -525,3 +525,77 @@ func TestSetBackend(t *testing.T) {
 	}
 }
 
+func TestNewQueues(t *testing.T) {
+	queues := NewQueues()
+
+	if queues == nil {
+		t.Fatal("expected non-nil queues")
+	}
+	if queues.Soldiers == nil {
+		t.Error("expected Soldiers queue to be initialized")
+	}
+	if queues.SoldierStates == nil {
+		t.Error("expected SoldierStates queue to be initialized")
+	}
+	if queues.Vehicles == nil {
+		t.Error("expected Vehicles queue to be initialized")
+	}
+	if queues.VehicleStates == nil {
+		t.Error("expected VehicleStates queue to be initialized")
+	}
+	if queues.FiredEvents == nil {
+		t.Error("expected FiredEvents queue to be initialized")
+	}
+	if queues.ProjectileEvents == nil {
+		t.Error("expected ProjectileEvents queue to be initialized")
+	}
+	if queues.GeneralEvents == nil {
+		t.Error("expected GeneralEvents queue to be initialized")
+	}
+	if queues.HitEvents == nil {
+		t.Error("expected HitEvents queue to be initialized")
+	}
+	if queues.KillEvents == nil {
+		t.Error("expected KillEvents queue to be initialized")
+	}
+	if queues.ChatEvents == nil {
+		t.Error("expected ChatEvents queue to be initialized")
+	}
+	if queues.RadioEvents == nil {
+		t.Error("expected RadioEvents queue to be initialized")
+	}
+	if queues.FpsEvents == nil {
+		t.Error("expected FpsEvents queue to be initialized")
+	}
+	if queues.Ace3DeathEvents == nil {
+		t.Error("expected Ace3DeathEvents queue to be initialized")
+	}
+	if queues.Ace3UnconsciousEvents == nil {
+		t.Error("expected Ace3UnconsciousEvents queue to be initialized")
+	}
+	if queues.Markers == nil {
+		t.Error("expected Markers queue to be initialized")
+	}
+	if queues.MarkerStates == nil {
+		t.Error("expected MarkerStates queue to be initialized")
+	}
+}
+
+func TestNewManager(t *testing.T) {
+	deps := Dependencies{
+		IsDatabaseValid: func() bool { return true },
+		ShouldSaveLocal: func() bool { return false },
+		DBInsertsPaused: func() bool { return false },
+	}
+	queues := NewQueues()
+
+	manager := NewManager(deps, queues)
+
+	if manager == nil {
+		t.Fatal("expected non-nil manager")
+	}
+	if manager.hasBackend() {
+		t.Error("expected no backend initially")
+	}
+}
+


### PR DESCRIPTION
## Summary
- Add comprehensive tests for `internal/cache` package (EntityCache, SafeCounter, MarkerCache)
- Add tests for `internal/geo` package (coordinate parsing and transformation)
- Add tests for `internal/queue` package (all queue types and SoldierStatesMap)
- Expand tests in `internal/worker/dispatch_test.go`

## Coverage Improvements

| Package | Before | After |
|---------|--------|-------|
| `internal/cache` | 0% | **100%** |
| `internal/geo` | 0% | **92%** |
| `internal/queue` | 0% | **89%** |
| **Total** | ~15% | **29%** |

## Test plan
- [x] All new tests pass locally
- [x] No regressions in existing tests
- [x] Coverage verified with `go test ./... -coverprofile=cover.out`