### PR TITLE
refactor(worker): rename marker commands for consistency

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -1312,7 +1312,7 @@ func (s *Service) LogAce3UnconsciousEvent(data []string) (model.Ace3UnconsciousE
 
 // LogMarkerCreate parses marker create data and returns a Marker model
 func (s *Service) LogMarkerCreate(data []string) (model.Marker, error) {
-	functionName := ":MARKER:CREATE:"
+	functionName := ":NEW:MARKER:"
 	var marker model.Marker
 
 	// fix received data
@@ -1401,7 +1401,7 @@ func (s *Service) LogMarkerCreate(data []string) (model.Marker, error) {
 
 // LogMarkerMove parses marker move data and returns a MarkerState model
 func (s *Service) LogMarkerMove(data []string) (model.MarkerState, error) {
-	functionName := ":MARKER:MOVE:"
+	functionName := ":NEW:MARKER:STATE:"
 	var markerState model.MarkerState
 
 	// fix received data
@@ -1462,7 +1462,7 @@ func (s *Service) LogMarkerMove(data []string) (model.MarkerState, error) {
 
 // LogMarkerDelete parses marker delete data and returns the marker name and frame number
 func (s *Service) LogMarkerDelete(data []string) (string, uint, error) {
-	functionName := ":MARKER:DELETE:"
+	functionName := ":DELETE:MARKER:"
 
 	// fix received data
 	for i, v := range data {

--- a/internal/worker/dispatch.go
+++ b/internal/worker/dispatch.go
@@ -37,9 +37,9 @@ func (m *Manager) RegisterHandlers(d *dispatcher.Dispatcher) {
 	d.Register(":ACE3:UNCONSCIOUS:", m.handleAce3UnconsciousEvent, dispatcher.Buffered(1000))
 
 	// Marker events - buffered
-	d.Register(":MARKER:CREATE:", m.handleMarkerCreate, dispatcher.Buffered(500))
-	d.Register(":MARKER:MOVE:", m.handleMarkerMove, dispatcher.Buffered(1000))
-	d.Register(":MARKER:DELETE:", m.handleMarkerDelete, dispatcher.Buffered(500))
+	d.Register(":NEW:MARKER:", m.handleMarkerCreate, dispatcher.Buffered(500))
+	d.Register(":NEW:MARKER:STATE:", m.handleMarkerMove, dispatcher.Buffered(1000))
+	d.Register(":DELETE:MARKER:", m.handleMarkerDelete, dispatcher.Buffered(500))
 }
 
 func (m *Manager) handleNewSoldier(e dispatcher.Event) (any, error) {
@@ -390,3 +390,4 @@ func (m *Manager) handleMarkerDelete(e dispatcher.Event) (any, error) {
 
 	return nil, nil
 }
+

--- a/internal/worker/dispatch_test.go
+++ b/internal/worker/dispatch_test.go
@@ -475,9 +475,9 @@ func TestRegisterHandlers_RegistersAllCommands(t *testing.T) {
 		":FPS:",
 		":ACE3:DEATH:",
 		":ACE3:UNCONSCIOUS:",
-		":MARKER:CREATE:",
-		":MARKER:MOVE:",
-		":MARKER:DELETE:",
+		":NEW:MARKER:",
+		":NEW:MARKER:STATE:",
+		":DELETE:MARKER:",
 	}
 
 	for _, cmd := range expectedCommands {


### PR DESCRIPTION
## Summary
- Rename marker commands to follow the same naming convention as other database commands
- `:MARKER:CREATE:` → `:NEW:MARKER:`
- `:MARKER:MOVE:` → `:NEW:MARKER:STATE:`
- `:MARKER:DELETE:` → `:DELETE:MARKER:`

## Test plan
- [x] All existing tests pass
- [ ] Verify addon sends updated command names