### PR TITLE
refactor(queue): replace type-specific queues with generic Queue[T]

### DIFF
--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -3,882 +3,103 @@ package queue
 import (
 	"fmt"
 	"sync"
-
-	"github.com/OCAP2/extension/v5/internal/model"
 )
 
-type ArraysQueue struct {
+// Queue is a generic thread-safe queue.
+type Queue[T any] struct {
 	mu    sync.Mutex
-	queue [][]string
+	items []T
 }
 
-func (q *ArraysQueue) Push(n [][]string) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.queue = append(q.queue, n...)
-}
-
-func (q *ArraysQueue) Pop() []string {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	if len(q.queue) == 0 {
-		return nil
+// New creates a new empty queue.
+func New[T any]() *Queue[T] {
+	return &Queue[T]{
+		items: make([]T, 0),
 	}
-	n := q.queue[0]
-	q.queue = q.queue[1:]
-	return n
 }
 
-func (q *ArraysQueue) Len() int {
+// Push appends items to the queue.
+func (q *Queue[T]) Push(items ...T) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	return len(q.queue)
+	q.items = append(q.items, items...)
 }
 
-func (q *ArraysQueue) Empty() bool {
+// Pop removes and returns the first item. Returns zero value if empty.
+func (q *Queue[T]) Pop() T {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	return len(q.queue) == 0
-}
-
-func (q *ArraysQueue) Clear() {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.queue = [][]string{}
-}
-
-func (q *ArraysQueue) GetAndEmpty() [][]string {
-	q.mu.Lock()
-	defer q.Clear()
-	defer q.mu.Unlock()
-	return q.queue
-}
-
-type SoldiersQueue struct {
-	mu    sync.Mutex
-	Queue []model.Soldier
-}
-
-func (q *SoldiersQueue) Lock() bool {
-	q.mu.Lock()
-	return true
-}
-
-func (q *SoldiersQueue) Unlock() {
-	q.mu.Unlock()
-}
-
-func (q *SoldiersQueue) Empty() bool {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue) == 0
-}
-
-func (q *SoldiersQueue) Push(n []model.Soldier) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = append(q.Queue, n...)
-}
-
-func (q *SoldiersQueue) Pop() model.Soldier {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	if len(q.Queue) == 0 {
-		return model.Soldier{}
+	if len(q.items) == 0 {
+		var zero T
+		return zero
 	}
-	n := q.Queue[0]
-	q.Queue = q.Queue[1:]
-	return n
+	item := q.items[0]
+	q.items = q.items[1:]
+	return item
 }
 
-func (q *SoldiersQueue) Len() int {
+// Empty returns true if the queue has no items.
+func (q *Queue[T]) Empty() bool {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	return len(q.Queue)
+	return len(q.items) == 0
 }
 
-func (q *SoldiersQueue) Clear() int {
+// Len returns the number of items in the queue.
+func (q *Queue[T]) Len() int {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	q.Queue = []model.Soldier{}
-	return len(q.Queue)
+	return len(q.items)
 }
 
-func (q *SoldiersQueue) GetAndEmpty() []model.Soldier {
+// Clear removes all items from the queue.
+func (q *Queue[T]) Clear() {
 	q.mu.Lock()
-	defer q.Clear()
 	defer q.mu.Unlock()
-	return q.Queue
+	q.items = q.items[:0]
 }
 
-type SoldierStatesQueue struct {
-	mu    sync.Mutex
-	Queue []model.SoldierState
-}
-
-func (q *SoldierStatesQueue) Lock() bool {
-	q.mu.Lock()
-	return true
-}
-
-func (q *SoldierStatesQueue) Unlock() {
-	q.mu.Unlock()
-}
-
-func (q *SoldierStatesQueue) Empty() bool {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue) == 0
-}
-
-func (q *SoldierStatesQueue) Push(n []model.SoldierState) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = append(q.Queue, n...)
-}
-
-func (q *SoldierStatesQueue) Pop() model.SoldierState {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	if len(q.Queue) == 0 {
-		return model.SoldierState{}
-	}
-	n := q.Queue[0]
-	q.Queue = q.Queue[1:]
-	return n
-}
-
-func (q *SoldierStatesQueue) Len() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue)
-}
-
-func (q *SoldierStatesQueue) Clear() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = []model.SoldierState{}
-	return len(q.Queue)
-}
-
-func (q *SoldierStatesQueue) GetAndEmpty() []model.SoldierState {
-	q.mu.Lock()
-	defer q.Clear()
-	defer q.mu.Unlock()
-	return q.Queue
-}
-
-type VehiclesQueue struct {
-	mu    sync.Mutex
-	Queue []model.Vehicle
-}
-
-func (q *VehiclesQueue) Lock() bool {
-	q.mu.Lock()
-	return true
-}
-
-func (q *VehiclesQueue) Unlock() {
-	q.mu.Unlock()
-}
-
-func (q *VehiclesQueue) Empty() bool {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue) == 0
-}
-
-func (q *VehiclesQueue) Push(n []model.Vehicle) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = append(q.Queue, n...)
-}
-
-func (q *VehiclesQueue) Pop() model.Vehicle {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	if len(q.Queue) == 0 {
-		return model.Vehicle{}
-	}
-	n := q.Queue[0]
-	q.Queue = q.Queue[1:]
-	return n
-}
-
-func (q *VehiclesQueue) Len() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue)
-}
-
-func (q *VehiclesQueue) Clear() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = []model.Vehicle{}
-	return len(q.Queue)
-}
-
-func (q *VehiclesQueue) GetAndEmpty() []model.Vehicle {
-	q.mu.Lock()
-	defer q.Clear()
-	defer q.mu.Unlock()
-	return q.Queue
-}
-
-type VehicleStatesQueue struct {
-	mu    sync.Mutex
-	Queue []model.VehicleState
-}
-
-func (q *VehicleStatesQueue) Lock() bool {
-	q.mu.Lock()
-	return true
-}
-
-func (q *VehicleStatesQueue) Unlock() {
-	q.mu.Unlock()
-}
-
-func (q *VehicleStatesQueue) Empty() bool {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue) == 0
-}
-
-func (q *VehicleStatesQueue) Push(n []model.VehicleState) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = append(q.Queue, n...)
-}
-
-func (q *VehicleStatesQueue) Pop() model.VehicleState {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	if len(q.Queue) == 0 {
-		return model.VehicleState{}
-	}
-	n := q.Queue[0]
-	q.Queue = q.Queue[1:]
-	return n
-}
-
-func (q *VehicleStatesQueue) Len() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue)
-}
-
-func (q *VehicleStatesQueue) Clear() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = []model.VehicleState{}
-	return len(q.Queue)
-}
-
-func (q *VehicleStatesQueue) GetAndEmpty() []model.VehicleState {
-	q.mu.Lock()
-	defer q.Clear()
-	defer q.mu.Unlock()
-	return q.Queue
-}
-
-type FiredEventsQueue struct {
-	mu    sync.Mutex
-	Queue []model.FiredEvent
-}
-
-func (q *FiredEventsQueue) Lock() bool {
-	q.mu.Lock()
-	return true
-}
-
-func (q *FiredEventsQueue) Unlock() {
-	q.mu.Unlock()
-}
-
-func (q *FiredEventsQueue) Empty() bool {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue) == 0
-}
-
-func (q *FiredEventsQueue) Push(n []model.FiredEvent) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = append(q.Queue, n...)
-}
-
-func (q *FiredEventsQueue) Pop() model.FiredEvent {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	if len(q.Queue) == 0 {
-		return model.FiredEvent{}
-	}
-	n := q.Queue[0]
-	q.Queue = q.Queue[1:]
-	return n
-}
-
-func (q *FiredEventsQueue) Len() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue)
-}
-
-func (q *FiredEventsQueue) Clear() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = []model.FiredEvent{}
-	return len(q.Queue)
-}
-
-func (q *FiredEventsQueue) GetAndEmpty() []model.FiredEvent {
-	q.mu.Lock()
-	defer q.Clear()
-	defer q.mu.Unlock()
-	return q.Queue
-}
-
-type ProjectileEventsQueue struct {
-	mu    sync.Mutex
-	Queue []model.ProjectileEvent
-}
-
-func (q *ProjectileEventsQueue) Lock() bool {
-	q.mu.Lock()
-	return true
-}
-
-func (q *ProjectileEventsQueue) Unlock() {
-	q.mu.Unlock()
-}
-
-func (q *ProjectileEventsQueue) Empty() bool {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue) == 0
-}
-
-func (q *ProjectileEventsQueue) Push(n []model.ProjectileEvent) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = append(q.Queue, n...)
-}
-
-func (q *ProjectileEventsQueue) Pop() model.ProjectileEvent {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	if len(q.Queue) == 0 {
-		return model.ProjectileEvent{}
-	}
-	n := q.Queue[0]
-	q.Queue = q.Queue[1:]
-	return n
-}
-
-func (q *ProjectileEventsQueue) Len() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue)
-}
-
-func (q *ProjectileEventsQueue) Clear() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = []model.ProjectileEvent{}
-	return len(q.Queue)
-}
-
-func (q *ProjectileEventsQueue) GetAndEmpty() []model.ProjectileEvent {
-	q.mu.Lock()
-	defer q.Clear()
-	defer q.mu.Unlock()
-	return q.Queue
-}
-
-type GeneralEventsQueue struct {
-	mu    sync.Mutex
-	Queue []model.GeneralEvent
-}
-
-func (q *GeneralEventsQueue) Lock() bool {
-	q.mu.Lock()
-	return true
-}
-
-func (q *GeneralEventsQueue) Unlock() {
-	q.mu.Unlock()
-}
-
-func (q *GeneralEventsQueue) Empty() bool {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue) == 0
-}
-
-func (q *GeneralEventsQueue) Push(n []model.GeneralEvent) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = append(q.Queue, n...)
-}
-
-func (q *GeneralEventsQueue) Pop() model.GeneralEvent {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	if len(q.Queue) == 0 {
-		return model.GeneralEvent{}
-	}
-	n := q.Queue[0]
-	q.Queue = q.Queue[1:]
-	return n
-}
-
-func (q *GeneralEventsQueue) Len() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue)
-}
-
-func (q *GeneralEventsQueue) Clear() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = []model.GeneralEvent{}
-	return len(q.Queue)
-}
-
-func (q *GeneralEventsQueue) GetAndEmpty() []model.GeneralEvent {
-	q.mu.Lock()
-	defer q.Clear()
-	defer q.mu.Unlock()
-	return q.Queue
-}
-
-type HitEventsQueue struct {
-	mu    sync.Mutex
-	Queue []model.HitEvent
-}
-
-func (q *HitEventsQueue) Lock() bool {
-	q.mu.Lock()
-	return true
-}
-
-func (q *HitEventsQueue) Unlock() {
-	q.mu.Unlock()
-}
-
-func (q *HitEventsQueue) Empty() bool {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue) == 0
-}
-
-func (q *HitEventsQueue) Push(n []model.HitEvent) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = append(q.Queue, n...)
-}
-
-func (q *HitEventsQueue) Pop() model.HitEvent {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	if len(q.Queue) == 0 {
-		return model.HitEvent{}
-	}
-	n := q.Queue[0]
-	q.Queue = q.Queue[1:]
-	return n
-}
-
-func (q *HitEventsQueue) Len() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue)
-}
-
-func (q *HitEventsQueue) Clear() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = []model.HitEvent{}
-	return len(q.Queue)
-}
-
-func (q *HitEventsQueue) GetAndEmpty() []model.HitEvent {
-	q.mu.Lock()
-	defer q.Clear()
-	defer q.mu.Unlock()
-	return q.Queue
-}
-
-type KillEventsQueue struct {
-	mu    sync.Mutex
-	Queue []model.KillEvent
-}
-
-func (q *KillEventsQueue) Lock() bool {
-	q.mu.Lock()
-	return true
-}
-
-func (q *KillEventsQueue) Unlock() {
-	q.mu.Unlock()
-}
-
-func (q *KillEventsQueue) Empty() bool {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue) == 0
-}
-
-func (q *KillEventsQueue) Push(n []model.KillEvent) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = append(q.Queue, n...)
-}
-
-func (q *KillEventsQueue) Pop() model.KillEvent {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	if len(q.Queue) == 0 {
-		return model.KillEvent{}
-	}
-	n := q.Queue[0]
-	q.Queue = q.Queue[1:]
-	return n
-}
-
-func (q *KillEventsQueue) Len() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue)
-}
-
-func (q *KillEventsQueue) Clear() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = []model.KillEvent{}
-	return len(q.Queue)
-}
-
-func (q *KillEventsQueue) GetAndEmpty() []model.KillEvent {
-	q.mu.Lock()
-	defer q.Clear()
-	defer q.mu.Unlock()
-	return q.Queue
-}
-
-type ChatEventsQueue struct {
-	mu    sync.Mutex
-	Queue []model.ChatEvent
-}
-
-func (q *ChatEventsQueue) Lock() bool {
-	q.mu.Lock()
-	return true
-}
-
-func (q *ChatEventsQueue) Unlock() {
-	q.mu.Unlock()
-}
-
-func (q *ChatEventsQueue) Empty() bool {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue) == 0
-}
-
-func (q *ChatEventsQueue) Push(n []model.ChatEvent) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = append(q.Queue, n...)
-}
-
-func (q *ChatEventsQueue) Pop() model.ChatEvent {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	if len(q.Queue) == 0 {
-		return model.ChatEvent{}
-	}
-	n := q.Queue[0]
-	q.Queue = q.Queue[1:]
-	return n
-}
-
-func (q *ChatEventsQueue) Len() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue)
-}
-
-func (q *ChatEventsQueue) Clear() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = []model.ChatEvent{}
-	return len(q.Queue)
-}
-
-func (q *ChatEventsQueue) GetAndEmpty() []model.ChatEvent {
-	q.mu.Lock()
-	defer q.Clear()
-	defer q.mu.Unlock()
-	return q.Queue
-}
-
-type RadioEventsQueue struct {
-	mu    sync.Mutex
-	Queue []model.RadioEvent
-}
-
-func (q *RadioEventsQueue) Lock() bool {
-	q.mu.Lock()
-	return true
-}
-
-func (q *RadioEventsQueue) Unlock() {
-	q.mu.Unlock()
-}
-
-func (q *RadioEventsQueue) Empty() bool {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue) == 0
-}
-
-func (q *RadioEventsQueue) Push(n []model.RadioEvent) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = append(q.Queue, n...)
-}
-
-func (q *RadioEventsQueue) Pop() model.RadioEvent {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	if len(q.Queue) == 0 {
-		return model.RadioEvent{}
-	}
-	n := q.Queue[0]
-	q.Queue = q.Queue[1:]
-	return n
-}
-
-func (q *RadioEventsQueue) Len() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue)
-}
-
-func (q *RadioEventsQueue) Clear() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = []model.RadioEvent{}
-	return len(q.Queue)
-}
-
-func (q *RadioEventsQueue) GetAndEmpty() []model.RadioEvent {
-	q.mu.Lock()
-	defer q.Clear()
-	defer q.mu.Unlock()
-	return q.Queue
-}
-
-type FpsEventsQueue struct {
-	mu    sync.Mutex
-	Queue []model.ServerFpsEvent
-}
-
-func (q *FpsEventsQueue) Lock() bool {
-	q.mu.Lock()
-	return true
-}
-
-func (q *FpsEventsQueue) Unlock() {
-	q.mu.Unlock()
-}
-
-func (q *FpsEventsQueue) Empty() bool {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue) == 0
-}
-
-func (q *FpsEventsQueue) Push(n []model.ServerFpsEvent) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = append(q.Queue, n...)
-}
-
-func (q *FpsEventsQueue) Pop() model.ServerFpsEvent {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	if len(q.Queue) == 0 {
-		return model.ServerFpsEvent{}
-	}
-	n := q.Queue[0]
-	q.Queue = q.Queue[1:]
-	return n
-}
-
-func (q *FpsEventsQueue) Len() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue)
-}
-
-func (q *FpsEventsQueue) Clear() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = []model.ServerFpsEvent{}
-	return len(q.Queue)
-}
-
-func (q *FpsEventsQueue) GetAndEmpty() []model.ServerFpsEvent {
-	q.mu.Lock()
-	defer q.Clear()
-	defer q.mu.Unlock()
-	return q.Queue
-}
-
-type Ace3DeathEventsQueue struct {
-	mu    sync.Mutex
-	Queue []model.Ace3DeathEvent
-}
-
-func (q *Ace3DeathEventsQueue) Lock() bool {
-	q.mu.Lock()
-	return true
-}
-
-func (q *Ace3DeathEventsQueue) Unlock() {
-	q.mu.Unlock()
-}
-
-func (q *Ace3DeathEventsQueue) Empty() bool {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue) == 0
-}
-
-func (q *Ace3DeathEventsQueue) Push(n []model.Ace3DeathEvent) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = append(q.Queue, n...)
-}
-
-func (q *Ace3DeathEventsQueue) Pop() model.Ace3DeathEvent {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	if len(q.Queue) == 0 {
-		return model.Ace3DeathEvent{}
-	}
-	n := q.Queue[0]
-	q.Queue = q.Queue[1:]
-	return n
-}
-
-func (q *Ace3DeathEventsQueue) Len() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue)
-}
-
-func (q *Ace3DeathEventsQueue) Clear() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = []model.Ace3DeathEvent{}
-	return len(q.Queue)
-}
-
-func (q *Ace3DeathEventsQueue) GetAndEmpty() []model.Ace3DeathEvent {
-	q.mu.Lock()
-	defer q.Clear()
-	defer q.mu.Unlock()
-	return q.Queue
-}
-
-type Ace3UnconsciousEventsQueue struct {
-	mu    sync.Mutex
-	Queue []model.Ace3UnconsciousEvent
-}
-
-func (q *Ace3UnconsciousEventsQueue) Lock() bool {
-	q.mu.Lock()
-	return true
-}
-
-func (q *Ace3UnconsciousEventsQueue) Unlock() {
-	q.mu.Unlock()
-}
-
-func (q *Ace3UnconsciousEventsQueue) Empty() bool {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue) == 0
-}
-
-func (q *Ace3UnconsciousEventsQueue) Push(n []model.Ace3UnconsciousEvent) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = append(q.Queue, n...)
-}
-
-func (q *Ace3UnconsciousEventsQueue) Pop() model.Ace3UnconsciousEvent {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	if len(q.Queue) == 0 {
-		return model.Ace3UnconsciousEvent{}
-	}
-	n := q.Queue[0]
-	q.Queue = q.Queue[1:]
-	return n
-}
-
-func (q *Ace3UnconsciousEventsQueue) Len() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue)
-}
-
-func (q *Ace3UnconsciousEventsQueue) Clear() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = []model.Ace3UnconsciousEvent{}
-	return len(q.Queue)
-}
-
-func (q *Ace3UnconsciousEventsQueue) GetAndEmpty() []model.Ace3UnconsciousEvent {
+// GetAndEmpty returns all items and clears the queue.
+func (q *Queue[T]) GetAndEmpty() []T {
 	q.mu.Lock()
-	defer q.Clear()
 	defer q.mu.Unlock()
-	return q.Queue
+	result := q.items
+	q.items = make([]T, 0, cap(q.items))
+	return result
 }
 
-// SoldierStatesMap processes soldier states for write out to JSON
+// SoldierStatesMap processes soldier states for write out to JSON.
+// This is a separate data structure, not a queue.
 type SoldierStatesMap struct {
 	frameData map[uint][]any
 	lastState []any
 }
 
+// NewSoldierStatesMap creates a new SoldierStatesMap.
 func NewSoldierStatesMap() *SoldierStatesMap {
 	return &SoldierStatesMap{
 		frameData: make(map[uint][]any),
 	}
 }
 
-func (q *SoldierStatesMap) Set(frame uint, state []any) {
-	q.frameData[frame] = state
+// Set stores state data for a frame.
+func (m *SoldierStatesMap) Set(frame uint, state []any) {
+	m.frameData[frame] = state
 }
 
-func (q *SoldierStatesMap) Len() int {
-	return len(q.frameData)
+// Len returns the number of frames stored.
+func (m *SoldierStatesMap) Len() int {
+	return len(m.frameData)
 }
 
-func (q *SoldierStatesMap) GetStateAtFrame(frame uint, endFrame uint) ([]any, error) {
-	state, ok := q.frameData[frame]
+// GetStateAtFrame returns the state at a given frame, searching forward if not found.
+func (m *SoldierStatesMap) GetStateAtFrame(frame uint, endFrame uint) ([]any, error) {
+	state, ok := m.frameData[frame]
 	if !ok {
 		for i := frame; i <= endFrame; i++ {
-			state, ok := q.frameData[i]
+			state, ok := m.frameData[i]
 			if ok {
-				q.lastState = state
+				m.lastState = state
 				return state, nil
 			}
 		}
@@ -887,120 +108,7 @@ func (q *SoldierStatesMap) GetStateAtFrame(frame uint, endFrame uint) ([]any, er
 	return state, nil
 }
 
-func (q *SoldierStatesMap) GetLastState() []any {
-	return q.lastState
-}
-
-type MarkersQueue struct {
-	mu    sync.Mutex
-	Queue []model.Marker
-}
-
-func (q *MarkersQueue) Lock() bool {
-	q.mu.Lock()
-	return true
-}
-
-func (q *MarkersQueue) Unlock() {
-	q.mu.Unlock()
-}
-
-func (q *MarkersQueue) Empty() bool {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue) == 0
-}
-
-func (q *MarkersQueue) Push(n []model.Marker) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = append(q.Queue, n...)
-}
-
-func (q *MarkersQueue) Pop() model.Marker {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	if len(q.Queue) == 0 {
-		return model.Marker{}
-	}
-	n := q.Queue[0]
-	q.Queue = q.Queue[1:]
-	return n
-}
-
-func (q *MarkersQueue) Len() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue)
-}
-
-func (q *MarkersQueue) Clear() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = []model.Marker{}
-	return len(q.Queue)
-}
-
-func (q *MarkersQueue) GetAndEmpty() []model.Marker {
-	q.mu.Lock()
-	defer q.Clear()
-	defer q.mu.Unlock()
-	return q.Queue
-}
-
-type MarkerStatesQueue struct {
-	mu    sync.Mutex
-	Queue []model.MarkerState
-}
-
-func (q *MarkerStatesQueue) Lock() bool {
-	q.mu.Lock()
-	return true
-}
-
-func (q *MarkerStatesQueue) Unlock() {
-	q.mu.Unlock()
-}
-
-func (q *MarkerStatesQueue) Empty() bool {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue) == 0
-}
-
-func (q *MarkerStatesQueue) Push(n []model.MarkerState) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = append(q.Queue, n...)
-}
-
-func (q *MarkerStatesQueue) Pop() model.MarkerState {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	if len(q.Queue) == 0 {
-		return model.MarkerState{}
-	}
-	n := q.Queue[0]
-	q.Queue = q.Queue[1:]
-	return n
-}
-
-func (q *MarkerStatesQueue) Len() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return len(q.Queue)
-}
-
-func (q *MarkerStatesQueue) Clear() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.Queue = []model.MarkerState{}
-	return len(q.Queue)
-}
-
-func (q *MarkerStatesQueue) GetAndEmpty() []model.MarkerState {
-	q.mu.Lock()
-	defer q.Clear()
-	defer q.mu.Unlock()
-	return q.Queue
+// GetLastState returns the last state that was retrieved.
+func (m *SoldierStatesMap) GetLastState() []any {
+	return m.lastState
 }

--- a/internal/worker/dispatch.go
+++ b/internal/worker/dispatch.go
@@ -56,7 +56,7 @@ func (m *Manager) handleNewSoldier(e dispatcher.Event) (any, error) {
 		coreObj := convert.SoldierToCore(obj)
 		m.backend.AddSoldier(&coreObj)
 	} else {
-		m.queues.Soldiers.Push([]model.Soldier{obj})
+		m.queues.Soldiers.Push(obj)
 	}
 
 	return "ok", nil
@@ -76,7 +76,7 @@ func (m *Manager) handleNewVehicle(e dispatcher.Event) (any, error) {
 		coreObj := convert.VehicleToCore(obj)
 		m.backend.AddVehicle(&coreObj)
 	} else {
-		m.queues.Vehicles.Push([]model.Vehicle{obj})
+		m.queues.Vehicles.Push(obj)
 	}
 
 	return "ok", nil
@@ -97,7 +97,7 @@ func (m *Manager) handleSoldierState(e dispatcher.Event) (any, error) {
 		coreObj := convert.SoldierStateToCore(obj)
 		m.backend.RecordSoldierState(&coreObj)
 	} else {
-		m.queues.SoldierStates.Push([]model.SoldierState{obj})
+		m.queues.SoldierStates.Push(obj)
 	}
 
 	return nil, nil
@@ -117,7 +117,7 @@ func (m *Manager) handleVehicleState(e dispatcher.Event) (any, error) {
 		coreObj := convert.VehicleStateToCore(obj)
 		m.backend.RecordVehicleState(&coreObj)
 	} else {
-		m.queues.VehicleStates.Push([]model.VehicleState{obj})
+		m.queues.VehicleStates.Push(obj)
 	}
 
 	return nil, nil
@@ -137,7 +137,7 @@ func (m *Manager) handleFiredEvent(e dispatcher.Event) (any, error) {
 		coreObj := convert.FiredEventToCore(obj)
 		m.backend.RecordFiredEvent(&coreObj)
 	} else {
-		m.queues.FiredEvents.Push([]model.FiredEvent{obj})
+		m.queues.FiredEvents.Push(obj)
 	}
 
 	return nil, nil
@@ -154,7 +154,7 @@ func (m *Manager) handleProjectileEvent(e dispatcher.Event) (any, error) {
 		return nil, nil
 	}
 
-	m.queues.ProjectileEvents.Push([]model.ProjectileEvent{obj})
+	m.queues.ProjectileEvents.Push(obj)
 	return nil, nil
 }
 
@@ -172,7 +172,7 @@ func (m *Manager) handleGeneralEvent(e dispatcher.Event) (any, error) {
 		coreObj := convert.GeneralEventToCore(obj)
 		m.backend.RecordGeneralEvent(&coreObj)
 	} else {
-		m.queues.GeneralEvents.Push([]model.GeneralEvent{obj})
+		m.queues.GeneralEvents.Push(obj)
 	}
 
 	return nil, nil
@@ -192,7 +192,7 @@ func (m *Manager) handleHitEvent(e dispatcher.Event) (any, error) {
 		coreObj := convert.HitEventToCore(obj)
 		m.backend.RecordHitEvent(&coreObj)
 	} else {
-		m.queues.HitEvents.Push([]model.HitEvent{obj})
+		m.queues.HitEvents.Push(obj)
 	}
 
 	return nil, nil
@@ -212,7 +212,7 @@ func (m *Manager) handleKillEvent(e dispatcher.Event) (any, error) {
 		coreObj := convert.KillEventToCore(obj)
 		m.backend.RecordKillEvent(&coreObj)
 	} else {
-		m.queues.KillEvents.Push([]model.KillEvent{obj})
+		m.queues.KillEvents.Push(obj)
 	}
 
 	return nil, nil
@@ -232,7 +232,7 @@ func (m *Manager) handleChatEvent(e dispatcher.Event) (any, error) {
 		coreObj := convert.ChatEventToCore(obj)
 		m.backend.RecordChatEvent(&coreObj)
 	} else {
-		m.queues.ChatEvents.Push([]model.ChatEvent{obj})
+		m.queues.ChatEvents.Push(obj)
 	}
 
 	return nil, nil
@@ -252,7 +252,7 @@ func (m *Manager) handleRadioEvent(e dispatcher.Event) (any, error) {
 		coreObj := convert.RadioEventToCore(obj)
 		m.backend.RecordRadioEvent(&coreObj)
 	} else {
-		m.queues.RadioEvents.Push([]model.RadioEvent{obj})
+		m.queues.RadioEvents.Push(obj)
 	}
 
 	return nil, nil
@@ -272,7 +272,7 @@ func (m *Manager) handleFpsEvent(e dispatcher.Event) (any, error) {
 		coreObj := convert.ServerFpsEventToCore(obj)
 		m.backend.RecordServerFpsEvent(&coreObj)
 	} else {
-		m.queues.FpsEvents.Push([]model.ServerFpsEvent{obj})
+		m.queues.FpsEvents.Push(obj)
 	}
 
 	return nil, nil
@@ -292,7 +292,7 @@ func (m *Manager) handleAce3DeathEvent(e dispatcher.Event) (any, error) {
 		coreObj := convert.Ace3DeathEventToCore(obj)
 		m.backend.RecordAce3DeathEvent(&coreObj)
 	} else {
-		m.queues.Ace3DeathEvents.Push([]model.Ace3DeathEvent{obj})
+		m.queues.Ace3DeathEvents.Push(obj)
 	}
 
 	return nil, nil
@@ -312,7 +312,7 @@ func (m *Manager) handleAce3UnconsciousEvent(e dispatcher.Event) (any, error) {
 		coreObj := convert.Ace3UnconsciousEventToCore(obj)
 		m.backend.RecordAce3UnconsciousEvent(&coreObj)
 	} else {
-		m.queues.Ace3UnconsciousEvents.Push([]model.Ace3UnconsciousEvent{obj})
+		m.queues.Ace3UnconsciousEvents.Push(obj)
 	}
 
 	return nil, nil
@@ -332,7 +332,7 @@ func (m *Manager) handleMarkerCreate(e dispatcher.Event) (any, error) {
 		coreObj := convert.MarkerToCore(marker)
 		m.backend.AddMarker(&coreObj)
 	} else {
-		m.queues.Markers.Push([]model.Marker{marker})
+		m.queues.Markers.Push(marker)
 	}
 
 	return nil, nil
@@ -352,7 +352,7 @@ func (m *Manager) handleMarkerMove(e dispatcher.Event) (any, error) {
 		coreObj := convert.MarkerStateToCore(markerState)
 		m.backend.RecordMarkerState(&coreObj)
 	} else {
-		m.queues.MarkerStates.Push([]model.MarkerState{markerState})
+		m.queues.MarkerStates.Push(markerState)
 	}
 
 	return nil, nil
@@ -377,7 +377,7 @@ func (m *Manager) handleMarkerDelete(e dispatcher.Event) (any, error) {
 			Time:         time.Now(),
 			Alpha:        0,
 		}
-		m.queues.MarkerStates.Push([]model.MarkerState{deleteState})
+		m.queues.MarkerStates.Push(deleteState)
 		if m.deps.DB != nil {
 			m.deps.DB.Model(&model.Marker{}).Where("id = ?", markerID).Update("is_deleted", true)
 		}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -7,6 +7,7 @@ import (
 	"github.com/OCAP2/extension/v5/internal/cache"
 	"github.com/OCAP2/extension/v5/internal/handlers"
 	"github.com/OCAP2/extension/v5/internal/logging"
+	"github.com/OCAP2/extension/v5/internal/model"
 	"github.com/OCAP2/extension/v5/internal/queue"
 	"github.com/OCAP2/extension/v5/internal/storage"
 
@@ -18,43 +19,43 @@ var ErrTooEarlyForStateAssociation = fmt.Errorf("too early for state association
 
 // Queues holds all the write queues
 type Queues struct {
-	Soldiers              *queue.SoldiersQueue
-	SoldierStates         *queue.SoldierStatesQueue
-	Vehicles              *queue.VehiclesQueue
-	VehicleStates         *queue.VehicleStatesQueue
-	FiredEvents           *queue.FiredEventsQueue
-	ProjectileEvents      *queue.ProjectileEventsQueue
-	GeneralEvents         *queue.GeneralEventsQueue
-	HitEvents             *queue.HitEventsQueue
-	KillEvents            *queue.KillEventsQueue
-	ChatEvents            *queue.ChatEventsQueue
-	RadioEvents           *queue.RadioEventsQueue
-	FpsEvents             *queue.FpsEventsQueue
-	Ace3DeathEvents       *queue.Ace3DeathEventsQueue
-	Ace3UnconsciousEvents *queue.Ace3UnconsciousEventsQueue
-	Markers               *queue.MarkersQueue
-	MarkerStates          *queue.MarkerStatesQueue
+	Soldiers              *queue.Queue[model.Soldier]
+	SoldierStates         *queue.Queue[model.SoldierState]
+	Vehicles              *queue.Queue[model.Vehicle]
+	VehicleStates         *queue.Queue[model.VehicleState]
+	FiredEvents           *queue.Queue[model.FiredEvent]
+	ProjectileEvents      *queue.Queue[model.ProjectileEvent]
+	GeneralEvents         *queue.Queue[model.GeneralEvent]
+	HitEvents             *queue.Queue[model.HitEvent]
+	KillEvents            *queue.Queue[model.KillEvent]
+	ChatEvents            *queue.Queue[model.ChatEvent]
+	RadioEvents           *queue.Queue[model.RadioEvent]
+	FpsEvents             *queue.Queue[model.ServerFpsEvent]
+	Ace3DeathEvents       *queue.Queue[model.Ace3DeathEvent]
+	Ace3UnconsciousEvents *queue.Queue[model.Ace3UnconsciousEvent]
+	Markers               *queue.Queue[model.Marker]
+	MarkerStates          *queue.Queue[model.MarkerState]
 }
 
 // NewQueues creates all write queues
 func NewQueues() *Queues {
 	return &Queues{
-		Soldiers:              &queue.SoldiersQueue{},
-		SoldierStates:         &queue.SoldierStatesQueue{},
-		Vehicles:              &queue.VehiclesQueue{},
-		VehicleStates:         &queue.VehicleStatesQueue{},
-		FiredEvents:           &queue.FiredEventsQueue{},
-		ProjectileEvents:      &queue.ProjectileEventsQueue{},
-		GeneralEvents:         &queue.GeneralEventsQueue{},
-		HitEvents:             &queue.HitEventsQueue{},
-		KillEvents:            &queue.KillEventsQueue{},
-		ChatEvents:            &queue.ChatEventsQueue{},
-		RadioEvents:           &queue.RadioEventsQueue{},
-		FpsEvents:             &queue.FpsEventsQueue{},
-		Ace3DeathEvents:       &queue.Ace3DeathEventsQueue{},
-		Ace3UnconsciousEvents: &queue.Ace3UnconsciousEventsQueue{},
-		Markers:               &queue.MarkersQueue{},
-		MarkerStates:          &queue.MarkerStatesQueue{},
+		Soldiers:              queue.New[model.Soldier](),
+		SoldierStates:         queue.New[model.SoldierState](),
+		Vehicles:              queue.New[model.Vehicle](),
+		VehicleStates:         queue.New[model.VehicleState](),
+		FiredEvents:           queue.New[model.FiredEvent](),
+		ProjectileEvents:      queue.New[model.ProjectileEvent](),
+		GeneralEvents:         queue.New[model.GeneralEvent](),
+		HitEvents:             queue.New[model.HitEvent](),
+		KillEvents:            queue.New[model.KillEvent](),
+		ChatEvents:            queue.New[model.ChatEvent](),
+		RadioEvents:           queue.New[model.RadioEvent](),
+		FpsEvents:             queue.New[model.ServerFpsEvent](),
+		Ace3DeathEvents:       queue.New[model.Ace3DeathEvent](),
+		Ace3UnconsciousEvents: queue.New[model.Ace3UnconsciousEvent](),
+		Markers:               queue.New[model.Marker](),
+		MarkerStates:          queue.New[model.MarkerState](),
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace 16+ identical queue implementations with a single generic `Queue[T]` type
- Uses Go 1.18+ generics for type safety
- **892 lines removed** (1006 → 114 lines, 89% reduction)

## Changes

| File | Description |
|------|-------------|
| `internal/queue/queue.go` | New generic `Queue[T]` implementation |
| `internal/queue/queue_test.go` | Updated tests for generic queue |
| `internal/worker/worker.go` | Updated `Queues` struct to use `queue.Queue[model.X]` |
| `internal/worker/dispatch.go` | Updated Push calls to use variadic syntax |

## API Changes

```go
// Before: 16+ separate types
type SoldiersQueue struct { ... }
type VehiclesQueue struct { ... }
// etc.

// After: single generic type
type Queue[T any] struct {
    mu    sync.Mutex
    items []T
}
```

Push signature changed from slice to variadic:
```go
// Before
q.Push([]model.Soldier{obj})

// After
q.Push(obj)
```

## Test plan

- [x] All queue tests pass
- [x] All worker tests pass
- [x] Full test suite passes
- [x] DLL builds successfully