### PR TITLE
fix: standardize config filename to use underscores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .vscode/
 ocaplog/
 @ocap/
-ocap-recorder.cfg.json
+ocap_recorder.cfg.json
 vendor/
 dist/
 docs/plans/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ docker run --rm -v ${PWD}:/go/work -w /go/work x1unix/go-mingw:1.24 go build -bu
 Dockerfile                   - Docker build for Linux
 go.mod, go.sum               - Go module dependencies
 createViews.sql              - PostgreSQL materialized views
-ocap-recorder.cfg.json.example - Configuration template
+ocap_recorder.cfg.json.example - Configuration template
 ```
 
 ## Architecture
@@ -79,7 +79,7 @@ GORM models for PostgreSQL/SQLite:
 
 ## Configuration
 
-File: `ocap-recorder.cfg.json` (placed alongside DLL)
+File: `ocap_recorder.cfg.json` (placed alongside DLL)
 
 ```json
 {
@@ -87,7 +87,7 @@ File: `ocap-recorder.cfg.json` (placed alongside DLL)
   "logsDir": "./OCAPLOG",
   "defaultTag": "TvT",
   "api": {
-    "serverUrl": "127.0.0.1:5000",
+    "serverUrl": "http://127.0.0.1:5000",
     "apiKey": "secret"
   },
   "db": {

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ docker run --rm -v ${PWD}:/app -e GOOS=linux -e GOARCH=amd64 -e CGO_ENABLED=1 -e
 
 ## Configuration
 
-Copy `ocap-recorder.cfg.json.example` to `ocap-recorder.cfg.json` alongside the DLL and edit as needed.
+Copy `ocap_recorder.cfg.json.example` to `ocap_recorder.cfg.json` alongside the DLL and edit as needed.
 
 ## Supported Commands
 

--- a/ocap_recorder.cfg.json.example
+++ b/ocap_recorder.cfg.json.example
@@ -3,7 +3,7 @@
   "logsDir": "./OCAPLOG",
   "defaultTag": "TvT",
   "api": {
-    "serverUrl": "127.0.0.1:5000",
+    "serverUrl": "http://127.0.0.1:5000",
     "apiKey": "same-secret"
   },
   "db": {


### PR DESCRIPTION
## Summary
- Rename config file from `ocap-recorder.cfg.json` to `ocap_recorder.cfg.json` to match DLL naming convention
- The code already expects underscores but docs/example used dashes, causing config not to load
- Add `http://` scheme to serverUrl examples (required by Go http client)

## Root Cause
The 403 error on mission upload was caused by the config file not being found:
- Code looks for: `ocap_recorder.cfg.json` (underscores)
- User had: `ocap-recorder.cfg.json` (dashes)
- Result: defaults used, including empty `apiKey` → 403 Forbidden

## Action Required
Users need to rename their config file:
```bash
mv ocap-recorder.cfg.json ocap_recorder.cfg.json
```

## Test plan
- [x] Verify config loading with correct filename
- [ ] Test mission upload with matching secrets