### PR TITLE
fix(worker): cache entities when using memory backend

### DIFF
--- a/internal/worker/dispatch.go
+++ b/internal/worker/dispatch.go
@@ -52,6 +52,9 @@ func (m *Manager) handleNewSoldier(e dispatcher.Event) (any, error) {
 		return nil, fmt.Errorf("failed to log new soldier: %w", err)
 	}
 
+	// Always cache for state handler lookups
+	m.deps.EntityCache.AddSoldier(obj)
+
 	if m.hasBackend() {
 		coreObj := convert.SoldierToCore(obj)
 		m.backend.AddSoldier(&coreObj)
@@ -71,6 +74,9 @@ func (m *Manager) handleNewVehicle(e dispatcher.Event) (any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to log new vehicle: %w", err)
 	}
+
+	// Always cache for state handler lookups
+	m.deps.EntityCache.AddVehicle(obj)
 
 	if m.hasBackend() {
 		coreObj := convert.VehicleToCore(obj)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -17,6 +17,28 @@ import (
 // ErrTooEarlyForStateAssociation is returned when state data arrives before entity is registered
 var ErrTooEarlyForStateAssociation = fmt.Errorf("too early for state association")
 
+// HandlerService defines the interface for event handlers
+type HandlerService interface {
+	LogNewSoldier(args []string) (model.Soldier, error)
+	LogNewVehicle(args []string) (model.Vehicle, error)
+	LogSoldierState(args []string) (model.SoldierState, error)
+	LogVehicleState(args []string) (model.VehicleState, error)
+	LogFiredEvent(args []string) (model.FiredEvent, error)
+	LogProjectileEvent(args []string) (model.ProjectileEvent, error)
+	LogGeneralEvent(args []string) (model.GeneralEvent, error)
+	LogHitEvent(args []string) (model.HitEvent, error)
+	LogKillEvent(args []string) (model.KillEvent, error)
+	LogChatEvent(args []string) (model.ChatEvent, error)
+	LogRadioEvent(args []string) (model.RadioEvent, error)
+	LogFpsEvent(args []string) (model.ServerFpsEvent, error)
+	LogAce3DeathEvent(args []string) (model.Ace3DeathEvent, error)
+	LogAce3UnconsciousEvent(args []string) (model.Ace3UnconsciousEvent, error)
+	LogMarkerCreate(args []string) (model.Marker, error)
+	LogMarkerMove(args []string) (model.MarkerState, error)
+	LogMarkerDelete(args []string) (string, uint, error)
+	GetMissionContext() *handlers.MissionContext
+}
+
 // Queues holds all the write queues
 type Queues struct {
 	Soldiers              *queue.Queue[model.Soldier]
@@ -65,7 +87,7 @@ type Dependencies struct {
 	EntityCache     *cache.EntityCache
 	MarkerCache     *cache.MarkerCache
 	LogManager      *logging.SlogManager
-	HandlerService  *handlers.Service
+	HandlerService  HandlerService
 	IsDatabaseValid func() bool
 	ShouldSaveLocal func() bool
 	DBInsertsPaused func() bool


### PR DESCRIPTION
## Summary
**This is the root cause of empty positions in recordings.**

When using the memory storage backend, entities were only stored in the backend's internal map but NOT in `EntityCache`. State handlers use `EntityCache.GetSoldier()` to look up entities, causing all state updates to fail with "soldier X not found in cache".

## Root Cause Analysis
1. `handleNewSoldier` calls `m.backend.AddSoldier()` → stores in memory backend's map
2. `handleSoldierState` calls `s.deps.EntityCache.GetSoldier()` → EntityCache is empty!
3. Returns error "soldier not found in cache"
4. Error was silently discarded (fixed in PR #55)

## Fix
Now entities are always cached in EntityCache regardless of storage backend:
```go
// Always cache for state handler lookups
m.deps.EntityCache.AddSoldier(obj)
```

## Test plan
- [x] All tests pass
- [ ] Deploy and verify positions are now recorded