### PR TITLE
fix(config): unify logsDir default to ocaplogs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ File: `ocap_recorder.cfg.json` (placed alongside DLL)
 ```json
 {
   "logLevel": "info",
-  "logsDir": "./OCAPLOG",
+  "logsDir": "./ocaplogs",
   "defaultTag": "TvT",
   "api": {
     "serverUrl": "http://127.0.0.1:5000",

--- a/ocap_recorder.cfg.json.example
+++ b/ocap_recorder.cfg.json.example
@@ -1,6 +1,6 @@
 {
   "logLevel": "info",
-  "logsDir": "./OCAPLOG",
+  "logsDir": "./ocaplogs",
   "defaultTag": "TvT",
   "api": {
     "serverUrl": "http://127.0.0.1:5000",


### PR DESCRIPTION
## Summary
Unified the logsDir setting to `./ocaplogs` across all files.

## Changes
- `ocap_recorder.cfg.json.example`: `./OCAPLOG` → `./ocaplogs`
- `CLAUDE.md`: `./OCAPLOG` → `./ocaplogs`

The code default in `internal/config/config.go` was already `./ocaplogs`.