### PR TITLE
fix(dispatcher): log errors from buffered handlers

### DIFF
--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -191,7 +191,10 @@ func (d *Dispatcher) withBuffer(command string, cfg *config, h HandlerFunc) Hand
 		}
 
 		for e := range buffer {
-			h(e)
+			_, err := h(e)
+			if err != nil {
+				d.logger.Error("buffered handler failed", "command", command, "error", err)
+			}
 			d.processed.Add(context.Background(), 1, metric.WithAttributes(cmdAttr))
 		}
 	}()


### PR DESCRIPTION
## Summary
Errors from buffered handlers were silently discarded in the goroutine processing loop.

## Problem
In `withBuffer`, the handler was called but its error was ignored:
```go
for e := range buffer {
    h(e)  // Error discarded!
    d.processed.Add(...)
}
```

This made debugging impossible - even with PR #53 (propagate errors), the errors were never logged.

## Fix
Now errors are logged:
```go
_, err := h(e)
if err != nil {
    d.logger.Error("buffered handler failed", "command", command, "error", err)
}
```

## Test plan
- [x] All dispatcher tests pass