### PR TITLE
refactor: use composite primary keys for Soldier/Vehicle

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ internal/
 ├── worker/                  Handler registration and DB writer loop
 ├── handlers/                Business logic for parsing and validation
 ├── queue/                   Thread-safe queues for batch writes
-├── cache/                   Entity lookup caching (OcapID → model)
+├── cache/                   Entity lookup caching (ObjectID → model)
 ├── model/                   GORM database models
 ├── storage/                 Optional alternative storage backend
 └── geo/                     Coordinate/geometry utilities

--- a/cmd/ocap_recorder/main.go
+++ b/cmd/ocap_recorder/main.go
@@ -1376,7 +1376,7 @@ func getOcapRecording(missionIDs []string) (err error) {
 		entities := []map[string]any{}
 		for _, soldier := range soldiers {
 			entity := map[string]any{}
-			entity["id"] = soldier.OcapID
+			entity["id"] = soldier.ObjectID
 			entity["name"] = soldier.UnitName
 			entity["group"] = soldier.GroupID
 			entity["side"] = soldier.Side
@@ -1389,7 +1389,7 @@ func getOcapRecording(missionIDs []string) (err error) {
 
 			soldierStates := []model.SoldierState{}
 			err = DB.Model(&model.SoldierState{}).
-				Where("mission_id = ? AND soldier_ocap_id = ?", missionIDInt, soldier.OcapID).
+				Where("mission_id = ? AND soldier_ocap_id = ?", missionIDInt, soldier.ObjectID).
 				Order("capture_frame ASC").
 				Find(&soldierStates).Error
 			if err != nil {
@@ -1403,7 +1403,7 @@ func getOcapRecording(missionIDs []string) (err error) {
 					[]float64{coord.XY.X, coord.XY.Y},
 					state.Bearing,
 					state.Lifestate,
-					state.InVehicleOcapID,
+					state.InVehicleObjectID,
 					state.UnitName,
 					state.IsPlayer,
 					state.CurrentRole,
@@ -1414,7 +1414,7 @@ func getOcapRecording(missionIDs []string) (err error) {
 
 			firedEvents := []model.FiredEvent{}
 			err = DB.Model(&model.FiredEvent{}).
-				Where("mission_id = ? AND soldier_ocap_id = ?", missionIDInt, soldier.OcapID).
+				Where("mission_id = ? AND soldier_ocap_id = ?", missionIDInt, soldier.ObjectID).
 				Order("capture_frame ASC").
 				Find(&firedEvents).Error
 			if err != nil {
@@ -1447,7 +1447,7 @@ func getOcapRecording(missionIDs []string) (err error) {
 		}
 		for _, vehicle := range vehicles {
 			entity := map[string]any{}
-			entity["id"] = vehicle.OcapID
+			entity["id"] = vehicle.ObjectID
 			entity["name"] = vehicle.DisplayName
 			entity["class"] = vehicle.ClassName
 			entity["side"] = "UNKNOWN"
@@ -1456,7 +1456,7 @@ func getOcapRecording(missionIDs []string) (err error) {
 
 			vehicleStates := []model.VehicleState{}
 			err = DB.Model(&model.VehicleState{}).
-				Where("mission_id = ? AND vehicle_ocap_id = ?", missionIDInt, vehicle.OcapID).
+				Where("mission_id = ? AND vehicle_ocap_id = ?", missionIDInt, vehicle.ObjectID).
 				Order("capture_frame ASC").
 				Find(&vehicleStates).Error
 			if err != nil {

--- a/cmd/ocap_recorder/main.go
+++ b/cmd/ocap_recorder/main.go
@@ -1389,7 +1389,7 @@ func getOcapRecording(missionIDs []string) (err error) {
 
 			soldierStates := []model.SoldierState{}
 			err = DB.Model(&model.SoldierState{}).
-				Where("mission_id = ? AND soldier_id = ?", missionIDInt, soldier.ID).
+				Where("mission_id = ? AND soldier_ocap_id = ?", missionIDInt, soldier.OcapID).
 				Order("capture_frame ASC").
 				Find(&soldierStates).Error
 			if err != nil {
@@ -1403,7 +1403,7 @@ func getOcapRecording(missionIDs []string) (err error) {
 					[]float64{coord.XY.X, coord.XY.Y},
 					state.Bearing,
 					state.Lifestate,
-					state.InVehicleObjectID,
+					state.InVehicleOcapID,
 					state.UnitName,
 					state.IsPlayer,
 					state.CurrentRole,
@@ -1414,7 +1414,7 @@ func getOcapRecording(missionIDs []string) (err error) {
 
 			firedEvents := []model.FiredEvent{}
 			err = DB.Model(&model.FiredEvent{}).
-				Where("mission_id = ? AND soldier_id = ?", missionIDInt, soldier.ID).
+				Where("mission_id = ? AND soldier_ocap_id = ?", missionIDInt, soldier.OcapID).
 				Order("capture_frame ASC").
 				Find(&firedEvents).Error
 			if err != nil {
@@ -1456,7 +1456,7 @@ func getOcapRecording(missionIDs []string) (err error) {
 
 			vehicleStates := []model.VehicleState{}
 			err = DB.Model(&model.VehicleState{}).
-				Where("mission_id = ? AND vehicle_id = ?", missionIDInt, vehicle.ID).
+				Where("mission_id = ? AND vehicle_ocap_id = ?", missionIDInt, vehicle.OcapID).
 				Order("capture_frame ASC").
 				Find(&vehicleStates).Error
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/glebarez/sqlite v1.11.0
 	github.com/peterstace/simplefeatures v0.44.0
 	github.com/spf13/viper v1.21.0
+	github.com/stretchr/testify v1.11.1
 	github.com/wroge/wgs84 v1.1.7
 	go.opentelemetry.io/contrib/bridges/otelslog v0.14.0
 	go.opentelemetry.io/otel v1.39.0
@@ -23,6 +24,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/glebarez/go-sqlite v1.21.2 // indirect
@@ -40,6 +42,7 @@ require (
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
@@ -61,6 +64,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/grpc v1.77.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/driver/mysql v1.5.6 // indirect
 	modernc.org/libc v1.24.1 // indirect
 	modernc.org/mathutil v1.6.0 // indirect

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -58,13 +58,13 @@ func (c *EntityCache) GetVehicle(id uint16) (model.Vehicle, bool) {
 func (c *EntityCache) AddSoldier(s model.Soldier) {
 	c.m.Lock()
 	defer c.m.Unlock()
-	c.Soldiers[s.OcapID] = s
+	c.Soldiers[s.ObjectID] = s
 }
 
 func (c *EntityCache) AddVehicle(v model.Vehicle) {
 	c.m.Lock()
 	defer c.m.Unlock()
-	c.Vehicles[v.OcapID] = v
+	c.Vehicles[v.ObjectID] = v
 }
 
 // SafeCounter is a thread-safe counter

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -31,7 +31,7 @@ func TestEntityCache_AddAndGetSoldier(t *testing.T) {
 	cache := NewEntityCache()
 
 	soldier := model.Soldier{
-		OcapID:   42,
+		ObjectID:   42,
 		UnitName: "Test Soldier",
 	}
 
@@ -39,10 +39,10 @@ func TestEntityCache_AddAndGetSoldier(t *testing.T) {
 
 	got, ok := cache.GetSoldier(42)
 	if !ok {
-		t.Fatal("expected to find soldier with OcapID 42")
+		t.Fatal("expected to find soldier with ObjectID 42")
 	}
-	if got.OcapID != 42 {
-		t.Errorf("expected OcapID 42, got %d", got.OcapID)
+	if got.ObjectID != 42 {
+		t.Errorf("expected ObjectID 42, got %d", got.ObjectID)
 	}
 	if got.UnitName != "Test Soldier" {
 		t.Errorf("expected UnitName 'Test Soldier', got %s", got.UnitName)
@@ -54,7 +54,7 @@ func TestEntityCache_GetSoldier_NotFound(t *testing.T) {
 
 	_, ok := cache.GetSoldier(999)
 	if ok {
-		t.Error("expected not to find soldier with OcapID 999")
+		t.Error("expected not to find soldier with ObjectID 999")
 	}
 }
 
@@ -62,7 +62,7 @@ func TestEntityCache_AddAndGetVehicle(t *testing.T) {
 	cache := NewEntityCache()
 
 	vehicle := model.Vehicle{
-		OcapID:    99,
+		ObjectID:    99,
 		ClassName: "Test_Vehicle",
 	}
 
@@ -70,10 +70,10 @@ func TestEntityCache_AddAndGetVehicle(t *testing.T) {
 
 	got, ok := cache.GetVehicle(99)
 	if !ok {
-		t.Fatal("expected to find vehicle with OcapID 99")
+		t.Fatal("expected to find vehicle with ObjectID 99")
 	}
-	if got.OcapID != 99 {
-		t.Errorf("expected OcapID 99, got %d", got.OcapID)
+	if got.ObjectID != 99 {
+		t.Errorf("expected ObjectID 99, got %d", got.ObjectID)
 	}
 	if got.ClassName != "Test_Vehicle" {
 		t.Errorf("expected className 'Test_Vehicle', got %s", got.ClassName)
@@ -85,7 +85,7 @@ func TestEntityCache_GetVehicle_NotFound(t *testing.T) {
 
 	_, ok := cache.GetVehicle(999)
 	if ok {
-		t.Error("expected not to find vehicle with OcapID 999")
+		t.Error("expected not to find vehicle with ObjectID 999")
 	}
 }
 
@@ -93,9 +93,9 @@ func TestEntityCache_Reset(t *testing.T) {
 	cache := NewEntityCache()
 
 	// Add some data
-	cache.AddSoldier(model.Soldier{OcapID: 1, UnitName: "Soldier 1"})
-	cache.AddSoldier(model.Soldier{OcapID: 2, UnitName: "Soldier 2"})
-	cache.AddVehicle(model.Vehicle{OcapID: 10, ClassName: "Vehicle 1"})
+	cache.AddSoldier(model.Soldier{ObjectID: 1, UnitName: "Soldier 1"})
+	cache.AddSoldier(model.Soldier{ObjectID: 2, UnitName: "Soldier 2"})
+	cache.AddVehicle(model.Vehicle{ObjectID: 10, ClassName: "Vehicle 1"})
 
 	// Verify data exists
 	if len(cache.Soldiers) != 2 {
@@ -117,7 +117,7 @@ func TestEntityCache_Reset(t *testing.T) {
 	}
 
 	// Verify we can still add data after reset
-	cache.AddSoldier(model.Soldier{OcapID: 3, UnitName: "Soldier 3"})
+	cache.AddSoldier(model.Soldier{ObjectID: 3, UnitName: "Soldier 3"})
 	_, ok := cache.GetSoldier(3)
 	if !ok {
 		t.Error("expected to find soldier added after reset")
@@ -130,7 +130,7 @@ func TestEntityCache_LockUnlock(t *testing.T) {
 	// Test Lock/Unlock don't cause deadlock
 	cache.Lock()
 	// Directly modify the map while holding the lock
-	cache.Soldiers[1] = model.Soldier{OcapID: 1, UnitName: "Direct Add"}
+	cache.Soldiers[1] = model.Soldier{ObjectID: 1, UnitName: "Direct Add"}
 	cache.Unlock()
 
 	// Verify the data was added
@@ -152,11 +152,11 @@ func TestEntityCache_Concurrent(t *testing.T) {
 		wg.Add(2)
 		go func(id uint16) {
 			defer wg.Done()
-			cache.AddSoldier(model.Soldier{OcapID: id, UnitName: "Soldier"})
+			cache.AddSoldier(model.Soldier{ObjectID: id, UnitName: "Soldier"})
 		}(i)
 		go func(id uint16) {
 			defer wg.Done()
-			cache.AddVehicle(model.Vehicle{OcapID: id, ClassName: "Vehicle"})
+			cache.AddVehicle(model.Vehicle{ObjectID: id, ClassName: "Vehicle"})
 		}(i)
 	}
 	wg.Wait()

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -37,8 +37,8 @@ func (b *mockBackend) RecordAce3DeathEvent(e *core.Ace3DeathEvent) error   { ret
 func (b *mockBackend) RecordAce3UnconsciousEvent(e *core.Ace3UnconsciousEvent) error {
 	return nil
 }
-func (b *mockBackend) GetSoldierByOcapID(ocapID uint16) (*core.Soldier, bool) { return nil, false }
-func (b *mockBackend) GetVehicleByOcapID(ocapID uint16) (*core.Vehicle, bool) { return nil, false }
+func (b *mockBackend) GetSoldierByObjectID(ocapID uint16) (*core.Soldier, bool) { return nil, false }
+func (b *mockBackend) GetVehicleByObjectID(ocapID uint16) (*core.Vehicle, bool) { return nil, false }
 func (b *mockBackend) GetMarkerByName(name string) (*core.Marker, bool)       { return nil, false }
 
 func (b *mockBackend) StartMission(mission *core.Mission, world *core.World) error {

--- a/internal/model/convert/convert.go
+++ b/internal/model/convert/convert.go
@@ -18,7 +18,8 @@ func pointToPosition3D(p geom.Point) core.Position3D {
 	return core.Position3D{X: coord.XY.X, Y: coord.XY.Y, Z: coord.Z}
 }
 
-// SoldierToCore converts a GORM Soldier to a core.Soldier
+// SoldierToCore converts a GORM Soldier to a core.Soldier.
+// GORM Soldier.OcapID maps to core Soldier.ID.
 func SoldierToCore(s model.Soldier) core.Soldier {
 	var squadParams []any
 	if len(s.SquadParams) > 0 {
@@ -26,11 +27,10 @@ func SoldierToCore(s model.Soldier) core.Soldier {
 	}
 
 	return core.Soldier{
-		ID:              s.ID,
+		ID:              s.OcapID, // Core ID = GORM OcapID
 		MissionID:       s.MissionID,
 		JoinTime:        s.JoinTime,
 		JoinFrame:       s.JoinFrame,
-		OcapID:          s.OcapID,
 		OcapType:        s.OcapType,
 		UnitName:        s.UnitName,
 		GroupID:         s.GroupID,
@@ -44,18 +44,18 @@ func SoldierToCore(s model.Soldier) core.Soldier {
 	}
 }
 
-// SoldierStateToCore converts a GORM SoldierState to a core.SoldierState
+// SoldierStateToCore converts a GORM SoldierState to a core.SoldierState.
+// SoldierOcapID in GORM maps directly to SoldierID in core (both are OcapID).
 func SoldierStateToCore(s model.SoldierState) core.SoldierState {
-	var inVehicleObjID *uint
-	if s.InVehicleObjectID.Valid {
-		id := uint(s.InVehicleObjectID.Int32)
+	var inVehicleObjID *uint16
+	if s.InVehicleOcapID.Valid {
+		id := uint16(s.InVehicleOcapID.Int32)
 		inVehicleObjID = &id
 	}
 
 	return core.SoldierState{
-		ID:                s.ID,
+		SoldierID:         s.SoldierOcapID, // Direct mapping: GORM SoldierOcapID = core SoldierID
 		MissionID:         s.MissionID,
-		SoldierID:         s.SoldierID,
 		Time:              s.Time,
 		CaptureFrame:      s.CaptureFrame,
 		Position:          pointToPosition3D(s.Position),
@@ -81,14 +81,14 @@ func SoldierStateToCore(s model.SoldierState) core.SoldierState {
 	}
 }
 
-// VehicleToCore converts a GORM Vehicle to a core.Vehicle
+// VehicleToCore converts a GORM Vehicle to a core.Vehicle.
+// GORM Vehicle.OcapID maps to core Vehicle.ID.
 func VehicleToCore(v model.Vehicle) core.Vehicle {
 	return core.Vehicle{
-		ID:            v.ID,
+		ID:            v.OcapID, // Core ID = GORM OcapID
 		MissionID:     v.MissionID,
 		JoinTime:      v.JoinTime,
 		JoinFrame:     v.JoinFrame,
-		OcapID:        v.OcapID,
 		OcapType:      v.OcapType,
 		ClassName:     v.ClassName,
 		DisplayName:   v.DisplayName,
@@ -96,12 +96,12 @@ func VehicleToCore(v model.Vehicle) core.Vehicle {
 	}
 }
 
-// VehicleStateToCore converts a GORM VehicleState to a core.VehicleState
+// VehicleStateToCore converts a GORM VehicleState to a core.VehicleState.
+// VehicleOcapID in GORM maps directly to VehicleID in core (both are OcapID).
 func VehicleStateToCore(v model.VehicleState) core.VehicleState {
 	return core.VehicleState{
-		ID:              v.ID,
+		VehicleID:       v.VehicleOcapID, // Direct mapping: GORM VehicleOcapID = core VehicleID
 		MissionID:       v.MissionID,
-		VehicleID:       v.VehicleID,
 		Time:            v.Time,
 		CaptureFrame:    v.CaptureFrame,
 		Position:        pointToPosition3D(v.Position),
@@ -120,12 +120,12 @@ func VehicleStateToCore(v model.VehicleState) core.VehicleState {
 	}
 }
 
-// FiredEventToCore converts a GORM FiredEvent to a core.FiredEvent
+// FiredEventToCore converts a GORM FiredEvent to a core.FiredEvent.
+// SoldierOcapID in GORM maps directly to SoldierID in core (both are OcapID).
 func FiredEventToCore(e model.FiredEvent) core.FiredEvent {
 	return core.FiredEvent{
-		ID:           e.ID,
 		MissionID:    e.MissionID,
-		SoldierID:    e.SoldierID,
+		SoldierID:    e.SoldierOcapID, // Direct mapping: GORM SoldierOcapID = core SoldierID
 		Time:         e.Time,
 		CaptureFrame: e.CaptureFrame,
 		Weapon:       e.Weapon,
@@ -155,6 +155,7 @@ func GeneralEventToCore(e model.GeneralEvent) core.GeneralEvent {
 }
 
 // HitEventToCore converts a GORM HitEvent to a core.HitEvent
+// OcapID fields in GORM map to uint IDs in core (cast to uint for compatibility)
 func HitEventToCore(e model.HitEvent) core.HitEvent {
 	result := core.HitEvent{
 		ID:           e.ID,
@@ -165,20 +166,20 @@ func HitEventToCore(e model.HitEvent) core.HitEvent {
 		Distance:     e.Distance,
 	}
 
-	if e.VictimSoldierID.Valid {
-		id := uint(e.VictimSoldierID.Int32)
+	if e.VictimSoldierOcapID.Valid {
+		id := uint(e.VictimSoldierOcapID.Int32)
 		result.VictimSoldierID = &id
 	}
-	if e.VictimVehicleID.Valid {
-		id := uint(e.VictimVehicleID.Int32)
+	if e.VictimVehicleOcapID.Valid {
+		id := uint(e.VictimVehicleOcapID.Int32)
 		result.VictimVehicleID = &id
 	}
-	if e.ShooterSoldierID.Valid {
-		id := uint(e.ShooterSoldierID.Int32)
+	if e.ShooterSoldierOcapID.Valid {
+		id := uint(e.ShooterSoldierOcapID.Int32)
 		result.ShooterSoldierID = &id
 	}
-	if e.ShooterVehicleID.Valid {
-		id := uint(e.ShooterVehicleID.Int32)
+	if e.ShooterVehicleOcapID.Valid {
+		id := uint(e.ShooterVehicleOcapID.Int32)
 		result.ShooterVehicleID = &id
 	}
 
@@ -186,6 +187,7 @@ func HitEventToCore(e model.HitEvent) core.HitEvent {
 }
 
 // KillEventToCore converts a GORM KillEvent to a core.KillEvent
+// OcapID fields in GORM map to uint IDs in core (cast to uint for compatibility)
 func KillEventToCore(e model.KillEvent) core.KillEvent {
 	result := core.KillEvent{
 		ID:           e.ID,
@@ -196,20 +198,20 @@ func KillEventToCore(e model.KillEvent) core.KillEvent {
 		Distance:     e.Distance,
 	}
 
-	if e.VictimIDSoldier.Valid {
-		id := uint(e.VictimIDSoldier.Int32)
+	if e.VictimSoldierOcapID.Valid {
+		id := uint(e.VictimSoldierOcapID.Int32)
 		result.VictimSoldierID = &id
 	}
-	if e.VictimIDVehicle.Valid {
-		id := uint(e.VictimIDVehicle.Int32)
+	if e.VictimVehicleOcapID.Valid {
+		id := uint(e.VictimVehicleOcapID.Int32)
 		result.VictimVehicleID = &id
 	}
-	if e.KillerIDSoldier.Valid {
-		id := uint(e.KillerIDSoldier.Int32)
+	if e.KillerSoldierOcapID.Valid {
+		id := uint(e.KillerSoldierOcapID.Int32)
 		result.KillerSoldierID = &id
 	}
-	if e.KillerIDVehicle.Valid {
-		id := uint(e.KillerIDVehicle.Int32)
+	if e.KillerVehicleOcapID.Valid {
+		id := uint(e.KillerVehicleOcapID.Int32)
 		result.KillerVehicleID = &id
 	}
 
@@ -230,8 +232,8 @@ func ChatEventToCore(e model.ChatEvent) core.ChatEvent {
 		PlayerUID:    e.PlayerUID,
 	}
 
-	if e.SoldierID.Valid {
-		id := uint(e.SoldierID.Int32)
+	if e.SoldierOcapID.Valid {
+		id := uint(e.SoldierOcapID.Int32)
 		result.SoldierID = &id
 	}
 
@@ -254,8 +256,8 @@ func RadioEventToCore(e model.RadioEvent) core.RadioEvent {
 		Code:         e.Code,
 	}
 
-	if e.SoldierID.Valid {
-		id := uint(e.SoldierID.Int32)
+	if e.SoldierOcapID.Valid {
+		id := uint(e.SoldierOcapID.Int32)
 		result.SoldierID = &id
 	}
 
@@ -291,14 +293,14 @@ func Ace3DeathEventToCore(e model.Ace3DeathEvent) core.Ace3DeathEvent {
 	result := core.Ace3DeathEvent{
 		ID:           e.ID,
 		MissionID:    e.MissionID,
-		SoldierID:    e.SoldierID,
+		SoldierID:    uint(e.SoldierOcapID), // OcapID -> uint for core model
 		Time:         e.Time,
 		CaptureFrame: e.CaptureFrame,
 		Reason:       e.Reason,
 	}
 
-	if e.LastDamageSourceID.Valid {
-		id := uint(e.LastDamageSourceID.Int32)
+	if e.LastDamageSourceOcapID.Valid {
+		id := uint(e.LastDamageSourceOcapID.Int32)
 		result.LastDamageSourceID = &id
 	}
 
@@ -310,7 +312,7 @@ func Ace3UnconsciousEventToCore(e model.Ace3UnconsciousEvent) core.Ace3Unconscio
 	return core.Ace3UnconsciousEvent{
 		ID:           e.ID,
 		MissionID:    e.MissionID,
-		SoldierID:    e.SoldierID,
+		SoldierID:    uint(e.SoldierOcapID), // OcapID -> uint for core model
 		Time:         e.Time,
 		CaptureFrame: e.CaptureFrame,
 		IsAwake:      e.IsAwake,

--- a/internal/model/convert/convert.go
+++ b/internal/model/convert/convert.go
@@ -19,7 +19,7 @@ func pointToPosition3D(p geom.Point) core.Position3D {
 }
 
 // SoldierToCore converts a GORM Soldier to a core.Soldier.
-// GORM Soldier.OcapID maps to core Soldier.ID.
+// GORM Soldier.ObjectID maps to core Soldier.ID.
 func SoldierToCore(s model.Soldier) core.Soldier {
 	var squadParams []any
 	if len(s.SquadParams) > 0 {
@@ -27,7 +27,7 @@ func SoldierToCore(s model.Soldier) core.Soldier {
 	}
 
 	return core.Soldier{
-		ID:              s.OcapID, // Core ID = GORM OcapID
+		ID:              s.ObjectID, // Core ID = GORM ObjectID
 		MissionID:       s.MissionID,
 		JoinTime:        s.JoinTime,
 		JoinFrame:       s.JoinFrame,
@@ -45,16 +45,16 @@ func SoldierToCore(s model.Soldier) core.Soldier {
 }
 
 // SoldierStateToCore converts a GORM SoldierState to a core.SoldierState.
-// SoldierOcapID in GORM maps directly to SoldierID in core (both are OcapID).
+// SoldierObjectID in GORM maps directly to SoldierID in core (both are ObjectID).
 func SoldierStateToCore(s model.SoldierState) core.SoldierState {
 	var inVehicleObjID *uint16
-	if s.InVehicleOcapID.Valid {
-		id := uint16(s.InVehicleOcapID.Int32)
+	if s.InVehicleObjectID.Valid {
+		id := uint16(s.InVehicleObjectID.Int32)
 		inVehicleObjID = &id
 	}
 
 	return core.SoldierState{
-		SoldierID:         s.SoldierOcapID, // Direct mapping: GORM SoldierOcapID = core SoldierID
+		SoldierID:         s.SoldierObjectID, // Direct mapping: GORM SoldierObjectID = core SoldierID
 		MissionID:         s.MissionID,
 		Time:              s.Time,
 		CaptureFrame:      s.CaptureFrame,
@@ -82,10 +82,10 @@ func SoldierStateToCore(s model.SoldierState) core.SoldierState {
 }
 
 // VehicleToCore converts a GORM Vehicle to a core.Vehicle.
-// GORM Vehicle.OcapID maps to core Vehicle.ID.
+// GORM Vehicle.ObjectID maps to core Vehicle.ID.
 func VehicleToCore(v model.Vehicle) core.Vehicle {
 	return core.Vehicle{
-		ID:            v.OcapID, // Core ID = GORM OcapID
+		ID:            v.ObjectID, // Core ID = GORM ObjectID
 		MissionID:     v.MissionID,
 		JoinTime:      v.JoinTime,
 		JoinFrame:     v.JoinFrame,
@@ -97,10 +97,10 @@ func VehicleToCore(v model.Vehicle) core.Vehicle {
 }
 
 // VehicleStateToCore converts a GORM VehicleState to a core.VehicleState.
-// VehicleOcapID in GORM maps directly to VehicleID in core (both are OcapID).
+// VehicleObjectID in GORM maps directly to VehicleID in core (both are ObjectID).
 func VehicleStateToCore(v model.VehicleState) core.VehicleState {
 	return core.VehicleState{
-		VehicleID:       v.VehicleOcapID, // Direct mapping: GORM VehicleOcapID = core VehicleID
+		VehicleID:       v.VehicleObjectID, // Direct mapping: GORM VehicleObjectID = core VehicleID
 		MissionID:       v.MissionID,
 		Time:            v.Time,
 		CaptureFrame:    v.CaptureFrame,
@@ -121,11 +121,11 @@ func VehicleStateToCore(v model.VehicleState) core.VehicleState {
 }
 
 // FiredEventToCore converts a GORM FiredEvent to a core.FiredEvent.
-// SoldierOcapID in GORM maps directly to SoldierID in core (both are OcapID).
+// SoldierObjectID in GORM maps directly to SoldierID in core (both are ObjectID).
 func FiredEventToCore(e model.FiredEvent) core.FiredEvent {
 	return core.FiredEvent{
 		MissionID:    e.MissionID,
-		SoldierID:    e.SoldierOcapID, // Direct mapping: GORM SoldierOcapID = core SoldierID
+		SoldierID:    e.SoldierObjectID, // Direct mapping: GORM SoldierObjectID = core SoldierID
 		Time:         e.Time,
 		CaptureFrame: e.CaptureFrame,
 		Weapon:       e.Weapon,
@@ -155,7 +155,7 @@ func GeneralEventToCore(e model.GeneralEvent) core.GeneralEvent {
 }
 
 // HitEventToCore converts a GORM HitEvent to a core.HitEvent
-// OcapID fields in GORM map to uint IDs in core (cast to uint for compatibility)
+// ObjectID fields in GORM map to uint IDs in core (cast to uint for compatibility)
 func HitEventToCore(e model.HitEvent) core.HitEvent {
 	result := core.HitEvent{
 		ID:           e.ID,
@@ -166,20 +166,20 @@ func HitEventToCore(e model.HitEvent) core.HitEvent {
 		Distance:     e.Distance,
 	}
 
-	if e.VictimSoldierOcapID.Valid {
-		id := uint(e.VictimSoldierOcapID.Int32)
+	if e.VictimSoldierObjectID.Valid {
+		id := uint(e.VictimSoldierObjectID.Int32)
 		result.VictimSoldierID = &id
 	}
-	if e.VictimVehicleOcapID.Valid {
-		id := uint(e.VictimVehicleOcapID.Int32)
+	if e.VictimVehicleObjectID.Valid {
+		id := uint(e.VictimVehicleObjectID.Int32)
 		result.VictimVehicleID = &id
 	}
-	if e.ShooterSoldierOcapID.Valid {
-		id := uint(e.ShooterSoldierOcapID.Int32)
+	if e.ShooterSoldierObjectID.Valid {
+		id := uint(e.ShooterSoldierObjectID.Int32)
 		result.ShooterSoldierID = &id
 	}
-	if e.ShooterVehicleOcapID.Valid {
-		id := uint(e.ShooterVehicleOcapID.Int32)
+	if e.ShooterVehicleObjectID.Valid {
+		id := uint(e.ShooterVehicleObjectID.Int32)
 		result.ShooterVehicleID = &id
 	}
 
@@ -187,7 +187,7 @@ func HitEventToCore(e model.HitEvent) core.HitEvent {
 }
 
 // KillEventToCore converts a GORM KillEvent to a core.KillEvent
-// OcapID fields in GORM map to uint IDs in core (cast to uint for compatibility)
+// ObjectID fields in GORM map to uint IDs in core (cast to uint for compatibility)
 func KillEventToCore(e model.KillEvent) core.KillEvent {
 	result := core.KillEvent{
 		ID:           e.ID,
@@ -198,20 +198,20 @@ func KillEventToCore(e model.KillEvent) core.KillEvent {
 		Distance:     e.Distance,
 	}
 
-	if e.VictimSoldierOcapID.Valid {
-		id := uint(e.VictimSoldierOcapID.Int32)
+	if e.VictimSoldierObjectID.Valid {
+		id := uint(e.VictimSoldierObjectID.Int32)
 		result.VictimSoldierID = &id
 	}
-	if e.VictimVehicleOcapID.Valid {
-		id := uint(e.VictimVehicleOcapID.Int32)
+	if e.VictimVehicleObjectID.Valid {
+		id := uint(e.VictimVehicleObjectID.Int32)
 		result.VictimVehicleID = &id
 	}
-	if e.KillerSoldierOcapID.Valid {
-		id := uint(e.KillerSoldierOcapID.Int32)
+	if e.KillerSoldierObjectID.Valid {
+		id := uint(e.KillerSoldierObjectID.Int32)
 		result.KillerSoldierID = &id
 	}
-	if e.KillerVehicleOcapID.Valid {
-		id := uint(e.KillerVehicleOcapID.Int32)
+	if e.KillerVehicleObjectID.Valid {
+		id := uint(e.KillerVehicleObjectID.Int32)
 		result.KillerVehicleID = &id
 	}
 
@@ -232,8 +232,8 @@ func ChatEventToCore(e model.ChatEvent) core.ChatEvent {
 		PlayerUID:    e.PlayerUID,
 	}
 
-	if e.SoldierOcapID.Valid {
-		id := uint(e.SoldierOcapID.Int32)
+	if e.SoldierObjectID.Valid {
+		id := uint(e.SoldierObjectID.Int32)
 		result.SoldierID = &id
 	}
 
@@ -256,8 +256,8 @@ func RadioEventToCore(e model.RadioEvent) core.RadioEvent {
 		Code:         e.Code,
 	}
 
-	if e.SoldierOcapID.Valid {
-		id := uint(e.SoldierOcapID.Int32)
+	if e.SoldierObjectID.Valid {
+		id := uint(e.SoldierObjectID.Int32)
 		result.SoldierID = &id
 	}
 
@@ -293,14 +293,14 @@ func Ace3DeathEventToCore(e model.Ace3DeathEvent) core.Ace3DeathEvent {
 	result := core.Ace3DeathEvent{
 		ID:           e.ID,
 		MissionID:    e.MissionID,
-		SoldierID:    uint(e.SoldierOcapID), // OcapID -> uint for core model
+		SoldierID:    uint(e.SoldierObjectID), // ObjectID -> uint for core model
 		Time:         e.Time,
 		CaptureFrame: e.CaptureFrame,
 		Reason:       e.Reason,
 	}
 
-	if e.LastDamageSourceOcapID.Valid {
-		id := uint(e.LastDamageSourceOcapID.Int32)
+	if e.LastDamageSourceObjectID.Valid {
+		id := uint(e.LastDamageSourceObjectID.Int32)
 		result.LastDamageSourceID = &id
 	}
 
@@ -312,7 +312,7 @@ func Ace3UnconsciousEventToCore(e model.Ace3UnconsciousEvent) core.Ace3Unconscio
 	return core.Ace3UnconsciousEvent{
 		ID:           e.ID,
 		MissionID:    e.MissionID,
-		SoldierID:    uint(e.SoldierOcapID), // OcapID -> uint for core model
+		SoldierID:    uint(e.SoldierObjectID), // ObjectID -> uint for core model
 		Time:         e.Time,
 		CaptureFrame: e.CaptureFrame,
 		IsAwake:      e.IsAwake,

--- a/internal/model/convert/convert_test.go
+++ b/internal/model/convert/convert_test.go
@@ -54,18 +54,15 @@ func TestSoldierToCore(t *testing.T) {
 		PlayerUID:       "12345678",
 		SquadParams:     datatypes.JSON(squadParams),
 	}
-	gormSoldier.ID = 1
 
 	coreSoldier := SoldierToCore(gormSoldier)
 
-	if coreSoldier.ID != 1 {
-		t.Errorf("expected ID=1, got %d", coreSoldier.ID)
+	// Core ID = GORM OcapID (not GORM ID)
+	if coreSoldier.ID != 42 {
+		t.Errorf("expected ID=42 (OcapID), got %d", coreSoldier.ID)
 	}
 	if coreSoldier.MissionID != 1 {
 		t.Errorf("expected MissionID=1, got %d", coreSoldier.MissionID)
-	}
-	if coreSoldier.OcapID != 42 {
-		t.Errorf("expected OcapID=42, got %d", coreSoldier.OcapID)
 	}
 	if coreSoldier.UnitName != "TestUnit" {
 		t.Errorf("expected UnitName=TestUnit, got %s", coreSoldier.UnitName)
@@ -83,24 +80,24 @@ func TestSoldierStateToCore(t *testing.T) {
 	inVehicleID := sql.NullInt32{Int32: 5, Valid: true}
 
 	gormState := model.SoldierState{
-		ID:                1,
-		MissionID:         1,
-		SoldierID:         2,
-		Time:              now,
-		CaptureFrame:      100,
-		Position:          makePoint(1000.0, 2000.0, 10.0),
-		ElevationASL:      10.0,
-		Bearing:           90,
-		Lifestate:         1,
-		InVehicle:         true,
-		InVehicleObjectID: inVehicleID,
-		VehicleRole:       "driver",
-		UnitName:          "TestUnit",
-		IsPlayer:          true,
-		CurrentRole:       "Rifleman",
-		HasStableVitals:   true,
-		IsDraggedCarried:  false,
-		Stance:            "Up",
+		ID:              1,
+		MissionID:       1,
+		SoldierOcapID:   2,
+		Time:            now,
+		CaptureFrame:    100,
+		Position:        makePoint(1000.0, 2000.0, 10.0),
+		ElevationASL:    10.0,
+		Bearing:         90,
+		Lifestate:       1,
+		InVehicle:       true,
+		InVehicleOcapID: inVehicleID,
+		VehicleRole:     "driver",
+		UnitName:        "TestUnit",
+		IsPlayer:        true,
+		CurrentRole:     "Rifleman",
+		HasStableVitals: true,
+		IsDraggedCarried: false,
+		Stance:          "Up",
 		Scores: model.SoldierScores{
 			InfantryKills: 5,
 			VehicleKills:  2,
@@ -113,8 +110,9 @@ func TestSoldierStateToCore(t *testing.T) {
 
 	coreState := SoldierStateToCore(gormState)
 
-	if coreState.ID != 1 {
-		t.Errorf("expected ID=1, got %d", coreState.ID)
+	// SoldierID maps from SoldierOcapID
+	if coreState.SoldierID != 2 {
+		t.Errorf("expected SoldierID=2 (from SoldierOcapID), got %d", coreState.SoldierID)
 	}
 	if coreState.CaptureFrame != 100 {
 		t.Errorf("expected CaptureFrame=100, got %d", coreState.CaptureFrame)
@@ -146,15 +144,12 @@ func TestVehicleToCore(t *testing.T) {
 		DisplayName:   "Hunter",
 		Customization: "default",
 	}
-	gormVehicle.ID = 5
 
 	coreVehicle := VehicleToCore(gormVehicle)
 
-	if coreVehicle.ID != 5 {
-		t.Errorf("expected ID=5, got %d", coreVehicle.ID)
-	}
-	if coreVehicle.OcapID != 10 {
-		t.Errorf("expected OcapID=10, got %d", coreVehicle.OcapID)
+	// Core ID = GORM OcapID (not GORM ID)
+	if coreVehicle.ID != 10 {
+		t.Errorf("expected ID=10 (OcapID), got %d", coreVehicle.ID)
 	}
 	if coreVehicle.OcapType != "car" {
 		t.Errorf("expected OcapType=car, got %s", coreVehicle.OcapType)
@@ -170,7 +165,7 @@ func TestVehicleStateToCore(t *testing.T) {
 	gormState := model.VehicleState{
 		ID:              1,
 		MissionID:       1,
-		VehicleID:       5,
+		VehicleOcapID:   5,
 		Time:            now,
 		CaptureFrame:    50,
 		Position:        makePoint(500.0, 600.0, 0.0),
@@ -191,8 +186,9 @@ func TestVehicleStateToCore(t *testing.T) {
 
 	coreState := VehicleStateToCore(gormState)
 
+	// VehicleID maps from VehicleOcapID
 	if coreState.VehicleID != 5 {
-		t.Errorf("expected VehicleID=5, got %d", coreState.VehicleID)
+		t.Errorf("expected VehicleID=5 (from VehicleOcapID), got %d", coreState.VehicleID)
 	}
 	if coreState.Position.X != 500.0 {
 		t.Errorf("expected Position.X=500.0, got %f", coreState.Position.X)
@@ -211,7 +207,7 @@ func TestFiredEventToCore(t *testing.T) {
 	gormEvent := model.FiredEvent{
 		ID:                1,
 		MissionID:         1,
-		SoldierID:         2,
+		SoldierOcapID:     2,
 		Time:              now,
 		CaptureFrame:      100,
 		Weapon:            "arifle_MX_F",
@@ -225,8 +221,9 @@ func TestFiredEventToCore(t *testing.T) {
 
 	coreEvent := FiredEventToCore(gormEvent)
 
+	// SoldierID maps from SoldierOcapID
 	if coreEvent.SoldierID != 2 {
-		t.Errorf("expected SoldierID=2, got %d", coreEvent.SoldierID)
+		t.Errorf("expected SoldierID=2 (from SoldierOcapID), got %d", coreEvent.SoldierID)
 	}
 	if coreEvent.Weapon != "arifle_MX_F" {
 		t.Errorf("expected Weapon=arifle_MX_F, got %s", coreEvent.Weapon)
@@ -243,14 +240,14 @@ func TestHitEventToCore(t *testing.T) {
 	now := time.Now()
 
 	gormEvent := model.HitEvent{
-		ID:               1,
-		MissionID:        1,
-		Time:             now,
-		CaptureFrame:     100,
-		VictimSoldierID:  sql.NullInt32{Int32: 5, Valid: true},
-		ShooterSoldierID: sql.NullInt32{Int32: 10, Valid: true},
-		EventText:        "Hit event",
-		Distance:         50.5,
+		ID:                   1,
+		MissionID:            1,
+		Time:                 now,
+		CaptureFrame:         100,
+		VictimSoldierOcapID:  sql.NullInt32{Int32: 5, Valid: true},
+		ShooterSoldierOcapID: sql.NullInt32{Int32: 10, Valid: true},
+		EventText:            "Hit event",
+		Distance:             50.5,
 	}
 
 	coreEvent := HitEventToCore(gormEvent)
@@ -270,14 +267,14 @@ func TestKillEventToCore(t *testing.T) {
 	now := time.Now()
 
 	gormEvent := model.KillEvent{
-		ID:              1,
-		MissionID:       1,
-		Time:            now,
-		CaptureFrame:    100,
-		VictimIDSoldier: sql.NullInt32{Int32: 5, Valid: true},
-		KillerIDSoldier: sql.NullInt32{Int32: 10, Valid: true},
-		EventText:       "Kill event",
-		Distance:        100.0,
+		ID:                  1,
+		MissionID:           1,
+		Time:                now,
+		CaptureFrame:        100,
+		VictimSoldierOcapID: sql.NullInt32{Int32: 5, Valid: true},
+		KillerSoldierOcapID: sql.NullInt32{Int32: 10, Valid: true},
+		EventText:           "Kill event",
+		Distance:            100.0,
 	}
 
 	coreEvent := KillEventToCore(gormEvent)
@@ -418,16 +415,16 @@ func TestChatEventToCore(t *testing.T) {
 	now := time.Now()
 
 	gormEvent := model.ChatEvent{
-		ID:           1,
-		MissionID:    1,
-		SoldierID:    sql.NullInt32{Int32: 5, Valid: true},
-		Time:         now,
-		CaptureFrame: 100,
-		Channel:      "Global",
-		FromName:     "Player1",
-		SenderName:   "John",
-		Message:      "Hello world",
-		PlayerUID:    "12345678",
+		ID:            1,
+		MissionID:     1,
+		SoldierOcapID: sql.NullInt32{Int32: 5, Valid: true},
+		Time:          now,
+		CaptureFrame:  100,
+		Channel:       "Global",
+		FromName:      "Player1",
+		SenderName:    "John",
+		Message:       "Hello world",
+		PlayerUID:     "12345678",
 	}
 
 	coreEvent := ChatEventToCore(gormEvent)
@@ -447,18 +444,18 @@ func TestRadioEventToCore(t *testing.T) {
 	now := time.Now()
 
 	gormEvent := model.RadioEvent{
-		ID:           1,
-		MissionID:    1,
-		SoldierID:    sql.NullInt32{Int32: 5, Valid: true},
-		Time:         now,
-		CaptureFrame: 100,
-		Radio:        "AN/PRC-152",
-		RadioType:    "SW",
-		StartEnd:     "start",
-		Channel:      1,
-		IsAdditional: false,
-		Frequency:    100.0,
-		Code:         "ABC",
+		ID:            1,
+		MissionID:     1,
+		SoldierOcapID: sql.NullInt32{Int32: 5, Valid: true},
+		Time:          now,
+		CaptureFrame:  100,
+		Radio:         "AN/PRC-152",
+		RadioType:     "SW",
+		StartEnd:      "start",
+		Channel:       1,
+		IsAdditional:  false,
+		Frequency:     100.0,
+		Code:          "ABC",
 	}
 
 	coreEvent := RadioEventToCore(gormEvent)
@@ -531,13 +528,13 @@ func TestAce3DeathEventToCore(t *testing.T) {
 	now := time.Now()
 
 	gormEvent := model.Ace3DeathEvent{
-		ID:                 1,
-		MissionID:          1,
-		SoldierID:          5,
-		Time:               now,
-		CaptureFrame:       100,
-		Reason:             "BLOODLOSS",
-		LastDamageSourceID: sql.NullInt32{Int32: 10, Valid: true},
+		ID:                     1,
+		MissionID:              1,
+		SoldierOcapID:          5,
+		Time:                   now,
+		CaptureFrame:           100,
+		Reason:                 "BLOODLOSS",
+		LastDamageSourceOcapID: sql.NullInt32{Int32: 10, Valid: true},
 	}
 
 	coreEvent := Ace3DeathEventToCore(gormEvent)
@@ -554,12 +551,12 @@ func TestAce3UnconsciousEventToCore(t *testing.T) {
 	now := time.Now()
 
 	gormEvent := model.Ace3UnconsciousEvent{
-		ID:           1,
-		MissionID:    1,
-		SoldierID:    5,
-		Time:         now,
-		CaptureFrame: 100,
-		IsAwake:      false,
+		ID:            1,
+		MissionID:     1,
+		SoldierOcapID: 5,
+		Time:          now,
+		CaptureFrame:  100,
+		IsAwake:       false,
 	}
 
 	coreEvent := Ace3UnconsciousEventToCore(gormEvent)
@@ -602,7 +599,7 @@ func TestMarkerStateToCore(t *testing.T) {
 // Test with nil/invalid values
 func TestSoldierStateToCore_NilInVehicleID(t *testing.T) {
 	gormState := model.SoldierState{
-		InVehicleObjectID: sql.NullInt32{Valid: false},
+		InVehicleOcapID: sql.NullInt32{Valid: false},
 	}
 
 	coreState := SoldierStateToCore(gormState)
@@ -614,8 +611,8 @@ func TestSoldierStateToCore_NilInVehicleID(t *testing.T) {
 
 func TestHitEventToCore_NilIDs(t *testing.T) {
 	gormEvent := model.HitEvent{
-		VictimSoldierID:  sql.NullInt32{Valid: false},
-		ShooterSoldierID: sql.NullInt32{Valid: false},
+		VictimSoldierOcapID:  sql.NullInt32{Valid: false},
+		ShooterSoldierOcapID: sql.NullInt32{Valid: false},
 	}
 
 	coreEvent := HitEventToCore(gormEvent)

--- a/internal/model/convert/convert_test.go
+++ b/internal/model/convert/convert_test.go
@@ -42,7 +42,7 @@ func TestSoldierToCore(t *testing.T) {
 		MissionID:       1,
 		JoinTime:        now,
 		JoinFrame:       10,
-		OcapID:          42,
+		ObjectID:          42,
 		OcapType:        "man",
 		UnitName:        "TestUnit",
 		GroupID:         "Alpha",
@@ -57,9 +57,9 @@ func TestSoldierToCore(t *testing.T) {
 
 	coreSoldier := SoldierToCore(gormSoldier)
 
-	// Core ID = GORM OcapID (not GORM ID)
+	// Core ID = GORM ObjectID (not GORM ID)
 	if coreSoldier.ID != 42 {
-		t.Errorf("expected ID=42 (OcapID), got %d", coreSoldier.ID)
+		t.Errorf("expected ID=42 (ObjectID), got %d", coreSoldier.ID)
 	}
 	if coreSoldier.MissionID != 1 {
 		t.Errorf("expected MissionID=1, got %d", coreSoldier.MissionID)
@@ -82,7 +82,7 @@ func TestSoldierStateToCore(t *testing.T) {
 	gormState := model.SoldierState{
 		ID:              1,
 		MissionID:       1,
-		SoldierOcapID:   2,
+		SoldierObjectID:   2,
 		Time:            now,
 		CaptureFrame:    100,
 		Position:        makePoint(1000.0, 2000.0, 10.0),
@@ -90,7 +90,7 @@ func TestSoldierStateToCore(t *testing.T) {
 		Bearing:         90,
 		Lifestate:       1,
 		InVehicle:       true,
-		InVehicleOcapID: inVehicleID,
+		InVehicleObjectID: inVehicleID,
 		VehicleRole:     "driver",
 		UnitName:        "TestUnit",
 		IsPlayer:        true,
@@ -110,9 +110,9 @@ func TestSoldierStateToCore(t *testing.T) {
 
 	coreState := SoldierStateToCore(gormState)
 
-	// SoldierID maps from SoldierOcapID
+	// SoldierID maps from SoldierObjectID
 	if coreState.SoldierID != 2 {
-		t.Errorf("expected SoldierID=2 (from SoldierOcapID), got %d", coreState.SoldierID)
+		t.Errorf("expected SoldierID=2 (from SoldierObjectID), got %d", coreState.SoldierID)
 	}
 	if coreState.CaptureFrame != 100 {
 		t.Errorf("expected CaptureFrame=100, got %d", coreState.CaptureFrame)
@@ -138,7 +138,7 @@ func TestVehicleToCore(t *testing.T) {
 		MissionID:     1,
 		JoinTime:      now,
 		JoinFrame:     20,
-		OcapID:        10,
+		ObjectID:        10,
 		OcapType:      "car",
 		ClassName:     "B_MRAP_01_F",
 		DisplayName:   "Hunter",
@@ -147,9 +147,9 @@ func TestVehicleToCore(t *testing.T) {
 
 	coreVehicle := VehicleToCore(gormVehicle)
 
-	// Core ID = GORM OcapID (not GORM ID)
+	// Core ID = GORM ObjectID (not GORM ID)
 	if coreVehicle.ID != 10 {
-		t.Errorf("expected ID=10 (OcapID), got %d", coreVehicle.ID)
+		t.Errorf("expected ID=10 (ObjectID), got %d", coreVehicle.ID)
 	}
 	if coreVehicle.OcapType != "car" {
 		t.Errorf("expected OcapType=car, got %s", coreVehicle.OcapType)
@@ -165,7 +165,7 @@ func TestVehicleStateToCore(t *testing.T) {
 	gormState := model.VehicleState{
 		ID:              1,
 		MissionID:       1,
-		VehicleOcapID:   5,
+		VehicleObjectID:   5,
 		Time:            now,
 		CaptureFrame:    50,
 		Position:        makePoint(500.0, 600.0, 0.0),
@@ -186,9 +186,9 @@ func TestVehicleStateToCore(t *testing.T) {
 
 	coreState := VehicleStateToCore(gormState)
 
-	// VehicleID maps from VehicleOcapID
+	// VehicleID maps from VehicleObjectID
 	if coreState.VehicleID != 5 {
-		t.Errorf("expected VehicleID=5 (from VehicleOcapID), got %d", coreState.VehicleID)
+		t.Errorf("expected VehicleID=5 (from VehicleObjectID), got %d", coreState.VehicleID)
 	}
 	if coreState.Position.X != 500.0 {
 		t.Errorf("expected Position.X=500.0, got %f", coreState.Position.X)
@@ -207,7 +207,7 @@ func TestFiredEventToCore(t *testing.T) {
 	gormEvent := model.FiredEvent{
 		ID:                1,
 		MissionID:         1,
-		SoldierOcapID:     2,
+		SoldierObjectID:     2,
 		Time:              now,
 		CaptureFrame:      100,
 		Weapon:            "arifle_MX_F",
@@ -221,9 +221,9 @@ func TestFiredEventToCore(t *testing.T) {
 
 	coreEvent := FiredEventToCore(gormEvent)
 
-	// SoldierID maps from SoldierOcapID
+	// SoldierID maps from SoldierObjectID
 	if coreEvent.SoldierID != 2 {
-		t.Errorf("expected SoldierID=2 (from SoldierOcapID), got %d", coreEvent.SoldierID)
+		t.Errorf("expected SoldierID=2 (from SoldierObjectID), got %d", coreEvent.SoldierID)
 	}
 	if coreEvent.Weapon != "arifle_MX_F" {
 		t.Errorf("expected Weapon=arifle_MX_F, got %s", coreEvent.Weapon)
@@ -244,8 +244,8 @@ func TestHitEventToCore(t *testing.T) {
 		MissionID:            1,
 		Time:                 now,
 		CaptureFrame:         100,
-		VictimSoldierOcapID:  sql.NullInt32{Int32: 5, Valid: true},
-		ShooterSoldierOcapID: sql.NullInt32{Int32: 10, Valid: true},
+		VictimSoldierObjectID:  sql.NullInt32{Int32: 5, Valid: true},
+		ShooterSoldierObjectID: sql.NullInt32{Int32: 10, Valid: true},
 		EventText:            "Hit event",
 		Distance:             50.5,
 	}
@@ -271,8 +271,8 @@ func TestKillEventToCore(t *testing.T) {
 		MissionID:           1,
 		Time:                now,
 		CaptureFrame:        100,
-		VictimSoldierOcapID: sql.NullInt32{Int32: 5, Valid: true},
-		KillerSoldierOcapID: sql.NullInt32{Int32: 10, Valid: true},
+		VictimSoldierObjectID: sql.NullInt32{Int32: 5, Valid: true},
+		KillerSoldierObjectID: sql.NullInt32{Int32: 10, Valid: true},
 		EventText:           "Kill event",
 		Distance:            100.0,
 	}
@@ -417,7 +417,7 @@ func TestChatEventToCore(t *testing.T) {
 	gormEvent := model.ChatEvent{
 		ID:            1,
 		MissionID:     1,
-		SoldierOcapID: sql.NullInt32{Int32: 5, Valid: true},
+		SoldierObjectID: sql.NullInt32{Int32: 5, Valid: true},
 		Time:          now,
 		CaptureFrame:  100,
 		Channel:       "Global",
@@ -446,7 +446,7 @@ func TestRadioEventToCore(t *testing.T) {
 	gormEvent := model.RadioEvent{
 		ID:            1,
 		MissionID:     1,
-		SoldierOcapID: sql.NullInt32{Int32: 5, Valid: true},
+		SoldierObjectID: sql.NullInt32{Int32: 5, Valid: true},
 		Time:          now,
 		CaptureFrame:  100,
 		Radio:         "AN/PRC-152",
@@ -530,11 +530,11 @@ func TestAce3DeathEventToCore(t *testing.T) {
 	gormEvent := model.Ace3DeathEvent{
 		ID:                     1,
 		MissionID:              1,
-		SoldierOcapID:          5,
+		SoldierObjectID:          5,
 		Time:                   now,
 		CaptureFrame:           100,
 		Reason:                 "BLOODLOSS",
-		LastDamageSourceOcapID: sql.NullInt32{Int32: 10, Valid: true},
+		LastDamageSourceObjectID: sql.NullInt32{Int32: 10, Valid: true},
 	}
 
 	coreEvent := Ace3DeathEventToCore(gormEvent)
@@ -553,7 +553,7 @@ func TestAce3UnconsciousEventToCore(t *testing.T) {
 	gormEvent := model.Ace3UnconsciousEvent{
 		ID:            1,
 		MissionID:     1,
-		SoldierOcapID: 5,
+		SoldierObjectID: 5,
 		Time:          now,
 		CaptureFrame:  100,
 		IsAwake:       false,
@@ -599,7 +599,7 @@ func TestMarkerStateToCore(t *testing.T) {
 // Test with nil/invalid values
 func TestSoldierStateToCore_NilInVehicleID(t *testing.T) {
 	gormState := model.SoldierState{
-		InVehicleOcapID: sql.NullInt32{Valid: false},
+		InVehicleObjectID: sql.NullInt32{Valid: false},
 	}
 
 	coreState := SoldierStateToCore(gormState)
@@ -611,8 +611,8 @@ func TestSoldierStateToCore_NilInVehicleID(t *testing.T) {
 
 func TestHitEventToCore_NilIDs(t *testing.T) {
 	gormEvent := model.HitEvent{
-		VictimSoldierOcapID:  sql.NullInt32{Valid: false},
-		ShooterSoldierOcapID: sql.NullInt32{Valid: false},
+		VictimSoldierObjectID:  sql.NullInt32{Valid: false},
+		ShooterSoldierObjectID: sql.NullInt32{Valid: false},
 	}
 
 	coreEvent := HitEventToCore(gormEvent)

--- a/internal/model/core/events.go
+++ b/internal/model/core/events.go
@@ -4,10 +4,10 @@ package core
 import "time"
 
 // FiredEvent represents a weapon being fired.
-// SoldierID is the OcapID of the soldier who fired.
+// SoldierID is the ObjectID of the soldier who fired.
 type FiredEvent struct {
 	MissionID    uint
-	SoldierID    uint16 // OcapID of the soldier who fired
+	SoldierID    uint16 // ObjectID of the soldier who fired
 	Time         time.Time
 	CaptureFrame uint
 	Weapon       string

--- a/internal/model/core/events.go
+++ b/internal/model/core/events.go
@@ -3,11 +3,11 @@ package core
 
 import "time"
 
-// FiredEvent represents a weapon being fired
+// FiredEvent represents a weapon being fired.
+// SoldierID is the OcapID of the soldier who fired.
 type FiredEvent struct {
-	ID           uint
 	MissionID    uint
-	SoldierID    uint
+	SoldierID    uint16 // OcapID of the soldier who fired
 	Time         time.Time
 	CaptureFrame uint
 	Weapon       string

--- a/internal/model/core/soldier.go
+++ b/internal/model/core/soldier.go
@@ -3,13 +3,13 @@ package core
 
 import "time"
 
-// Soldier represents a player or AI unit
+// Soldier represents a player or AI unit.
+// ID is the OcapID - the game's identifier for this entity.
 type Soldier struct {
-	ID              uint
+	ID              uint16 // OcapID - game identifier
 	MissionID       uint
 	JoinTime        time.Time
 	JoinFrame       uint
-	OcapID          uint16
 	OcapType        string
 	UnitName        string
 	GroupID         string
@@ -22,18 +22,18 @@ type Soldier struct {
 	SquadParams     []any
 }
 
-// SoldierState represents soldier state at a point in time
+// SoldierState represents soldier state at a point in time.
+// SoldierID references the Soldier's ID (OcapID).
 type SoldierState struct {
-	ID                uint
+	SoldierID         uint16 // References Soldier.ID (OcapID)
 	MissionID         uint
-	SoldierID         uint
 	Time              time.Time
 	CaptureFrame      uint
 	Position          Position3D
 	Bearing           uint16
 	Lifestate         uint8
 	InVehicle         bool
-	InVehicleObjectID *uint
+	InVehicleObjectID *uint16 // OcapID of vehicle, if in one
 	VehicleRole       string
 	UnitName          string
 	IsPlayer          bool

--- a/internal/model/core/soldier.go
+++ b/internal/model/core/soldier.go
@@ -4,9 +4,9 @@ package core
 import "time"
 
 // Soldier represents a player or AI unit.
-// ID is the OcapID - the game's identifier for this entity.
+// ID is the ObjectID - the game's identifier for this entity.
 type Soldier struct {
-	ID              uint16 // OcapID - game identifier
+	ID              uint16 // ObjectID - game identifier
 	MissionID       uint
 	JoinTime        time.Time
 	JoinFrame       uint
@@ -23,9 +23,9 @@ type Soldier struct {
 }
 
 // SoldierState represents soldier state at a point in time.
-// SoldierID references the Soldier's ID (OcapID).
+// SoldierID references the Soldier's ID (ObjectID).
 type SoldierState struct {
-	SoldierID         uint16 // References Soldier.ID (OcapID)
+	SoldierID         uint16 // References Soldier.ID (ObjectID)
 	MissionID         uint
 	Time              time.Time
 	CaptureFrame      uint
@@ -33,7 +33,7 @@ type SoldierState struct {
 	Bearing           uint16
 	Lifestate         uint8
 	InVehicle         bool
-	InVehicleObjectID *uint16 // OcapID of vehicle, if in one
+	InVehicleObjectID *uint16 // ObjectID of vehicle, if in one
 	VehicleRole       string
 	UnitName          string
 	IsPlayer          bool

--- a/internal/model/core/vehicle.go
+++ b/internal/model/core/vehicle.go
@@ -4,9 +4,9 @@ package core
 import "time"
 
 // Vehicle represents a vehicle or static weapon.
-// ID is the OcapID - the game's identifier for this entity.
+// ID is the ObjectID - the game's identifier for this entity.
 type Vehicle struct {
-	ID            uint16 // OcapID - game identifier
+	ID            uint16 // ObjectID - game identifier
 	MissionID     uint
 	JoinTime      time.Time
 	JoinFrame     uint
@@ -17,9 +17,9 @@ type Vehicle struct {
 }
 
 // VehicleState represents vehicle state at a point in time.
-// VehicleID references the Vehicle's ID (OcapID).
+// VehicleID references the Vehicle's ID (ObjectID).
 type VehicleState struct {
-	VehicleID       uint16 // References Vehicle.ID (OcapID)
+	VehicleID       uint16 // References Vehicle.ID (ObjectID)
 	MissionID       uint
 	Time            time.Time
 	CaptureFrame    uint

--- a/internal/model/core/vehicle.go
+++ b/internal/model/core/vehicle.go
@@ -3,24 +3,24 @@ package core
 
 import "time"
 
-// Vehicle represents a vehicle or static weapon
+// Vehicle represents a vehicle or static weapon.
+// ID is the OcapID - the game's identifier for this entity.
 type Vehicle struct {
-	ID            uint
+	ID            uint16 // OcapID - game identifier
 	MissionID     uint
 	JoinTime      time.Time
 	JoinFrame     uint
-	OcapID        uint16
 	OcapType      string
 	ClassName     string
 	DisplayName   string
 	Customization string
 }
 
-// VehicleState represents vehicle state at a point in time
+// VehicleState represents vehicle state at a point in time.
+// VehicleID references the Vehicle's ID (OcapID).
 type VehicleState struct {
-	ID              uint
+	VehicleID       uint16 // References Vehicle.ID (OcapID)
 	MissionID       uint
-	VehicleID       uint
 	Time            time.Time
 	CaptureFrame    uint
 	Position        Position3D

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -148,7 +148,7 @@ func (b *BufferLengths) TableName() string {
 
 // FrameData is the main model for a frame
 type FrameData struct {
-	OcapID       uint16         `json:"ocapId"`
+	ObjectID       uint16         `json:"ocapId"`
 	CaptureFrame uint           `json:"captureFrame"`
 	States       datatypes.JSON `json:"states"`
 	Hits         datatypes.JSON `json:"hits"`
@@ -294,10 +294,10 @@ func (*Addon) TableName() string {
 }
 
 // Soldier is a player or AI unit
-// Uses composite primary key (MissionID, OcapID) - OcapID is the game identifier
+// Uses composite primary key (MissionID, ObjectID) - ObjectID is the game identifier
 type Soldier struct {
 	MissionID   uint           `json:"missionId" gorm:"primaryKey;autoIncrement:false"`
-	OcapID      uint16         `json:"ocapId" gorm:"primaryKey;autoIncrement:false"`
+	ObjectID      uint16         `json:"ocapId" gorm:"primaryKey;autoIncrement:false"`
 	Mission     Mission        `gorm:"foreignkey:MissionID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	CreatedAt   time.Time      `json:"createdAt"`
 	UpdatedAt   time.Time      `json:"updatedAt"`
@@ -328,22 +328,22 @@ func (s *Soldier) Get(db *gorm.DB) (err error) {
 }
 
 // SoldierState tracks soldier state at a point in time
-// References Soldier by (MissionID, SoldierOcapID) composite FK
+// References Soldier by (MissionID, SoldierObjectID) composite FK
 type SoldierState struct {
 	ID             uint      `json:"id" gorm:"primarykey;autoIncrement;"`
 	Time           time.Time `json:"time" gorm:"type:timestamptz;"`
 	MissionID      uint      `json:"missionId" gorm:"index:idx_soldierstate_mission_id"`
 	Mission        Mission   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
 	CaptureFrame   uint      `json:"captureFrame" gorm:"index:idx_capture_frame"`
-	SoldierOcapID  uint16    `json:"soldierOcapId" gorm:"index:idx_soldierstate_soldier_ocap_id"`
-	Soldier        Soldier   `gorm:"foreignkey:MissionID,SoldierOcapID;references:MissionID,OcapID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	SoldierObjectID  uint16    `json:"soldierOcapId" gorm:"index:idx_soldierstate_soldier_ocap_id"`
+	Soldier        Soldier   `gorm:"foreignkey:MissionID,SoldierObjectID;references:MissionID,ObjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 
 	Position          geom.Point      `json:"position"`
 	ElevationASL      float32         `json:"elevationASL"`
 	Bearing           uint16          `json:"bearing" gorm:"default:0"`
 	Lifestate         uint8           `json:"lifestate" gorm:"default:0"`
 	InVehicle         bool            `json:"inVehicle" gorm:"default:false"`
-	InVehicleOcapID   sql.NullInt32   `json:"inVehicleOcapId" gorm:"default:NULL"`
+	InVehicleObjectID   sql.NullInt32   `json:"inVehicleOcapId" gorm:"default:NULL"`
 	VehicleRole       string          `json:"vehicleRole" gorm:"size:64"`
 	UnitName          string          `json:"unitName" gorm:"size:64"`
 	IsPlayer          bool            `json:"isPlayer" gorm:"default:false"`
@@ -369,10 +369,10 @@ type SoldierScores struct {
 }
 
 // Vehicle is a vehicle or static weapon
-// Uses composite primary key (MissionID, OcapID) - OcapID is the game identifier
+// Uses composite primary key (MissionID, ObjectID) - ObjectID is the game identifier
 type Vehicle struct {
 	MissionID     uint           `json:"missionId" gorm:"primaryKey;autoIncrement:false"`
-	OcapID        uint16         `json:"ocapId" gorm:"primaryKey;autoIncrement:false"`
+	ObjectID        uint16         `json:"ocapId" gorm:"primaryKey;autoIncrement:false"`
 	Mission       Mission        `gorm:"foreignkey:MissionID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	CreatedAt     time.Time      `json:"createdAt"`
 	UpdatedAt     time.Time      `json:"updatedAt"`
@@ -390,15 +390,15 @@ func (*Vehicle) TableName() string {
 }
 
 // VehicleState tracks vehicle state at a point in time
-// References Vehicle by (MissionID, VehicleOcapID) composite FK
+// References Vehicle by (MissionID, VehicleObjectID) composite FK
 type VehicleState struct {
 	ID            uint      `json:"id" gorm:"primarykey;autoIncrement;"`
 	Time          time.Time `json:"time" gorm:"type:timestamptz;"`
 	MissionID     uint      `json:"missionId" gorm:"index:idx_vehiclestate_mission_id"`
 	Mission       Mission   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
 	CaptureFrame  uint      `json:"captureFrame" gorm:"index:idx_vehiclestate_capture_frame"`
-	VehicleOcapID uint16    `json:"vehicleOcapId" gorm:"index:idx_vehiclestate_vehicle_ocap_id"`
-	Vehicle       Vehicle   `gorm:"foreignkey:MissionID,VehicleOcapID;references:MissionID,OcapID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	VehicleObjectID uint16    `json:"vehicleOcapId" gorm:"index:idx_vehiclestate_vehicle_ocap_id"`
+	Vehicle       Vehicle   `gorm:"foreignkey:MissionID,VehicleObjectID;references:MissionID,ObjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 
 	Position        geom.Point `json:"position"`
 	ElevationASL    float32    `json:"elevationASL"`
@@ -421,14 +421,14 @@ func (*VehicleState) TableName() string {
 }
 
 // FiredEvent represents a weapon being fired
-// References Soldier by (MissionID, SoldierOcapID) composite FK
+// References Soldier by (MissionID, SoldierObjectID) composite FK
 type FiredEvent struct {
 	ID            uint      `json:"id" gorm:"primarykey;autoIncrement;"`
 	Time          time.Time `json:"time" gorm:"type:timestamptz;"`
 	MissionID     uint      `json:"missionId" gorm:"index:idx_firedevent_mission_id"`
 	Mission       Mission   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
-	SoldierOcapID uint16    `json:"soldierOcapId" gorm:"index:idx_firedevent_soldier_ocap_id"`
-	Soldier       Soldier   `gorm:"foreignkey:MissionID,SoldierOcapID;references:MissionID,OcapID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	SoldierObjectID uint16    `json:"soldierOcapId" gorm:"index:idx_firedevent_soldier_ocap_id"`
+	Soldier       Soldier   `gorm:"foreignkey:MissionID,SoldierObjectID;references:MissionID,ObjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	CaptureFrame  uint      `json:"captureFrame" gorm:"index:idx_firedevent_capture_frame;"`
 	Weapon        string    `json:"weapon" gorm:"size:64"`
 	Magazine      string    `json:"magazine" gorm:"size:64"`
@@ -445,19 +445,19 @@ func (*FiredEvent) TableName() string {
 }
 
 // ProjectileEvent represents a weapon being fired and its lifetime
-// References Soldier by OcapID for Firer and ActualFirer
+// References Soldier by ObjectID for Firer and ActualFirer
 type ProjectileEvent struct {
 	ID                  uint          `json:"id" gorm:"primarykey;autoIncrement;"`
 	Time                time.Time     `json:"firedTime" gorm:"type:timestamptz;"`
 	MissionID           uint          `json:"missionId" gorm:"index:idx_projectile_mission_id"`
 	Mission             Mission       `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
-	FirerOcapID         uint16        `json:"firerOcapId" gorm:"index:idx_projectile_firer_ocap_id"`
-	Firer               Soldier       `gorm:"foreignkey:MissionID,FirerOcapID;references:MissionID,OcapID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
-	ActualFirerOcapID   uint16        `json:"actualFirerOcapId" gorm:"index:idx_projectile_actual_firer_ocap_id"`
-	ActualFirer         Soldier       `gorm:"foreignkey:MissionID,ActualFirerOcapID;references:MissionID,OcapID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	FirerObjectID         uint16        `json:"firerOcapId" gorm:"index:idx_projectile_firer_ocap_id"`
+	Firer               Soldier       `gorm:"foreignkey:MissionID,FirerObjectID;references:MissionID,ObjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	ActualFirerObjectID   uint16        `json:"actualFirerOcapId" gorm:"index:idx_projectile_actual_firer_ocap_id"`
+	ActualFirer         Soldier       `gorm:"foreignkey:MissionID,ActualFirerObjectID;references:MissionID,ObjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	VehicleRole         string        `json:"vehicleRole" gorm:"size:32"`
 	// omit the vehicle if nil, implying the soldier was not in one
-	VehicleOcapID sql.NullInt32 `json:"vehicleOcapId,omitempty" gorm:"index:idx_projectile_vehicle_ocap_id"`
+	VehicleObjectID sql.NullInt32 `json:"vehicleOcapId,omitempty" gorm:"index:idx_projectile_vehicle_ocap_id"`
 	CaptureFrame  uint          `json:"firedFrame" gorm:"index:idx_projectile_capture_frame;"`
 
 	Positions geom.Geometry `json:"-"`
@@ -487,8 +487,8 @@ type ProjectileHitsSoldier struct {
 	ProjectileEventID uint            `json:"projectileEventId" gorm:"index:idx_projectile_hit_soldier_projectile_event_id"`
 	ProjectileEvent   ProjectileEvent `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:ProjectileEventID;"`
 	MissionID         uint            `json:"missionId"`
-	SoldierOcapID     uint16          `json:"soldierOcapId" gorm:"index:idx_projectile_hit_soldier_ocap_id"`
-	Soldier           Soldier         `gorm:"foreignkey:MissionID,SoldierOcapID;references:MissionID,OcapID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	SoldierObjectID     uint16          `json:"soldierOcapId" gorm:"index:idx_projectile_hit_soldier_ocap_id"`
+	Soldier           Soldier         `gorm:"foreignkey:MissionID,SoldierObjectID;references:MissionID,ObjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	CaptureFrame      uint            `json:"captureFrame" gorm:"index:idx_projectile_hit_soldier_capture_frame;"`
 	Position          geom.Point      `json:"position"`
 	ComponentsHit     datatypes.JSON  `json:"componentsHit"`
@@ -499,8 +499,8 @@ type ProjectileHitsVehicle struct {
 	ProjectileEventID uint            `json:"projectileEventId" gorm:"index:idx_projectile_hit_vehicle_projectile_event_id"`
 	ProjectileEvent   ProjectileEvent `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:ProjectileEventID;"`
 	MissionID         uint            `json:"missionId"`
-	VehicleOcapID     uint16          `json:"vehicleOcapId" gorm:"index:idx_projectile_hit_vehicle_ocap_id"`
-	Vehicle           Vehicle         `gorm:"foreignkey:MissionID,VehicleOcapID;references:MissionID,OcapID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	VehicleObjectID     uint16          `json:"vehicleOcapId" gorm:"index:idx_projectile_hit_vehicle_ocap_id"`
+	Vehicle           Vehicle         `gorm:"foreignkey:MissionID,VehicleObjectID;references:MissionID,ObjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	CaptureFrame      uint            `json:"captureFrame" gorm:"index:idx_projectile_hit_vehicle_capture_frame;"`
 	Position          geom.Point      `json:"position"`
 	ComponentsHit     datatypes.JSON  `json:"componentsHit"`
@@ -523,7 +523,7 @@ func (g *GeneralEvent) TableName() string {
 }
 
 // HitEvent represents something being hit by a projectile or explosion
-// Stores OcapIDs directly - victim/shooter could be soldier or vehicle
+// Stores ObjectIDs directly - victim/shooter could be soldier or vehicle
 type HitEvent struct {
 	ID           uint      `json:"id" gorm:"primarykey;autoIncrement;"`
 	Time         time.Time `json:"time" gorm:"type:timestamptz;"`
@@ -531,11 +531,11 @@ type HitEvent struct {
 	Mission      Mission   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
 	CaptureFrame uint      `json:"captureFrame" gorm:"index:idx_hitevent_capture_frame;"`
 
-	// victim/shooter OcapIDs - nullable since could be soldier or vehicle
-	VictimSoldierOcapID  sql.NullInt32 `json:"victimSoldierOcapId" gorm:"index:idx_hitevent_victim_soldier_ocap;default:NULL"`
-	VictimVehicleOcapID  sql.NullInt32 `json:"victimVehicleOcapId" gorm:"index:idx_hitevent_victim_vehicle_ocap;default:NULL"`
-	ShooterSoldierOcapID sql.NullInt32 `json:"shooterSoldierOcapId" gorm:"index:idx_hitevent_shooter_soldier_ocap;default:NULL"`
-	ShooterVehicleOcapID sql.NullInt32 `json:"shooterVehicleOcapId" gorm:"index:idx_hitevent_shooter_vehicle_ocap;default:NULL"`
+	// victim/shooter ObjectIDs - nullable since could be soldier or vehicle
+	VictimSoldierObjectID  sql.NullInt32 `json:"victimSoldierOcapId" gorm:"index:idx_hitevent_victim_soldier_ocap;default:NULL"`
+	VictimVehicleObjectID  sql.NullInt32 `json:"victimVehicleOcapId" gorm:"index:idx_hitevent_victim_vehicle_ocap;default:NULL"`
+	ShooterSoldierObjectID sql.NullInt32 `json:"shooterSoldierOcapId" gorm:"index:idx_hitevent_shooter_soldier_ocap;default:NULL"`
+	ShooterVehicleObjectID sql.NullInt32 `json:"shooterVehicleOcapId" gorm:"index:idx_hitevent_shooter_vehicle_ocap;default:NULL"`
 
 	EventText string  `json:"eventText" gorm:"size:80"`
 	Distance  float32 `json:"distance"`
@@ -546,7 +546,7 @@ func (h *HitEvent) TableName() string {
 }
 
 // KillEvent represents something being killed
-// Stores OcapIDs directly - victim/killer could be soldier or vehicle
+// Stores ObjectIDs directly - victim/killer could be soldier or vehicle
 type KillEvent struct {
 	ID   uint      `json:"id" gorm:"primarykey;autoIncrement;"`
 	Time time.Time `json:"time" gorm:"type:timestamptz;"`
@@ -555,11 +555,11 @@ type KillEvent struct {
 	Mission      Mission `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
 	CaptureFrame uint    `json:"captureFrame" gorm:"index:idx_killevent_capture_frame;"`
 
-	// victim/killer OcapIDs - nullable since could be soldier or vehicle
-	VictimSoldierOcapID sql.NullInt32 `json:"victimSoldierOcapId" gorm:"index:idx_killevent_victim_soldier_ocap;default:NULL"`
-	VictimVehicleOcapID sql.NullInt32 `json:"victimVehicleOcapId" gorm:"index:idx_killevent_victim_vehicle_ocap;default:NULL"`
-	KillerSoldierOcapID sql.NullInt32 `json:"killerSoldierOcapId" gorm:"index:idx_killevent_killer_soldier_ocap;default:NULL"`
-	KillerVehicleOcapID sql.NullInt32 `json:"killerVehicleOcapId" gorm:"index:idx_killevent_killer_vehicle_ocap;default:NULL"`
+	// victim/killer ObjectIDs - nullable since could be soldier or vehicle
+	VictimSoldierObjectID sql.NullInt32 `json:"victimSoldierOcapId" gorm:"index:idx_killevent_victim_soldier_ocap;default:NULL"`
+	VictimVehicleObjectID sql.NullInt32 `json:"victimVehicleOcapId" gorm:"index:idx_killevent_victim_vehicle_ocap;default:NULL"`
+	KillerSoldierObjectID sql.NullInt32 `json:"killerSoldierOcapId" gorm:"index:idx_killevent_killer_soldier_ocap;default:NULL"`
+	KillerVehicleObjectID sql.NullInt32 `json:"killerVehicleOcapId" gorm:"index:idx_killevent_killer_vehicle_ocap;default:NULL"`
 
 	EventText string  `json:"eventText" gorm:"size:80"`
 	Distance  float32 `json:"distance"`
@@ -570,18 +570,18 @@ func (k *KillEvent) TableName() string {
 }
 
 // Ace3DeathEvent captures death events for medical mods (ACE3)
-// Stores OcapIDs directly
+// Stores ObjectIDs directly
 type Ace3DeathEvent struct {
 	ID            uint      `json:"id" gorm:"primarykey;autoIncrement;"`
 	Time          time.Time `json:"time" gorm:"type:timestamptz;"`
 	MissionID     uint      `json:"missionId" gorm:"index:idx_deathevent_mission_id"`
 	Mission       Mission   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
 	CaptureFrame  uint      `json:"captureFrame" gorm:"index:idx_deathevent_capture_frame;"`
-	SoldierOcapID uint16    `json:"soldierOcapId" gorm:"index:idx_deathevent_soldier_ocap_id"`
+	SoldierObjectID uint16    `json:"soldierOcapId" gorm:"index:idx_deathevent_soldier_ocap_id"`
 
 	Reason string `json:"reason"`
 
-	LastDamageSourceOcapID sql.NullInt32 `json:"lastDamageSourceOcapId" gorm:"index:idx_deathevent_last_damage_source_ocap"`
+	LastDamageSourceObjectID sql.NullInt32 `json:"lastDamageSourceOcapId" gorm:"index:idx_deathevent_last_damage_source_ocap"`
 }
 
 func (a *Ace3DeathEvent) TableName() string {
@@ -589,14 +589,14 @@ func (a *Ace3DeathEvent) TableName() string {
 }
 
 // Ace3UnconsciousEvent captures unconscious events for medical mods (ACE3)
-// Stores OcapID directly
+// Stores ObjectID directly
 type Ace3UnconsciousEvent struct {
 	ID            uint      `json:"id" gorm:"primarykey;autoIncrement;"`
 	Time          time.Time `json:"time" gorm:"type:timestamptz;"`
 	MissionID     uint      `json:"missionId" gorm:"index:idx_unconsciousevent_mission_id"`
 	Mission       Mission   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
 	CaptureFrame  uint      `json:"captureFrame" gorm:"index:idx_unconsciousevent_capture_frame;"`
-	SoldierOcapID uint16    `json:"soldierOcapId" gorm:"index:idx_unconsciousevent_soldier_ocap_id"`
+	SoldierObjectID uint16    `json:"soldierOcapId" gorm:"index:idx_unconsciousevent_soldier_ocap_id"`
 
 	IsAwake bool `json:"isAwake"`
 }
@@ -620,7 +620,7 @@ type ChatEvent struct {
 	Time          time.Time     `json:"time" gorm:"type:timestamptz;"`
 	MissionID     uint          `json:"missionId" gorm:"index:idx_chatevent_mission_id"`
 	Mission       Mission       `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
-	SoldierOcapID sql.NullInt32 `json:"soldierOcapId" gorm:"index:idx_chatevent_soldier_ocap_id;default:NULL"`
+	SoldierObjectID sql.NullInt32 `json:"soldierOcapId" gorm:"index:idx_chatevent_soldier_ocap_id;default:NULL"`
 	CaptureFrame  uint          `json:"captureFrame" gorm:"index:idx_chatevent_capture_frame;"`
 	Channel       string        `json:"channel" gorm:"size:64"`
 	FromName      string        `json:"from" gorm:"size:64"`
@@ -638,7 +638,7 @@ type RadioEvent struct {
 	Time          time.Time     `json:"time" gorm:"type:timestamptz;"`
 	MissionID     uint          `json:"missionId" gorm:"index:idx_radioevent_mission_id"`
 	Mission       Mission       `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
-	SoldierOcapID sql.NullInt32 `json:"soldierOcapId" gorm:"index:idx_radioevent_soldier_ocap_id;default:NULL"`
+	SoldierObjectID sql.NullInt32 `json:"soldierOcapId" gorm:"index:idx_radioevent_soldier_ocap_id;default:NULL"`
 	CaptureFrame  uint          `json:"captureFrame" gorm:"index:idx_radioevent_capture_frame;"`
 
 	Radio        string  `json:"radio" gorm:"size:32"`

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -244,10 +244,8 @@ type Mission struct {
 	OcapRecorderExtensionVersion string  `json:"ocapRecorderExtensionVersion" gorm:"size:64;default:1.0.0"`
 	Tag                          string  `json:"tag" gorm:"size:127"`
 
-	Addons                []Addon       `json:"-" gorm:"many2many:mission_addons;"`
-	Soldiers              []Soldier     `gorm:"foreignkey:MissionID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
-	Vehicles              []Vehicle     `gorm:"foreignkey:MissionID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
-	PlayableSlots         PlayableSlots `json:"playableSlots" gorm:"embedded;embeddedPrefix:playable_"`
+	Addons        []Addon       `json:"-" gorm:"many2many:mission_addons;"`
+	PlayableSlots PlayableSlots `json:"playableSlots" gorm:"embedded;embeddedPrefix:playable_"`
 	SideFriendly          SideFriendly  `json:"sideFriendly" gorm:"embedded;embeddedPrefix:sidefriendly_"`
 	GeneralEvents         []GeneralEvent
 	HitEvents             []HitEvent
@@ -296,29 +294,26 @@ func (*Addon) TableName() string {
 }
 
 // Soldier is a player or AI unit
+// Uses composite primary key (MissionID, OcapID) - OcapID is the game identifier
 type Soldier struct {
-	gorm.Model
-	Mission                     Mission        `gorm:"foreignkey:MissionID"`
-	MissionID                   uint           `json:"missionId"`
-	JoinTime                    time.Time      `json:"joinTime" gorm:"type:timestamptz;NOT NULL;index:idx_soldier_join_time"`
-	JoinFrame                   uint           `json:"joinFrame"`
-	OcapID                      uint16         `json:"ocapId" gorm:"index:idx_soldier_ocap_id"`
-	OcapType                    string         `json:"type" gorm:"size:16;default:man"`
-	UnitName                    string         `json:"unitName" gorm:"size:64"`
-	GroupID                     string         `json:"groupId" gorm:"size:64"`
-	Side                        string         `json:"side" gorm:"size:16"`
-	IsPlayer                    bool           `json:"isPlayer" gorm:"default:false"`
-	RoleDescription             string         `json:"roleDescription" gorm:"size:64"`
-	SquadParams                 datatypes.JSON `json:"squadParams" gorm:"type:jsonb;default:'[]'"`
-	PlayerUID                   string         `json:"playerUID" gorm:"size:64; default:NULL; index:idx_soldier_player_uid"`
-	ClassName                   string         `json:"className" gorm:"default:NULL;size:64"`
-	DisplayName                 string         `json:"displayName" gorm:"default:NULL;size:64"`
-	SoldierStates               []SoldierState
-	FiredEvents                 []FiredEvent
-	ProjectileEventsFirer       []ProjectileEvent `gorm:"foreignkey:FirerID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
-	ProjectileEventsActualFirer []ProjectileEvent `gorm:"foreignkey:ActualFirerID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
-	ChatEvents                  []ChatEvent
-	RadioEvents                 []RadioEvent
+	MissionID   uint           `json:"missionId" gorm:"primaryKey;autoIncrement:false"`
+	OcapID      uint16         `json:"ocapId" gorm:"primaryKey;autoIncrement:false"`
+	Mission     Mission        `gorm:"foreignkey:MissionID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	CreatedAt   time.Time      `json:"createdAt"`
+	UpdatedAt   time.Time      `json:"updatedAt"`
+	DeletedAt   gorm.DeletedAt `json:"deletedAt" gorm:"index"`
+	JoinTime    time.Time      `json:"joinTime" gorm:"type:timestamptz;NOT NULL;index:idx_soldier_join_time"`
+	JoinFrame   uint           `json:"joinFrame"`
+	OcapType    string         `json:"type" gorm:"size:16;default:man"`
+	UnitName    string         `json:"unitName" gorm:"size:64"`
+	GroupID     string         `json:"groupId" gorm:"size:64"`
+	Side        string         `json:"side" gorm:"size:16"`
+	IsPlayer    bool           `json:"isPlayer" gorm:"default:false"`
+	RoleDescription string     `json:"roleDescription" gorm:"size:64"`
+	SquadParams datatypes.JSON `json:"squadParams" gorm:"type:jsonb;default:'[]'"`
+	PlayerUID   string         `json:"playerUID" gorm:"size:64; default:NULL; index:idx_soldier_player_uid"`
+	ClassName   string         `json:"className" gorm:"default:NULL;size:64"`
+	DisplayName string         `json:"displayName" gorm:"default:NULL;size:64"`
 }
 
 func (*Soldier) TableName() string {
@@ -332,32 +327,31 @@ func (s *Soldier) Get(db *gorm.DB) (err error) {
 	return err
 }
 
-// SoldierState inherits from Frame
+// SoldierState tracks soldier state at a point in time
+// References Soldier by (MissionID, SoldierOcapID) composite FK
 type SoldierState struct {
-	// composite primary key with Time and OCAPID
-	ID           uint      `json:"id" gorm:"primarykey;autoIncrement;"`
-	Time         time.Time `json:"time" gorm:"type:timestamptz;"`
-	MissionID    uint      `json:"missionId" gorm:"index:idx_soldierstate_mission_id"`
-	Mission      Mission   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
-	CaptureFrame uint      `json:"captureFrame" gorm:"index:idx_capture_frame"`
-	SoldierID    uint      `json:"soldierId" gorm:"index:idx_soldierstate_soldier_id"`
-	Soldier      Soldier   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:SoldierID;"`
+	ID             uint      `json:"id" gorm:"primarykey;autoIncrement;"`
+	Time           time.Time `json:"time" gorm:"type:timestamptz;"`
+	MissionID      uint      `json:"missionId" gorm:"index:idx_soldierstate_mission_id"`
+	Mission        Mission   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
+	CaptureFrame   uint      `json:"captureFrame" gorm:"index:idx_capture_frame"`
+	SoldierOcapID  uint16    `json:"soldierOcapId" gorm:"index:idx_soldierstate_soldier_ocap_id"`
+	Soldier        Soldier   `gorm:"foreignkey:MissionID,SoldierOcapID;references:MissionID,OcapID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 
-	Position          geom.Point    `json:"position"`
-	ElevationASL      float32       `json:"elevationASL"`
-	Bearing           uint16        `json:"bearing" gorm:"default:0"`
-	Lifestate         uint8         `json:"lifestate" gorm:"default:0"`
-	InVehicle         bool          `json:"inVehicle" gorm:"default:false"`
-	InVehicleObjectID sql.NullInt32 `json:"inVehicleObjectId" gorm:"default:NULL"`
-	InVehicleObject   Vehicle       `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:InVehicleObjectID;"`
-	VehicleRole       string        `json:"vehicleRole" gorm:"size:64"`
-	UnitName          string        `json:"unitName" gorm:"size:64"`
-	IsPlayer          bool          `json:"isPlayer" gorm:"default:false"`
-	CurrentRole       string        `json:"currentRole" gorm:"size:64"`
-	HasStableVitals   bool          `json:"hasStableVitals" gorm:"default:true"`
-	IsDraggedCarried  bool          `json:"isDraggedCarried" gorm:"default:false"`
-	Stance            string        `json:"stance" gorm:"size:64"`
-	Scores            SoldierScores `json:"scores" gorm:"embedded;embeddedPrefix:scores_"`
+	Position          geom.Point      `json:"position"`
+	ElevationASL      float32         `json:"elevationASL"`
+	Bearing           uint16          `json:"bearing" gorm:"default:0"`
+	Lifestate         uint8           `json:"lifestate" gorm:"default:0"`
+	InVehicle         bool            `json:"inVehicle" gorm:"default:false"`
+	InVehicleOcapID   sql.NullInt32   `json:"inVehicleOcapId" gorm:"default:NULL"`
+	VehicleRole       string          `json:"vehicleRole" gorm:"size:64"`
+	UnitName          string          `json:"unitName" gorm:"size:64"`
+	IsPlayer          bool            `json:"isPlayer" gorm:"default:false"`
+	CurrentRole       string          `json:"currentRole" gorm:"size:64"`
+	HasStableVitals   bool            `json:"hasStableVitals" gorm:"default:true"`
+	IsDraggedCarried  bool            `json:"isDraggedCarried" gorm:"default:false"`
+	Stance            string          `json:"stance" gorm:"size:64"`
+	Scores            SoldierScores   `json:"scores" gorm:"embedded;embeddedPrefix:scores_"`
 }
 
 func (*SoldierState) TableName() string {
@@ -375,34 +369,36 @@ type SoldierScores struct {
 }
 
 // Vehicle is a vehicle or static weapon
+// Uses composite primary key (MissionID, OcapID) - OcapID is the game identifier
 type Vehicle struct {
-	gorm.Model
-	Mission       Mission   `gorm:"foreignkey:MissionID"`
-	MissionID     uint      `json:"missionId"`
-	JoinTime      time.Time `json:"joinTime" gorm:"type:timestamptz;NOT NULL;index:idx_vehicle_join_time"`
-	JoinFrame     uint      `json:"joinFrame"`
-	OcapID        uint16    `json:"ocapId" gorm:"index:idx_vehicle_ocap_id"`
-	OcapType      string    `json:"vehicleClass" gorm:"size:64"`
-	ClassName     string    `json:"className" gorm:"size:64"`
-	DisplayName   string    `json:"displayName" gorm:"size:64"`
-	Customization string    `json:"customization"`
-	VehicleStates []VehicleState
+	MissionID     uint           `json:"missionId" gorm:"primaryKey;autoIncrement:false"`
+	OcapID        uint16         `json:"ocapId" gorm:"primaryKey;autoIncrement:false"`
+	Mission       Mission        `gorm:"foreignkey:MissionID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	CreatedAt     time.Time      `json:"createdAt"`
+	UpdatedAt     time.Time      `json:"updatedAt"`
+	DeletedAt     gorm.DeletedAt `json:"deletedAt" gorm:"index"`
+	JoinTime      time.Time      `json:"joinTime" gorm:"type:timestamptz;NOT NULL;index:idx_vehicle_join_time"`
+	JoinFrame     uint           `json:"joinFrame"`
+	OcapType      string         `json:"vehicleClass" gorm:"size:64"`
+	ClassName     string         `json:"className" gorm:"size:64"`
+	DisplayName   string         `json:"displayName" gorm:"size:64"`
+	Customization string         `json:"customization"`
 }
 
 func (*Vehicle) TableName() string {
 	return "vehicles"
 }
 
-// VehicleState defines the state of a vehicle at a given time
+// VehicleState tracks vehicle state at a point in time
+// References Vehicle by (MissionID, VehicleOcapID) composite FK
 type VehicleState struct {
-	// composite primary key with Time and OCAPID
-	ID           uint      `json:"id" gorm:"primarykey;autoIncrement;"`
-	Time         time.Time `json:"time" gorm:"type:timestamptz;"`
-	MissionID    uint      `json:"missionId" gorm:"index:idx_vehiclestate_mission_id"`
-	Mission      Mission   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
-	CaptureFrame uint      `json:"captureFrame" gorm:"index:idx_vehiclestate_capture_frame"`
-	VehicleID    uint      `json:"soldierID" gorm:"index:idx_vehicle_id"`
-	Vehicle      Vehicle   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:VehicleID;"`
+	ID            uint      `json:"id" gorm:"primarykey;autoIncrement;"`
+	Time          time.Time `json:"time" gorm:"type:timestamptz;"`
+	MissionID     uint      `json:"missionId" gorm:"index:idx_vehiclestate_mission_id"`
+	Mission       Mission   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
+	CaptureFrame  uint      `json:"captureFrame" gorm:"index:idx_vehiclestate_capture_frame"`
+	VehicleOcapID uint16    `json:"vehicleOcapId" gorm:"index:idx_vehiclestate_vehicle_ocap_id"`
+	Vehicle       Vehicle   `gorm:"foreignkey:MissionID,VehicleOcapID;references:MissionID,OcapID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 
 	Position        geom.Point `json:"position"`
 	ElevationASL    float32    `json:"elevationASL"`
@@ -425,17 +421,18 @@ func (*VehicleState) TableName() string {
 }
 
 // FiredEvent represents a weapon being fired
+// References Soldier by (MissionID, SoldierOcapID) composite FK
 type FiredEvent struct {
-	ID           uint      `json:"id" gorm:"primarykey;autoIncrement;"`
-	Time         time.Time `json:"time" gorm:"type:timestamptz;"`
-	MissionID    uint      `json:"missionId" gorm:"index:idx_firedevent_mission_id"`
-	Mission      Mission   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
-	SoldierID    uint      `json:"soldierId" gorm:"index:idx_firedevent_soldier_id"`
-	Soldier      Soldier   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:SoldierID;"`
-	CaptureFrame uint      `json:"captureFrame" gorm:"index:idx_firedevent_capture_frame;"`
-	Weapon       string    `json:"weapon" gorm:"size:64"`
-	Magazine     string    `json:"magazine" gorm:"size:64"`
-	FiringMode   string    `json:"mode" gorm:"size:64"`
+	ID            uint      `json:"id" gorm:"primarykey;autoIncrement;"`
+	Time          time.Time `json:"time" gorm:"type:timestamptz;"`
+	MissionID     uint      `json:"missionId" gorm:"index:idx_firedevent_mission_id"`
+	Mission       Mission   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
+	SoldierOcapID uint16    `json:"soldierOcapId" gorm:"index:idx_firedevent_soldier_ocap_id"`
+	Soldier       Soldier   `gorm:"foreignkey:MissionID,SoldierOcapID;references:MissionID,OcapID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	CaptureFrame  uint      `json:"captureFrame" gorm:"index:idx_firedevent_capture_frame;"`
+	Weapon        string    `json:"weapon" gorm:"size:64"`
+	Magazine      string    `json:"magazine" gorm:"size:64"`
+	FiringMode    string    `json:"mode" gorm:"size:64"`
 
 	StartPosition     geom.Point `json:"startPos"`
 	StartElevationASL float32    `json:"startElev"`
@@ -447,21 +444,21 @@ func (*FiredEvent) TableName() string {
 	return "fired_events"
 }
 
-// FiredEventNew represents a weapon being fired and its lifetime
+// ProjectileEvent represents a weapon being fired and its lifetime
+// References Soldier by OcapID for Firer and ActualFirer
 type ProjectileEvent struct {
-	ID            uint      `json:"id" gorm:"primarykey;autoIncrement;"`
-	Time          time.Time `json:"firedTime" gorm:"type:timestamptz;"`
-	MissionID     uint      `json:"missionId" gorm:"index:idx_projectile_mission_id"`
-	Mission       Mission   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
-	FirerID       uint      `json:"firerID" gorm:"index:idx_projectile_firer_id"`
-	Firer         Soldier   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:FirerID;"`
-	ActualFirerID uint      `json:"remoteControllerID" gorm:"index:idx_projectile_actual_firer_id"`
-	ActualFirer   Soldier   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:ActualFirerID;"`
-	VehicleRole   string    `json:"vehicleRole" gorm:"size:32"`
+	ID                  uint          `json:"id" gorm:"primarykey;autoIncrement;"`
+	Time                time.Time     `json:"firedTime" gorm:"type:timestamptz;"`
+	MissionID           uint          `json:"missionId" gorm:"index:idx_projectile_mission_id"`
+	Mission             Mission       `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
+	FirerOcapID         uint16        `json:"firerOcapId" gorm:"index:idx_projectile_firer_ocap_id"`
+	Firer               Soldier       `gorm:"foreignkey:MissionID,FirerOcapID;references:MissionID,OcapID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	ActualFirerOcapID   uint16        `json:"actualFirerOcapId" gorm:"index:idx_projectile_actual_firer_ocap_id"`
+	ActualFirer         Soldier       `gorm:"foreignkey:MissionID,ActualFirerOcapID;references:MissionID,OcapID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	VehicleRole         string        `json:"vehicleRole" gorm:"size:32"`
 	// omit the vehicle if nil, implying the soldier was not in one
-	VehicleID    sql.NullInt32 `json:"vehicleID,omitempty" gorm:"index:idx_projectile_vehicle_id"`
-	Vehicle      Vehicle       `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:VehicleID;"`
-	CaptureFrame uint          `json:"firedFrame" gorm:"index:idx_projectile_capture_frame;"`
+	VehicleOcapID sql.NullInt32 `json:"vehicleOcapId,omitempty" gorm:"index:idx_projectile_vehicle_ocap_id"`
+	CaptureFrame  uint          `json:"firedFrame" gorm:"index:idx_projectile_capture_frame;"`
 
 	Positions geom.Geometry `json:"-"`
 
@@ -489,8 +486,9 @@ type ProjectileHitsSoldier struct {
 	ID                uint            `json:"id" gorm:"primarykey;autoIncrement;"`
 	ProjectileEventID uint            `json:"projectileEventId" gorm:"index:idx_projectile_hit_soldier_projectile_event_id"`
 	ProjectileEvent   ProjectileEvent `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:ProjectileEventID;"`
-	SoldierID         uint            `json:"soldierId" gorm:"index:idx_projectile_hit_soldier_soldier_id"`
-	Soldier           Soldier         `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:SoldierID;"`
+	MissionID         uint            `json:"missionId"`
+	SoldierOcapID     uint16          `json:"soldierOcapId" gorm:"index:idx_projectile_hit_soldier_ocap_id"`
+	Soldier           Soldier         `gorm:"foreignkey:MissionID,SoldierOcapID;references:MissionID,OcapID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	CaptureFrame      uint            `json:"captureFrame" gorm:"index:idx_projectile_hit_soldier_capture_frame;"`
 	Position          geom.Point      `json:"position"`
 	ComponentsHit     datatypes.JSON  `json:"componentsHit"`
@@ -500,8 +498,9 @@ type ProjectileHitsVehicle struct {
 	ID                uint            `json:"id" gorm:"primarykey;autoIncrement;"`
 	ProjectileEventID uint            `json:"projectileEventId" gorm:"index:idx_projectile_hit_vehicle_projectile_event_id"`
 	ProjectileEvent   ProjectileEvent `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:ProjectileEventID;"`
-	VehicleID         uint            `json:"vehicleId" gorm:"index:idx_projectile_hit_vehicle_vehicle_id"`
-	Vehicle           Vehicle         `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:VehicleID;"`
+	MissionID         uint            `json:"missionId"`
+	VehicleOcapID     uint16          `json:"vehicleOcapId" gorm:"index:idx_projectile_hit_vehicle_ocap_id"`
+	Vehicle           Vehicle         `gorm:"foreignkey:MissionID,VehicleOcapID;references:MissionID,OcapID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	CaptureFrame      uint            `json:"captureFrame" gorm:"index:idx_projectile_hit_vehicle_capture_frame;"`
 	Position          geom.Point      `json:"position"`
 	ComponentsHit     datatypes.JSON  `json:"componentsHit"`
@@ -524,6 +523,7 @@ func (g *GeneralEvent) TableName() string {
 }
 
 // HitEvent represents something being hit by a projectile or explosion
+// Stores OcapIDs directly - victim/shooter could be soldier or vehicle
 type HitEvent struct {
 	ID           uint      `json:"id" gorm:"primarykey;autoIncrement;"`
 	Time         time.Time `json:"time" gorm:"type:timestamptz;"`
@@ -531,15 +531,11 @@ type HitEvent struct {
 	Mission      Mission   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
 	CaptureFrame uint      `json:"captureFrame" gorm:"index:idx_hitevent_capture_frame;"`
 
-	// caused by could be soldier or vehicle
-	VictimSoldierID  sql.NullInt32 `json:"victimSoldierId" gorm:"index:idx_hitevent_victim_id_soldier;default:NULL"`
-	VictimSoldier    Soldier       `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:VictimSoldierID;"`
-	VictimVehicleID  sql.NullInt32 `json:"victimVehicleId" gorm:"index:idx_hitevent_victim_id_vehicle;default:NULL"`
-	VictimVehicle    Vehicle       `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:VictimVehicleID;"`
-	ShooterSoldierID sql.NullInt32 `json:"shooterSoldierId" gorm:"index:idx_shooter_id;default:NULL"`
-	ShooterSoldier   Soldier       `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:ShooterSoldierID;"`
-	ShooterVehicleID sql.NullInt32 `json:"shoooterVehicleId" gorm:"index:idx_shooter_id;default:NULL"`
-	ShooterVehicle   Vehicle       `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:ShooterVehicleID;"`
+	// victim/shooter OcapIDs - nullable since could be soldier or vehicle
+	VictimSoldierOcapID  sql.NullInt32 `json:"victimSoldierOcapId" gorm:"index:idx_hitevent_victim_soldier_ocap;default:NULL"`
+	VictimVehicleOcapID  sql.NullInt32 `json:"victimVehicleOcapId" gorm:"index:idx_hitevent_victim_vehicle_ocap;default:NULL"`
+	ShooterSoldierOcapID sql.NullInt32 `json:"shooterSoldierOcapId" gorm:"index:idx_hitevent_shooter_soldier_ocap;default:NULL"`
+	ShooterVehicleOcapID sql.NullInt32 `json:"shooterVehicleOcapId" gorm:"index:idx_hitevent_shooter_vehicle_ocap;default:NULL"`
 
 	EventText string  `json:"eventText" gorm:"size:80"`
 	Distance  float32 `json:"distance"`
@@ -550,6 +546,7 @@ func (h *HitEvent) TableName() string {
 }
 
 // KillEvent represents something being killed
+// Stores OcapIDs directly - victim/killer could be soldier or vehicle
 type KillEvent struct {
 	ID   uint      `json:"id" gorm:"primarykey;autoIncrement;"`
 	Time time.Time `json:"time" gorm:"type:timestamptz;"`
@@ -558,15 +555,11 @@ type KillEvent struct {
 	Mission      Mission `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
 	CaptureFrame uint    `json:"captureFrame" gorm:"index:idx_killevent_capture_frame;"`
 
-	// caused by could be soldier or vehicle
-	VictimIDSoldier sql.NullInt32 `json:"victimIdSoldier" gorm:"index:idx_killevent_victim_id_soldier;default:NULL"`
-	VictimSoldier   Soldier       `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:VictimIDSoldier;"`
-	VictimIDVehicle sql.NullInt32 `json:"victimIdVehicle" gorm:"index:idx_killevent_victim_id_vehicle;default:NULL"`
-	VictimVehicle   Vehicle       `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:VictimIDVehicle;"`
-	KillerIDSoldier sql.NullInt32 `json:"killerIdSoldier" gorm:"index:idx_killevent_killer_id_soldier;default:NULL"`
-	KillerSoldier   Soldier       `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:KillerIDSoldier;"`
-	KillerIDVehicle sql.NullInt32 `json:"killerIdVehicle" gorm:"index:idx_killevent_killer_id_vehicle"`
-	KillerVehicle   Vehicle       `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:KillerIDVehicle;"`
+	// victim/killer OcapIDs - nullable since could be soldier or vehicle
+	VictimSoldierOcapID sql.NullInt32 `json:"victimSoldierOcapId" gorm:"index:idx_killevent_victim_soldier_ocap;default:NULL"`
+	VictimVehicleOcapID sql.NullInt32 `json:"victimVehicleOcapId" gorm:"index:idx_killevent_victim_vehicle_ocap;default:NULL"`
+	KillerSoldierOcapID sql.NullInt32 `json:"killerSoldierOcapId" gorm:"index:idx_killevent_killer_soldier_ocap;default:NULL"`
+	KillerVehicleOcapID sql.NullInt32 `json:"killerVehicleOcapId" gorm:"index:idx_killevent_killer_vehicle_ocap;default:NULL"`
 
 	EventText string  `json:"eventText" gorm:"size:80"`
 	Distance  float32 `json:"distance"`
@@ -576,35 +569,34 @@ func (k *KillEvent) TableName() string {
 	return "kill_events"
 }
 
-// for medical mods, capture death events (ACE3)
+// Ace3DeathEvent captures death events for medical mods (ACE3)
+// Stores OcapIDs directly
 type Ace3DeathEvent struct {
-	ID           uint      `json:"id" gorm:"primarykey;autoIncrement;"`
-	Time         time.Time `json:"time" gorm:"type:timestamptz;"`
-	MissionID    uint      `json:"missionId" gorm:"index:idx_deathevent_mission_id"`
-	Mission      Mission   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
-	CaptureFrame uint      `json:"captureFrame" gorm:"index:idx_deathevent_capture_frame;"`
-	SoldierID    uint      `json:"soldierId" gorm:"index:idx_deathevent_soldier_id"`
-	Soldier      Soldier   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:SoldierID;"`
+	ID            uint      `json:"id" gorm:"primarykey;autoIncrement;"`
+	Time          time.Time `json:"time" gorm:"type:timestamptz;"`
+	MissionID     uint      `json:"missionId" gorm:"index:idx_deathevent_mission_id"`
+	Mission       Mission   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
+	CaptureFrame  uint      `json:"captureFrame" gorm:"index:idx_deathevent_capture_frame;"`
+	SoldierOcapID uint16    `json:"soldierOcapId" gorm:"index:idx_deathevent_soldier_ocap_id"`
 
 	Reason string `json:"reason"`
 
-	LastDamageSourceID sql.NullInt32 `json:"lastDamageSourceId" gorm:"index:idx_deathevent_last_damage_source_id"`
-	LastDamageSource   Soldier       `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:LastDamageSourceID;"`
+	LastDamageSourceOcapID sql.NullInt32 `json:"lastDamageSourceOcapId" gorm:"index:idx_deathevent_last_damage_source_ocap"`
 }
 
 func (a *Ace3DeathEvent) TableName() string {
 	return "ace3_death_events"
 }
 
-// for medical mods, capture unconscious events (ACE3)
+// Ace3UnconsciousEvent captures unconscious events for medical mods (ACE3)
+// Stores OcapID directly
 type Ace3UnconsciousEvent struct {
-	ID           uint      `json:"id" gorm:"primarykey;autoIncrement;"`
-	Time         time.Time `json:"time" gorm:"type:timestamptz;"`
-	MissionID    uint      `json:"missionId" gorm:"index:idx_unconsciousevent_mission_id"`
-	Mission      Mission   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
-	CaptureFrame uint      `json:"captureFrame" gorm:"index:idx_unconsciousevent_capture_frame;"`
-	SoldierID    uint      `json:"soldierId" gorm:"index:idx_unconsciousevent_soldier_id"`
-	Soldier      Soldier   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:SoldierID;"`
+	ID            uint      `json:"id" gorm:"primarykey;autoIncrement;"`
+	Time          time.Time `json:"time" gorm:"type:timestamptz;"`
+	MissionID     uint      `json:"missionId" gorm:"index:idx_unconsciousevent_mission_id"`
+	Mission       Mission   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
+	CaptureFrame  uint      `json:"captureFrame" gorm:"index:idx_unconsciousevent_capture_frame;"`
+	SoldierOcapID uint16    `json:"soldierOcapId" gorm:"index:idx_unconsciousevent_soldier_ocap_id"`
 
 	IsAwake bool `json:"isAwake"`
 }
@@ -624,18 +616,17 @@ var ChatChannels map[int]string = map[int]string{
 }
 
 type ChatEvent struct {
-	ID           uint          `json:"id" gorm:"primarykey;autoIncrement;"`
-	Time         time.Time     `json:"time" gorm:"type:timestamptz;"`
-	MissionID    uint          `json:"missionId" gorm:"index:idx_chatevent_mission_id"`
-	Mission      Mission       `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
-	SoldierID    sql.NullInt32 `json:"soldierId" gorm:"index:idx_chatevent_soldier_id;default:NULL"`
-	Soldier      Soldier       `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:SoldierID;"`
-	CaptureFrame uint          `json:"captureFrame" gorm:"index:idx_chatevent_capture_frame;"`
-	Channel      string        `json:"channel" gorm:"size:64"`
-	FromName     string        `json:"from" gorm:"size:64"`
-	SenderName   string        `json:"name" gorm:"size:64"`
-	Message      string        `json:"text"`
-	PlayerUID    string        `json:"playerUID" gorm:"size:64; default:NULL; index:idx_chatevent_player_uid"`
+	ID            uint          `json:"id" gorm:"primarykey;autoIncrement;"`
+	Time          time.Time     `json:"time" gorm:"type:timestamptz;"`
+	MissionID     uint          `json:"missionId" gorm:"index:idx_chatevent_mission_id"`
+	Mission       Mission       `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
+	SoldierOcapID sql.NullInt32 `json:"soldierOcapId" gorm:"index:idx_chatevent_soldier_ocap_id;default:NULL"`
+	CaptureFrame  uint          `json:"captureFrame" gorm:"index:idx_chatevent_capture_frame;"`
+	Channel       string        `json:"channel" gorm:"size:64"`
+	FromName      string        `json:"from" gorm:"size:64"`
+	SenderName    string        `json:"name" gorm:"size:64"`
+	Message       string        `json:"text"`
+	PlayerUID     string        `json:"playerUID" gorm:"size:64; default:NULL; index:idx_chatevent_player_uid"`
 }
 
 func (c *ChatEvent) TableName() string {
@@ -643,13 +634,12 @@ func (c *ChatEvent) TableName() string {
 }
 
 type RadioEvent struct {
-	ID           uint          `json:"id" gorm:"primarykey;autoIncrement;"`
-	Time         time.Time     `json:"time" gorm:"type:timestamptz;"`
-	MissionID    uint          `json:"missionId" gorm:"index:idx_radioevent_mission_id"`
-	Mission      Mission       `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
-	SoldierID    sql.NullInt32 `json:"soldierId" gorm:"index:idx_radioevent_soldier_id;default:NULL"`
-	Soldier      Soldier       `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:SoldierID;"`
-	CaptureFrame uint          `json:"captureFrame" gorm:"index:idx_radioevent_capture_frame;"`
+	ID            uint          `json:"id" gorm:"primarykey;autoIncrement;"`
+	Time          time.Time     `json:"time" gorm:"type:timestamptz;"`
+	MissionID     uint          `json:"missionId" gorm:"index:idx_radioevent_mission_id"`
+	Mission       Mission       `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
+	SoldierOcapID sql.NullInt32 `json:"soldierOcapId" gorm:"index:idx_radioevent_soldier_ocap_id;default:NULL"`
+	CaptureFrame  uint          `json:"captureFrame" gorm:"index:idx_radioevent_capture_frame;"`
 
 	Radio        string  `json:"radio" gorm:"size:32"`
 	RadioType    string  `json:"radioType" gorm:"size:8"`

--- a/internal/storage/memory/export.go
+++ b/internal/storage/memory/export.go
@@ -113,7 +113,7 @@ func (b *Backend) buildExport() OcapExport {
 	// Convert soldiers
 	for _, record := range b.soldiers {
 		entity := EntityJSON{
-			ID:            record.Soldier.ID, // ID is the OcapID
+			ID:            record.Soldier.ID, // ID is the ObjectID
 			Name:          record.Soldier.UnitName,
 			Group:         record.Soldier.GroupID,
 			Side:          record.Soldier.Side,
@@ -158,7 +158,7 @@ func (b *Backend) buildExport() OcapExport {
 	// Convert vehicles
 	for _, record := range b.vehicles {
 		entity := EntityJSON{
-			ID:            record.Vehicle.ID, // ID is the OcapID
+			ID:            record.Vehicle.ID, // ID is the ObjectID
 			Name:          record.Vehicle.DisplayName,
 			Side:          "UNKNOWN",
 			IsPlayer:      0,

--- a/internal/storage/memory/export.go
+++ b/internal/storage/memory/export.go
@@ -113,7 +113,7 @@ func (b *Backend) buildExport() OcapExport {
 	// Convert soldiers
 	for _, record := range b.soldiers {
 		entity := EntityJSON{
-			ID:            record.Soldier.OcapID,
+			ID:            record.Soldier.ID, // ID is the OcapID
 			Name:          record.Soldier.UnitName,
 			Group:         record.Soldier.GroupID,
 			Side:          record.Soldier.Side,
@@ -158,7 +158,7 @@ func (b *Backend) buildExport() OcapExport {
 	// Convert vehicles
 	for _, record := range b.vehicles {
 		entity := EntityJSON{
-			ID:            record.Vehicle.OcapID,
+			ID:            record.Vehicle.ID, // ID is the OcapID
 			Name:          record.Vehicle.DisplayName,
 			Side:          "UNKNOWN",
 			IsPlayer:      0,

--- a/internal/storage/memory/export_test.go
+++ b/internal/storage/memory/export_test.go
@@ -6,33 +6,29 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/OCAP2/extension/v5/internal/config"
 	"github.com/OCAP2/extension/v5/internal/model/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBoolToInt(t *testing.T) {
-	tests := []struct {
-		input    bool
-		expected int
-	}{
-		{true, 1},
-		{false, 0},
-	}
-
-	for _, tt := range tests {
-		result := boolToInt(tt.input)
-		if result != tt.expected {
-			t.Errorf("boolToInt(%v) = %d, want %d", tt.input, result, tt.expected)
-		}
-	}
+	assert.Equal(t, 1, boolToInt(true))
+	assert.Equal(t, 0, boolToInt(false))
 }
 
-func TestBuildExport(t *testing.T) {
-	b := New(config.MemoryConfig{})
+// TestIntegrationFullExport is a comprehensive integration test that verifies the full flow:
+// start mission -> add entities (soldier, vehicle, marker) -> record states/events -> export JSON -> verify output
+func TestIntegrationFullExport(t *testing.T) {
+	tempDir := t.TempDir()
+
+	b := New(config.MemoryConfig{
+		OutputDir:      tempDir,
+		CompressOutput: false,
+	})
 
 	mission := &core.Mission{
 		MissionName:      "Test Mission",
@@ -46,218 +42,119 @@ func TestBuildExport(t *testing.T) {
 		WorldName: "Altis",
 	}
 
-	_ = b.StartMission(mission, world)
+	require.NoError(t, b.StartMission(mission, world))
+	require.NoError(t, b.AddSoldier(&core.Soldier{
+		ID: 1, UnitName: "Player1", GroupID: "Alpha", Side: "WEST", IsPlayer: true, JoinFrame: 0,
+	}))
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{
+		SoldierID: 1, CaptureFrame: 0, Position: core.Position3D{X: 1000, Y: 2000, Z: 100},
+		Bearing: 90, Lifestate: 1, UnitName: "Player1", IsPlayer: true, CurrentRole: "Rifleman",
+	}))
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{
+		SoldierID: 1, CaptureFrame: 10, Position: core.Position3D{X: 1050, Y: 2050, Z: 100},
+		Bearing: 95, Lifestate: 1, UnitName: "Player1", IsPlayer: true, CurrentRole: "Rifleman",
+	}))
+	require.NoError(t, b.RecordFiredEvent(&core.FiredEvent{
+		SoldierID: 1, CaptureFrame: 5, Weapon: "arifle_MX_F", Magazine: "30Rnd_65x39_caseless_mag",
+		FiringMode: "Single", StartPos: core.Position3D{X: 1000, Y: 2000, Z: 1.5}, EndPos: core.Position3D{X: 1100, Y: 2100, Z: 1.5},
+	}))
+	require.NoError(t, b.AddVehicle(&core.Vehicle{
+		ID: 10, ClassName: "B_MRAP_01_F", DisplayName: "Hunter", OcapType: "car", JoinFrame: 2,
+	}))
+	require.NoError(t, b.RecordVehicleState(&core.VehicleState{
+		VehicleID: 10, CaptureFrame: 5, Position: core.Position3D{X: 3000, Y: 4000, Z: 50},
+		Bearing: 180, IsAlive: true, Crew: "[[1,\"driver\"]]",
+	}))
+	require.NoError(t, b.AddMarker(&core.Marker{
+		MarkerName: "objective_1", Text: "Objective Alpha", MarkerType: "mil_objective",
+		Color: "ColorBLUFOR", Side: "WEST", Shape: "ICON", CaptureFrame: 0,
+		Position: core.Position3D{X: 5000, Y: 6000, Z: 0}, Direction: 0, Alpha: 1.0,
+	}))
+	require.NoError(t, b.RecordMarkerState(&core.MarkerState{
+		MarkerID: 0, CaptureFrame: 20, Position: core.Position3D{X: 5100, Y: 6100, Z: 0}, Direction: 45, Alpha: 0.8,
+	}))
+	require.NoError(t, b.RecordGeneralEvent(&core.GeneralEvent{
+		CaptureFrame: 15, Name: "connected", Message: "Player1 connected", ExtraData: map[string]any{"uid": "12345"},
+	}))
+	require.NoError(t, b.EndMission())
 
-	// Add soldier with states and fired events
-	soldier := &core.Soldier{
-		ID:    1,
-		UnitName:  "Player1",
-		GroupID:   "Alpha",
-		Side:      "WEST",
-		IsPlayer:  true,
-		JoinFrame: 0,
-	}
-	_ = b.AddSoldier(soldier)
+	// Find and read the exported JSON file
+	pattern := filepath.Join(tempDir, "Test_Mission_*.json")
+	matches, err := filepath.Glob(pattern)
+	require.NoError(t, err)
+	require.Len(t, matches, 1, "expected 1 JSON file")
 
-	state1 := &core.SoldierState{
-		SoldierID:     soldier.ID,
-				CaptureFrame:  0,
-		Position:      core.Position3D{X: 1000, Y: 2000, Z: 100},
-		Bearing:       90,
-		Lifestate:     1,
-		UnitName:      "Player1",
-		IsPlayer:      true,
-		CurrentRole:   "Rifleman",
-	}
-	state2 := &core.SoldierState{
-		SoldierID:     soldier.ID,
-				CaptureFrame:  10,
-		Position:      core.Position3D{X: 1050, Y: 2050, Z: 100},
-		Bearing:       95,
-		Lifestate:     1,
-		UnitName:      "Player1",
-		IsPlayer:      true,
-		CurrentRole:   "Rifleman",
-	}
-	_ = b.RecordSoldierState(state1)
-	_ = b.RecordSoldierState(state2)
+	data, err := os.ReadFile(matches[0])
+	require.NoError(t, err)
 
-	fired := &core.FiredEvent{
-		SoldierID:     soldier.ID,
-				CaptureFrame:  5,
-		Weapon:        "arifle_MX_F",
-		Magazine:      "30Rnd_65x39_caseless_mag",
-		FiringMode:    "Single",
-		StartPos:      core.Position3D{X: 1000, Y: 2000, Z: 1.5},
-		EndPos:        core.Position3D{X: 1100, Y: 2100, Z: 1.5},
-	}
-	_ = b.RecordFiredEvent(fired)
-
-	// Add vehicle with states
-	vehicle := &core.Vehicle{
-		ID:      10,
-		ClassName:   "B_MRAP_01_F",
-		DisplayName: "Hunter",
-		OcapType:    "car",
-		JoinFrame:   2,
-	}
-	_ = b.AddVehicle(vehicle)
-
-	vState := &core.VehicleState{
-		VehicleID:     vehicle.ID,
-				CaptureFrame:  5,
-		Position:      core.Position3D{X: 3000, Y: 4000, Z: 50},
-		Bearing:       180,
-		IsAlive:       true,
-		Crew:          "[[1,\"driver\"]]",
-	}
-	_ = b.RecordVehicleState(vState)
-
-	// Add marker with states
-	marker := &core.Marker{
-		MarkerName:   "objective_1",
-		Text:         "Objective Alpha",
-		MarkerType:   "mil_objective",
-		Color:        "ColorBLUFOR",
-		Side:         "WEST",
-		Shape:        "ICON",
-		CaptureFrame: 0,
-		Position:     core.Position3D{X: 5000, Y: 6000, Z: 0},
-		Direction:    0,
-		Alpha:        1.0,
-	}
-	_ = b.AddMarker(marker)
-
-	mState := &core.MarkerState{
-		MarkerID:     marker.ID,
-		CaptureFrame: 20,
-		Position:     core.Position3D{X: 5100, Y: 6100, Z: 0},
-		Direction:    45,
-		Alpha:        0.8,
-	}
-	_ = b.RecordMarkerState(mState)
-
-	// Add general event
-	evt := &core.GeneralEvent{
-		CaptureFrame: 15,
-		Name:         "connected",
-		Message:      "Player1 connected",
-		ExtraData:    map[string]any{"uid": "12345"},
-	}
-	_ = b.RecordGeneralEvent(evt)
-
-	// Build export
-	export := b.buildExport()
+	var export OcapExport
+	require.NoError(t, json.Unmarshal(data, &export))
 
 	// Verify mission metadata
-	if export.MissionName != "Test Mission" {
-		t.Errorf("expected MissionName='Test Mission', got '%s'", export.MissionName)
-	}
-	if export.MissionAuthor != "Test Author" {
-		t.Errorf("expected MissionAuthor='Test Author', got '%s'", export.MissionAuthor)
-	}
-	if export.WorldName != "Altis" {
-		t.Errorf("expected WorldName='Altis', got '%s'", export.WorldName)
-	}
-	if export.CaptureDelay != 1.0 {
-		t.Errorf("expected CaptureDelay=1.0, got %f", export.CaptureDelay)
-	}
-	if export.AddonVersion != "1.0.0" {
-		t.Errorf("expected AddonVersion='1.0.0', got '%s'", export.AddonVersion)
-	}
-	if export.ExtensionVersion != "2.0.0" {
-		t.Errorf("expected ExtensionVersion='2.0.0', got '%s'", export.ExtensionVersion)
-	}
+	assert.Equal(t, "Test Mission", export.MissionName)
+	assert.Equal(t, "Test Author", export.MissionAuthor)
+	assert.Equal(t, "Altis", export.WorldName)
+	assert.Equal(t, float32(1.0), export.CaptureDelay)
+	assert.Equal(t, "1.0.0", export.AddonVersion)
+	assert.Equal(t, "2.0.0", export.ExtensionVersion)
+	assert.Equal(t, uint(10), export.EndFrame, "EndFrame should be max state frame")
 
-	// Verify EndFrame is maximum frame from states
-	if export.EndFrame != 10 {
-		t.Errorf("expected EndFrame=10, got %d", export.EndFrame)
-	}
+	// Verify entities (1 soldier + 1 vehicle)
+	require.Len(t, export.Entities, 2)
 
-	// Verify entities
-	if len(export.Entities) != 2 {
-		t.Fatalf("expected 2 entities, got %d", len(export.Entities))
-	}
-
-	// Find soldier entity
+	// Find soldier and vehicle entities
 	var soldierEntity, vehicleEntity *EntityJSON
 	for i := range export.Entities {
-		if export.Entities[i].Type == "unit" {
+		switch export.Entities[i].Type {
+		case "unit":
 			soldierEntity = &export.Entities[i]
-		} else {
+		case "car":
 			vehicleEntity = &export.Entities[i]
 		}
 	}
 
-	if soldierEntity == nil {
-		t.Fatal("soldier entity not found")
-	}
-	if soldierEntity.ID != 1 {
-		t.Errorf("expected soldier ID=1, got %d", soldierEntity.ID)
-	}
-	if soldierEntity.Name != "Player1" {
-		t.Errorf("expected soldier Name='Player1', got '%s'", soldierEntity.Name)
-	}
-	if soldierEntity.Group != "Alpha" {
-		t.Errorf("expected soldier Group='Alpha', got '%s'", soldierEntity.Group)
-	}
-	if soldierEntity.Side != "WEST" {
-		t.Errorf("expected soldier Side='WEST', got '%s'", soldierEntity.Side)
-	}
-	if soldierEntity.IsPlayer != 1 {
-		t.Errorf("expected soldier IsPlayer=1, got %d", soldierEntity.IsPlayer)
-	}
-	if len(soldierEntity.Positions) != 2 {
-		t.Errorf("expected 2 positions, got %d", len(soldierEntity.Positions))
-	}
-	if len(soldierEntity.FramesFired) != 1 {
-		t.Errorf("expected 1 framesFired, got %d", len(soldierEntity.FramesFired))
-	}
+	// Verify soldier entity
+	require.NotNil(t, soldierEntity, "soldier entity not found")
+	assert.Equal(t, uint16(1), soldierEntity.ID)
+	assert.Equal(t, "Player1", soldierEntity.Name)
+	assert.Equal(t, "Alpha", soldierEntity.Group)
+	assert.Equal(t, "WEST", soldierEntity.Side)
+	assert.Equal(t, 1, soldierEntity.IsPlayer)
+	require.Len(t, soldierEntity.Positions, 2)
+	require.Len(t, soldierEntity.FramesFired, 1)
 
-	if vehicleEntity == nil {
-		t.Fatal("vehicle entity not found")
-	}
-	if vehicleEntity.ID != 10 {
-		t.Errorf("expected vehicle ID=10, got %d", vehicleEntity.ID)
-	}
-	if vehicleEntity.Name != "Hunter" {
-		t.Errorf("expected vehicle Name='Hunter', got '%s'", vehicleEntity.Name)
-	}
-	if vehicleEntity.Type != "car" {
-		t.Errorf("expected vehicle Type='car', got '%s'", vehicleEntity.Type)
-	}
-	if vehicleEntity.Class != "B_MRAP_01_F" {
-		t.Errorf("expected vehicle Class='B_MRAP_01_F', got '%s'", vehicleEntity.Class)
-	}
-	if len(vehicleEntity.Positions) != 1 {
-		t.Errorf("expected 1 position, got %d", len(vehicleEntity.Positions))
-	}
+	// Verify soldier position coordinates after JSON round-trip
+	coords, ok := soldierEntity.Positions[0][0].([]any)
+	require.True(t, ok, "position coords should be []any after JSON unmarshal")
+	assert.Equal(t, 1000.0, coords[0])
+	assert.Equal(t, 2000.0, coords[1])
+
+	// Verify fired event
+	ff := soldierEntity.FramesFired[0]
+	assert.Equal(t, 5.0, ff[0]) // JSON unmarshals numbers as float64
+	assert.Equal(t, "arifle_MX_F", ff[3])
+
+	// Verify vehicle entity
+	require.NotNil(t, vehicleEntity, "vehicle entity not found")
+	assert.Equal(t, uint16(10), vehicleEntity.ID)
+	assert.Equal(t, "Hunter", vehicleEntity.Name)
+	assert.Equal(t, "car", vehicleEntity.Type)
+	assert.Equal(t, "B_MRAP_01_F", vehicleEntity.Class)
+	require.Len(t, vehicleEntity.Positions, 1)
 
 	// Verify events
-	if len(export.Events) != 1 {
-		t.Fatalf("expected 1 event, got %d", len(export.Events))
-	}
-	if export.Events[0].Type != "connected" {
-		t.Errorf("expected event Type='connected', got '%s'", export.Events[0].Type)
-	}
-	if export.Events[0].Frame != 15 {
-		t.Errorf("expected event Frame=15, got %d", export.Events[0].Frame)
-	}
+	require.Len(t, export.Events, 1)
+	assert.Equal(t, "connected", export.Events[0].Type)
+	assert.Equal(t, uint(15), export.Events[0].Frame)
+	assert.Equal(t, "Player1 connected", export.Events[0].Message)
 
 	// Verify markers
-	if len(export.Markers) != 1 {
-		t.Fatalf("expected 1 marker, got %d", len(export.Markers))
-	}
-	if export.Markers[0].Name != "Objective Alpha" {
-		t.Errorf("expected marker Name='Objective Alpha', got '%s'", export.Markers[0].Name)
-	}
-	if export.Markers[0].Type != "mil_objective" {
-		t.Errorf("expected marker Type='mil_objective', got '%s'", export.Markers[0].Type)
-	}
-	// Initial position + 1 state change = 2 positions
-	if len(export.Markers[0].Positions) != 2 {
-		t.Errorf("expected 2 marker positions, got %d", len(export.Markers[0].Positions))
-	}
+	require.Len(t, export.Markers, 1)
+	assert.Equal(t, "Objective Alpha", export.Markers[0].Name)
+	assert.Equal(t, "mil_objective", export.Markers[0].Type)
+	assert.Equal(t, "ColorBLUFOR", export.Markers[0].Color)
+	assert.Equal(t, "WEST", export.Markers[0].Side)
+	assert.Len(t, export.Markers[0].Positions, 2, "initial position + 1 state change")
 }
 
 func TestExportJSON(t *testing.T) {
@@ -268,100 +165,50 @@ func TestExportJSON(t *testing.T) {
 		CompressOutput: false,
 	})
 
-	mission := &core.Mission{
-		MissionName: "Export Test",
-		Author:      "Author",
-		StartTime:   time.Date(2024, 3, 15, 14, 30, 0, 0, time.UTC),
-	}
-	world := &core.World{WorldName: "Tanoa"}
+	require.NoError(t, b.StartMission(&core.Mission{
+		MissionName: "Export Test", Author: "Author", StartTime: time.Date(2024, 3, 15, 14, 30, 0, 0, time.UTC),
+	}, &core.World{WorldName: "Tanoa"}))
+	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Test"}))
+	require.NoError(t, b.EndMission())
 
-	_ = b.StartMission(mission, world)
-	_ = b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Test"})
+	matches, err := filepath.Glob(filepath.Join(tempDir, "Export_Test_*.json"))
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
 
-	// EndMission triggers export
-	if err := b.EndMission(); err != nil {
-		t.Fatalf("EndMission failed: %v", err)
-	}
-
-	// Check file was created
-	pattern := filepath.Join(tempDir, "Export_Test_*.json")
-	matches, err := filepath.Glob(pattern)
-	if err != nil {
-		t.Fatalf("Glob failed: %v", err)
-	}
-	if len(matches) != 1 {
-		t.Fatalf("expected 1 JSON file, found %d", len(matches))
-	}
-
-	// Read and validate JSON
 	data, err := os.ReadFile(matches[0])
-	if err != nil {
-		t.Fatalf("failed to read output file: %v", err)
-	}
+	require.NoError(t, err)
 
 	var export OcapExport
-	if err := json.Unmarshal(data, &export); err != nil {
-		t.Fatalf("failed to unmarshal JSON: %v", err)
-	}
-
-	if export.MissionName != "Export Test" {
-		t.Errorf("expected MissionName='Export Test', got '%s'", export.MissionName)
-	}
+	require.NoError(t, json.Unmarshal(data, &export))
+	assert.Equal(t, "Export Test", export.MissionName)
 }
 
 func TestExportGzipJSON(t *testing.T) {
 	tempDir := t.TempDir()
 
-	b := New(config.MemoryConfig{
-		OutputDir:      tempDir,
-		CompressOutput: true,
-	})
+	b := New(config.MemoryConfig{OutputDir: tempDir, CompressOutput: true})
 
-	mission := &core.Mission{
-		MissionName: "Gzip Test",
-		Author:      "Author",
-		StartTime:   time.Date(2024, 3, 15, 14, 30, 0, 0, time.UTC),
-	}
-	world := &core.World{WorldName: "Livonia"}
+	require.NoError(t, b.StartMission(&core.Mission{
+		MissionName: "Gzip Test", Author: "Author", StartTime: time.Date(2024, 3, 15, 14, 30, 0, 0, time.UTC),
+	}, &core.World{WorldName: "Livonia"}))
+	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Test"}))
+	require.NoError(t, b.EndMission())
 
-	_ = b.StartMission(mission, world)
-	_ = b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Test"})
+	matches, err := filepath.Glob(filepath.Join(tempDir, "Gzip_Test_*.json.gz"))
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
 
-	if err := b.EndMission(); err != nil {
-		t.Fatalf("EndMission failed: %v", err)
-	}
-
-	// Check .json.gz file was created
-	pattern := filepath.Join(tempDir, "Gzip_Test_*.json.gz")
-	matches, err := filepath.Glob(pattern)
-	if err != nil {
-		t.Fatalf("Glob failed: %v", err)
-	}
-	if len(matches) != 1 {
-		t.Fatalf("expected 1 .json.gz file, found %d", len(matches))
-	}
-
-	// Read and decompress
 	f, err := os.Open(matches[0])
-	if err != nil {
-		t.Fatalf("failed to open gzip file: %v", err)
-	}
+	require.NoError(t, err)
 	defer f.Close()
 
 	gzReader, err := gzip.NewReader(f)
-	if err != nil {
-		t.Fatalf("failed to create gzip reader: %v", err)
-	}
+	require.NoError(t, err)
 	defer gzReader.Close()
 
 	var export OcapExport
-	if err := json.NewDecoder(gzReader).Decode(&export); err != nil {
-		t.Fatalf("failed to decode gzipped JSON: %v", err)
-	}
-
-	if export.MissionName != "Gzip Test" {
-		t.Errorf("expected MissionName='Gzip Test', got '%s'", export.MissionName)
-	}
+	require.NoError(t, json.NewDecoder(gzReader).Decode(&export))
+	assert.Equal(t, "Gzip Test", export.MissionName)
 }
 
 func TestFilenameGeneration(t *testing.T) {
@@ -379,36 +226,18 @@ func TestFilenameGeneration(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		b := New(config.MemoryConfig{
-			OutputDir:      tempDir,
-			CompressOutput: tt.compress,
-		})
+		b := New(config.MemoryConfig{OutputDir: tempDir, CompressOutput: tt.compress})
 
-		mission := &core.Mission{
-			MissionName: tt.missionName,
-			StartTime:   time.Now(),
-		}
-		world := &core.World{WorldName: "Test"}
+		require.NoError(t, b.StartMission(&core.Mission{MissionName: tt.missionName, StartTime: time.Now()}, &core.World{WorldName: "Test"}))
+		require.NoError(t, b.EndMission())
 
-		_ = b.StartMission(mission, world)
-		_ = b.EndMission()
+		matches, err := filepath.Glob(filepath.Join(tempDir, "*"+tt.expectedSuffix))
+		require.NoError(t, err)
+		require.NotEmpty(t, matches, "no file with suffix %s found for mission '%s'", tt.expectedSuffix, tt.missionName)
 
-		// Find the file
-		pattern := filepath.Join(tempDir, "*"+tt.expectedSuffix)
-		matches, _ := filepath.Glob(pattern)
-		if len(matches) == 0 {
-			t.Errorf("no file with suffix %s found for mission '%s'", tt.expectedSuffix, tt.missionName)
-			continue
-		}
-
-		// Check filename doesn't contain spaces or colons
 		filename := filepath.Base(matches[len(matches)-1])
-		if strings.Contains(filename, " ") {
-			t.Errorf("filename contains spaces: %s", filename)
-		}
-		if strings.Contains(filename, ":") {
-			t.Errorf("filename contains colons: %s", filename)
-		}
+		assert.NotContains(t, filename, " ", "filename should not contain spaces")
+		assert.NotContains(t, filename, ":", "filename should not contain colons")
 	}
 }
 
@@ -427,478 +256,231 @@ func TestExportCreatesOutputDir(t *testing.T) {
 	}
 	world := &core.World{WorldName: "Test"}
 
-	_ = b.StartMission(mission, world)
-	if err := b.EndMission(); err != nil {
-		t.Fatalf("EndMission failed: %v", err)
-	}
+	require.NoError(t, b.StartMission(mission, world))
+	require.NoError(t, b.EndMission())
 
-	// Verify directory was created
-	if _, err := os.Stat(nonExistentDir); os.IsNotExist(err) {
-		t.Error("output directory was not created")
-	}
+	_, err := os.Stat(nonExistentDir)
+	require.NoError(t, err, "output directory should be created")
 
-	// Verify file exists in nested directory
 	pattern := filepath.Join(nonExistentDir, "*.json")
-	matches, _ := filepath.Glob(pattern)
-	if len(matches) != 1 {
-		t.Errorf("expected 1 file in nested dir, found %d", len(matches))
-	}
+	matches, err := filepath.Glob(pattern)
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
 }
 
 func TestSoldierPositionFormat(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
-	mission := &core.Mission{MissionName: "Test", StartTime: time.Now()}
-	world := &core.World{WorldName: "Test"}
-	_ = b.StartMission(mission, world)
-
-	soldier := &core.Soldier{ID: 1, UnitName: "Player1", IsPlayer: true}
-	_ = b.AddSoldier(soldier)
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
+	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Player1", IsPlayer: true}))
 
 	inVehicleID := uint16(100)
-	state := &core.SoldierState{
-		SoldierID:         soldier.ID,
-		CaptureFrame:      5,
-		Position:          core.Position3D{X: 1234.56, Y: 7890.12, Z: 50},
-		Bearing:           270,
-		Lifestate:         1,
-		InVehicleObjectID: &inVehicleID,
-		UnitName:          "Player1_InVeh",
-		IsPlayer:          true,
-		CurrentRole:       "Gunner",
-	}
-	_ = b.RecordSoldierState(state)
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{
+		SoldierID: 1, CaptureFrame: 5, Position: core.Position3D{X: 1234.56, Y: 7890.12, Z: 50},
+		Bearing: 270, Lifestate: 1, InVehicleObjectID: &inVehicleID,
+		UnitName: "Player1_InVeh", IsPlayer: true, CurrentRole: "Gunner",
+	}))
 
 	export := b.buildExport()
 
-	if len(export.Entities) != 1 {
-		t.Fatalf("expected 1 entity, got %d", len(export.Entities))
-	}
+	require.Len(t, export.Entities, 1)
+	require.Len(t, export.Entities[0].Positions, 1)
 
-	entity := export.Entities[0]
-	if len(entity.Positions) != 1 {
-		t.Fatalf("expected 1 position, got %d", len(entity.Positions))
-	}
+	pos := export.Entities[0].Positions[0]
+	require.Len(t, pos, 7) // [[x, y], bearing, lifestate, inVehicleObjectID, unitName, isPlayer, currentRole]
 
-	pos := entity.Positions[0]
-	// Position format: [[x, y], bearing, lifestate, inVehicleObjectID, unitName, isPlayer, currentRole]
-	if len(pos) != 7 {
-		t.Fatalf("expected position array length 7, got %d", len(pos))
-	}
-
-	// Check coordinate array
 	coords, ok := pos[0].([]float64)
-	if !ok {
-		t.Fatal("position[0] is not []float64")
-	}
-	if coords[0] != 1234.56 || coords[1] != 7890.12 {
-		t.Errorf("expected coords [1234.56, 7890.12], got %v", coords)
-	}
-
-	// Check bearing
-	if pos[1].(uint16) != 270 {
-		t.Errorf("expected bearing=270, got %v", pos[1])
-	}
-
-	// Check lifestate
-	if pos[2].(uint8) != 1 {
-		t.Errorf("expected lifestate=1, got %v", pos[2])
-	}
-
-	// Check isPlayer (should be 1 for true)
-	if pos[5].(int) != 1 {
-		t.Errorf("expected isPlayer=1, got %v", pos[5])
-	}
+	require.True(t, ok, "position[0] should be []float64")
+	assert.Equal(t, 1234.56, coords[0])
+	assert.Equal(t, 7890.12, coords[1])
+	assert.Equal(t, uint16(270), pos[1])
+	assert.Equal(t, uint8(1), pos[2])
+	assert.Equal(t, 1, pos[5])
 }
 
 func TestVehiclePositionFormat(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
-	mission := &core.Mission{MissionName: "Test", StartTime: time.Now()}
-	world := &core.World{WorldName: "Test"}
-	_ = b.StartMission(mission, world)
-
-	vehicle := &core.Vehicle{ID: 10, DisplayName: "Hunter", OcapType: "car"}
-	_ = b.AddVehicle(vehicle)
-
-	state := &core.VehicleState{
-		VehicleID:     vehicle.ID,
-				CaptureFrame:  3,
-		Position:      core.Position3D{X: 5000, Y: 6000, Z: 25},
-		Bearing:       45,
-		IsAlive:       true,
-		Crew:          "[[1,\"driver\"],[2,\"gunner\"]]",
-	}
-	_ = b.RecordVehicleState(state)
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
+	require.NoError(t, b.AddVehicle(&core.Vehicle{ID: 10, DisplayName: "Hunter", OcapType: "car"}))
+	require.NoError(t, b.RecordVehicleState(&core.VehicleState{
+		VehicleID: 10, CaptureFrame: 3, Position: core.Position3D{X: 5000, Y: 6000, Z: 25},
+		Bearing: 45, IsAlive: true, Crew: "[[1,\"driver\"],[2,\"gunner\"]]",
+	}))
 
 	export := b.buildExport()
 
-	if len(export.Entities) != 1 {
-		t.Fatalf("expected 1 entity, got %d", len(export.Entities))
-	}
+	require.Len(t, export.Entities, 1)
+	require.Len(t, export.Entities[0].Positions, 1)
 
-	entity := export.Entities[0]
-	if len(entity.Positions) != 1 {
-		t.Fatalf("expected 1 position, got %d", len(entity.Positions))
-	}
+	pos := export.Entities[0].Positions[0]
+	require.Len(t, pos, 4) // [[x, y], bearing, isAlive, crew]
 
-	pos := entity.Positions[0]
-	// Vehicle position format: [[x, y], bearing, isAlive, crew]
-	if len(pos) != 4 {
-		t.Fatalf("expected position array length 4, got %d", len(pos))
-	}
-
-	// Check coordinate array
 	coords, ok := pos[0].([]float64)
-	if !ok {
-		t.Fatal("position[0] is not []float64")
-	}
-	if coords[0] != 5000 || coords[1] != 6000 {
-		t.Errorf("expected coords [5000, 6000], got %v", coords)
-	}
-
-	// Check isAlive (should be 1 for true)
-	if pos[2].(int) != 1 {
-		t.Errorf("expected isAlive=1, got %v", pos[2])
-	}
+	require.True(t, ok, "position[0] should be []float64")
+	assert.Equal(t, 5000.0, coords[0])
+	assert.Equal(t, 6000.0, coords[1])
+	assert.Equal(t, 1, pos[2])
 }
 
 func TestFiredEventFormat(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
-	mission := &core.Mission{MissionName: "Test", StartTime: time.Now()}
-	world := &core.World{WorldName: "Test"}
-	_ = b.StartMission(mission, world)
-
-	soldier := &core.Soldier{ID: 1}
-	_ = b.AddSoldier(soldier)
-
-	fired := &core.FiredEvent{
-		SoldierID:     soldier.ID,
-				CaptureFrame:  100,
-		Weapon:        "arifle_MX_F",
-		Magazine:      "30Rnd_65x39_caseless_mag",
-		FiringMode:    "FullAuto",
-		StartPos:      core.Position3D{X: 100, Y: 200, Z: 1.5},
-		EndPos:        core.Position3D{X: 300, Y: 400, Z: 1.8},
-	}
-	_ = b.RecordFiredEvent(fired)
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
+	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 1}))
+	require.NoError(t, b.RecordFiredEvent(&core.FiredEvent{
+		SoldierID: 1, CaptureFrame: 100, Weapon: "arifle_MX_F", Magazine: "30Rnd_65x39_caseless_mag",
+		FiringMode: "FullAuto", StartPos: core.Position3D{X: 100, Y: 200, Z: 1.5}, EndPos: core.Position3D{X: 300, Y: 400, Z: 1.8},
+	}))
 
 	export := b.buildExport()
 
-	if len(export.Entities) != 1 {
-		t.Fatalf("expected 1 entity, got %d", len(export.Entities))
-	}
+	require.Len(t, export.Entities, 1)
+	require.Len(t, export.Entities[0].FramesFired, 1)
 
-	entity := export.Entities[0]
-	if len(entity.FramesFired) != 1 {
-		t.Fatalf("expected 1 framesFired, got %d", len(entity.FramesFired))
-	}
-
-	ff := entity.FramesFired[0]
-	// Format: [captureFrame, [endX, endY], [startX, startY], weapon, magazine, firingMode]
-	if len(ff) != 6 {
-		t.Fatalf("expected framesFired array length 6, got %d", len(ff))
-	}
-
-	if ff[0].(uint) != 100 {
-		t.Errorf("expected captureFrame=100, got %v", ff[0])
-	}
+	ff := export.Entities[0].FramesFired[0]
+	require.Len(t, ff, 6) // [captureFrame, [endX, endY], [startX, startY], weapon, magazine, firingMode]
+	assert.Equal(t, uint(100), ff[0])
 
 	endPos, ok := ff[1].([]float64)
-	if !ok {
-		t.Fatal("endPos is not []float64")
-	}
-	if endPos[0] != 300 || endPos[1] != 400 {
-		t.Errorf("expected endPos [300, 400], got %v", endPos)
-	}
+	require.True(t, ok, "endPos should be []float64")
+	assert.Equal(t, 300.0, endPos[0])
+	assert.Equal(t, 400.0, endPos[1])
 
 	startPos, ok := ff[2].([]float64)
-	if !ok {
-		t.Fatal("startPos is not []float64")
-	}
-	if startPos[0] != 100 || startPos[1] != 200 {
-		t.Errorf("expected startPos [100, 200], got %v", startPos)
-	}
+	require.True(t, ok, "startPos should be []float64")
+	assert.Equal(t, 100.0, startPos[0])
+	assert.Equal(t, 200.0, startPos[1])
 
-	if ff[3].(string) != "arifle_MX_F" {
-		t.Errorf("expected weapon='arifle_MX_F', got %v", ff[3])
-	}
-	if ff[4].(string) != "30Rnd_65x39_caseless_mag" {
-		t.Errorf("expected magazine='30Rnd_65x39_caseless_mag', got %v", ff[4])
-	}
-	if ff[5].(string) != "FullAuto" {
-		t.Errorf("expected firingMode='FullAuto', got %v", ff[5])
-	}
+	assert.Equal(t, "arifle_MX_F", ff[3])
+	assert.Equal(t, "30Rnd_65x39_caseless_mag", ff[4])
+	assert.Equal(t, "FullAuto", ff[5])
 }
 
 func TestMarkerPositionFormat(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
-	mission := &core.Mission{MissionName: "Test", StartTime: time.Now()}
-	world := &core.World{WorldName: "Test"}
-	_ = b.StartMission(mission, world)
-
-	marker := &core.Marker{
-		MarkerName:   "test_marker",
-		Text:         "Test Marker",
-		MarkerType:   "mil_dot",
-		Color:        "ColorRed",
-		Side:         "EAST",
-		Shape:        "ICON",
-		CaptureFrame: 0,
-		Position:     core.Position3D{X: 1000, Y: 2000, Z: 0},
-		Direction:    90,
-		Alpha:        1.0,
-	}
-	_ = b.AddMarker(marker)
-
-	state := &core.MarkerState{
-		MarkerID:     marker.ID,
-		CaptureFrame: 50,
-		Position:     core.Position3D{X: 1100, Y: 2100, Z: 0},
-		Direction:    180,
-		Alpha:        0.5,
-	}
-	_ = b.RecordMarkerState(state)
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
+	require.NoError(t, b.AddMarker(&core.Marker{
+		MarkerName: "test_marker", Text: "Test Marker", MarkerType: "mil_dot", Color: "ColorRed",
+		Side: "EAST", Shape: "ICON", CaptureFrame: 0, Position: core.Position3D{X: 1000, Y: 2000, Z: 0}, Direction: 90, Alpha: 1.0,
+	}))
+	require.NoError(t, b.RecordMarkerState(&core.MarkerState{
+		MarkerID: 0, CaptureFrame: 50, Position: core.Position3D{X: 1100, Y: 2100, Z: 0}, Direction: 180, Alpha: 0.5,
+	}))
 
 	export := b.buildExport()
 
-	if len(export.Markers) != 1 {
-		t.Fatalf("expected 1 marker, got %d", len(export.Markers))
-	}
+	require.Len(t, export.Markers, 1)
+	require.Len(t, export.Markers[0].Positions, 2) // initial + 1 state
 
-	m := export.Markers[0]
-	// Should have initial position + 1 state = 2 positions
-	if len(m.Positions) != 2 {
-		t.Fatalf("expected 2 positions, got %d", len(m.Positions))
-	}
-
-	// Check initial position format: [frame, [x, y], direction, alpha]
-	initialPos := m.Positions[0]
-	if len(initialPos) != 4 {
-		t.Fatalf("expected position array length 4, got %d", len(initialPos))
-	}
-
-	if initialPos[0].(uint) != 0 {
-		t.Errorf("expected initial frame=0, got %v", initialPos[0])
-	}
+	initialPos := export.Markers[0].Positions[0]
+	require.Len(t, initialPos, 4) // [frame, [x, y], direction, alpha]
+	assert.Equal(t, uint(0), initialPos[0])
 
 	coords, ok := initialPos[1].([]float64)
-	if !ok {
-		t.Fatal("coords is not []float64")
-	}
-	if coords[0] != 1000 || coords[1] != 2000 {
-		t.Errorf("expected initial coords [1000, 2000], got %v", coords)
-	}
+	require.True(t, ok, "coords should be []float64")
+	assert.Equal(t, 1000.0, coords[0])
+	assert.Equal(t, 2000.0, coords[1])
 
-	// Check state position
-	statePos := m.Positions[1]
-	if statePos[0].(uint) != 50 {
-		t.Errorf("expected state frame=50, got %v", statePos[0])
-	}
+	assert.Equal(t, uint(50), export.Markers[0].Positions[1][0])
 }
 
 func TestEmptyExport(t *testing.T) {
 	tempDir := t.TempDir()
+	b := New(config.MemoryConfig{OutputDir: tempDir, CompressOutput: false})
 
-	b := New(config.MemoryConfig{
-		OutputDir:      tempDir,
-		CompressOutput: false,
-	})
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Empty Mission", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
+	require.NoError(t, b.EndMission())
 
-	mission := &core.Mission{
-		MissionName: "Empty Mission",
-		StartTime:   time.Now(),
-	}
-	world := &core.World{WorldName: "Test"}
+	matches, err := filepath.Glob(filepath.Join(tempDir, "*.json"))
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
 
-	_ = b.StartMission(mission, world)
-	// No entities, events, or markers added
+	data, err := os.ReadFile(matches[0])
+	require.NoError(t, err)
 
-	if err := b.EndMission(); err != nil {
-		t.Fatalf("EndMission failed: %v", err)
-	}
-
-	// Find and validate the file
-	pattern := filepath.Join(tempDir, "*.json")
-	matches, _ := filepath.Glob(pattern)
-	if len(matches) != 1 {
-		t.Fatalf("expected 1 file, found %d", len(matches))
-	}
-
-	data, _ := os.ReadFile(matches[0])
 	var export OcapExport
-	_ = json.Unmarshal(data, &export)
+	require.NoError(t, json.Unmarshal(data, &export))
 
-	if len(export.Entities) != 0 {
-		t.Errorf("expected 0 entities, got %d", len(export.Entities))
-	}
-	if len(export.Events) != 0 {
-		t.Errorf("expected 0 events, got %d", len(export.Events))
-	}
-	if len(export.Markers) != 0 {
-		t.Errorf("expected 0 markers, got %d", len(export.Markers))
-	}
+	assert.Empty(t, export.Entities)
+	assert.Empty(t, export.Events)
+	assert.Empty(t, export.Markers)
 }
 
 func TestMaxFrameCalculation(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
-	mission := &core.Mission{MissionName: "Test", StartTime: time.Now()}
-	world := &core.World{WorldName: "Test"}
-	_ = b.StartMission(mission, world)
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
+	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 1}))
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{SoldierID: 1, CaptureFrame: 10}))
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{SoldierID: 1, CaptureFrame: 50}))
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{SoldierID: 1, CaptureFrame: 30}))
+	require.NoError(t, b.AddVehicle(&core.Vehicle{ID: 10}))
+	require.NoError(t, b.RecordVehicleState(&core.VehicleState{VehicleID: 10, CaptureFrame: 100}))
+	require.NoError(t, b.RecordVehicleState(&core.VehicleState{VehicleID: 10, CaptureFrame: 75}))
 
-	// Add soldier with states at different frames
-	soldier := &core.Soldier{ID: 1}
-	_ = b.AddSoldier(soldier)
-
-	_ = b.RecordSoldierState(&core.SoldierState{SoldierID: soldier.ID, CaptureFrame: 10})
-	_ = b.RecordSoldierState(&core.SoldierState{SoldierID: soldier.ID, CaptureFrame: 50})
-	_ = b.RecordSoldierState(&core.SoldierState{SoldierID: soldier.ID, CaptureFrame: 30})
-
-	// Add vehicle with states at higher frames
-	vehicle := &core.Vehicle{ID: 10}
-	_ = b.AddVehicle(vehicle)
-
-	_ = b.RecordVehicleState(&core.VehicleState{VehicleID: vehicle.ID, CaptureFrame: 100})
-	_ = b.RecordVehicleState(&core.VehicleState{VehicleID: vehicle.ID, CaptureFrame: 75})
-
-	export := b.buildExport()
-
-	// EndFrame should be max of all state frames (100)
-	if export.EndFrame != 100 {
-		t.Errorf("expected EndFrame=100, got %d", export.EndFrame)
-	}
+	assert.Equal(t, uint(100), b.buildExport().EndFrame)
 }
 
 func TestSoldierWithoutVehicle(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
-	mission := &core.Mission{MissionName: "Test", StartTime: time.Now()}
-	world := &core.World{WorldName: "Test"}
-	_ = b.StartMission(mission, world)
-
-	soldier := &core.Soldier{ID: 1, UnitName: "Infantry", IsPlayer: false}
-	_ = b.AddSoldier(soldier)
-
-	// State with nil InVehicleObjectID (soldier on foot)
-	state := &core.SoldierState{
-		SoldierID:         soldier.ID,
-		CaptureFrame:      0,
-		Position:          core.Position3D{X: 100, Y: 200, Z: 10},
-		Bearing:           45,
-		Lifestate:         1,
-		InVehicleObjectID: nil, // Not in vehicle
-		UnitName:          "Infantry",
-		IsPlayer:          false,
-		CurrentRole:       "Rifleman",
-	}
-	_ = b.RecordSoldierState(state)
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
+	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Infantry", IsPlayer: false}))
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{
+		SoldierID: 1, CaptureFrame: 0, Position: core.Position3D{X: 100, Y: 200, Z: 10},
+		Bearing: 45, Lifestate: 1, InVehicleObjectID: nil, UnitName: "Infantry", IsPlayer: false, CurrentRole: "Rifleman",
+	}))
 
 	export := b.buildExport()
 
-	if len(export.Entities) != 1 {
-		t.Fatalf("expected 1 entity, got %d", len(export.Entities))
-	}
+	require.Len(t, export.Entities, 1)
+	pos := export.Entities[0].Positions[0]
 
-	entity := export.Entities[0]
-	pos := entity.Positions[0]
-
-	// InVehicleObjectID should be nil (*uint16 nil stored in any)
-	if pos[3] != (*uint16)(nil) {
-		t.Errorf("expected InVehicleObjectID=nil, got %v", pos[3])
-	}
-
-	// IsPlayer should be 0 for non-player
-	if entity.IsPlayer != 0 {
-		t.Errorf("expected IsPlayer=0, got %d", entity.IsPlayer)
-	}
-	if pos[5].(int) != 0 {
-		t.Errorf("expected position isPlayer=0, got %v", pos[5])
-	}
+	assert.Equal(t, (*uint16)(nil), pos[3], "InVehicleObjectID should be nil")
+	assert.Equal(t, 0, export.Entities[0].IsPlayer)
+	assert.Equal(t, 0, pos[5])
 }
 
 func TestDeadVehicle(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
-	mission := &core.Mission{MissionName: "Test", StartTime: time.Now()}
-	world := &core.World{WorldName: "Test"}
-	_ = b.StartMission(mission, world)
-
-	vehicle := &core.Vehicle{ID: 5, DisplayName: "Destroyed Tank", OcapType: "tank", ClassName: "B_MBT_01_cannon_F"}
-	_ = b.AddVehicle(vehicle)
-
-	state := &core.VehicleState{
-		VehicleID:     vehicle.ID,
-				CaptureFrame:  50,
-		Position:      core.Position3D{X: 2000, Y: 3000, Z: 0},
-		Bearing:       90,
-		IsAlive:       false, // Destroyed
-		Crew:          "[]",  // Empty crew (everyone dead/bailed)
-	}
-	_ = b.RecordVehicleState(state)
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
+	require.NoError(t, b.AddVehicle(&core.Vehicle{ID: 5, DisplayName: "Destroyed Tank", OcapType: "tank", ClassName: "B_MBT_01_cannon_F"}))
+	require.NoError(t, b.RecordVehicleState(&core.VehicleState{
+		VehicleID: 5, CaptureFrame: 50, Position: core.Position3D{X: 2000, Y: 3000, Z: 0},
+		Bearing: 90, IsAlive: false, Crew: "[]",
+	}))
 
 	export := b.buildExport()
 
-	if len(export.Entities) != 1 {
-		t.Fatalf("expected 1 entity, got %d", len(export.Entities))
-	}
-
-	entity := export.Entities[0]
-	if entity.Side != "UNKNOWN" {
-		t.Errorf("expected Side='UNKNOWN' for vehicle, got '%s'", entity.Side)
-	}
-	if entity.IsPlayer != 0 {
-		t.Errorf("expected IsPlayer=0 for vehicle, got %d", entity.IsPlayer)
-	}
-
-	pos := entity.Positions[0]
-	// IsAlive should be 0 for destroyed vehicle
-	if pos[2].(int) != 0 {
-		t.Errorf("expected isAlive=0, got %v", pos[2])
-	}
+	require.Len(t, export.Entities, 1)
+	assert.Equal(t, "UNKNOWN", export.Entities[0].Side)
+	assert.Equal(t, 0, export.Entities[0].IsPlayer)
+	assert.Equal(t, 0, export.Entities[0].Positions[0][2], "isAlive should be 0 for destroyed vehicle")
 }
 
 func TestMultipleEntitiesExport(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
-	mission := &core.Mission{MissionName: "Test", StartTime: time.Now()}
-	world := &core.World{WorldName: "Test"}
-	_ = b.StartMission(mission, world)
-
-	// Add multiple soldiers
-	soldier1 := &core.Soldier{ID: 1, UnitName: "Alpha1", GroupID: "Alpha", Side: "WEST", IsPlayer: true, JoinFrame: 0}
-	soldier2 := &core.Soldier{ID: 2, UnitName: "Alpha2", GroupID: "Alpha", Side: "WEST", IsPlayer: false, JoinFrame: 5}
-	soldier3 := &core.Soldier{ID: 3, UnitName: "Bravo1", GroupID: "Bravo", Side: "EAST", IsPlayer: false, JoinFrame: 10}
-	_ = b.AddSoldier(soldier1)
-	_ = b.AddSoldier(soldier2)
-	_ = b.AddSoldier(soldier3)
-
-	// Add states for each soldier
-	_ = b.RecordSoldierState(&core.SoldierState{SoldierID: soldier1.ID, CaptureFrame: 0, Position: core.Position3D{X: 100, Y: 100}, Lifestate: 1})
-	_ = b.RecordSoldierState(&core.SoldierState{SoldierID: soldier2.ID, CaptureFrame: 5, Position: core.Position3D{X: 110, Y: 100}, Lifestate: 1})
-	_ = b.RecordSoldierState(&core.SoldierState{SoldierID: soldier3.ID, CaptureFrame: 10, Position: core.Position3D{X: 500, Y: 500}, Lifestate: 1})
-
-	// Add multiple vehicles
-	vehicle1 := &core.Vehicle{ID: 10, DisplayName: "Hunter", OcapType: "car", JoinFrame: 0}
-	vehicle2 := &core.Vehicle{ID: 11, DisplayName: "Heli", OcapType: "heli", JoinFrame: 20}
-	_ = b.AddVehicle(vehicle1)
-	_ = b.AddVehicle(vehicle2)
-
-	_ = b.RecordVehicleState(&core.VehicleState{VehicleID: vehicle1.ID, CaptureFrame: 0, Position: core.Position3D{X: 200, Y: 200}, IsAlive: true})
-	_ = b.RecordVehicleState(&core.VehicleState{VehicleID: vehicle2.ID, CaptureFrame: 20, Position: core.Position3D{X: 300, Y: 300}, IsAlive: true})
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
+	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Alpha1", GroupID: "Alpha", Side: "WEST", IsPlayer: true, JoinFrame: 0}))
+	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 2, UnitName: "Alpha2", GroupID: "Alpha", Side: "WEST", IsPlayer: false, JoinFrame: 5}))
+	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 3, UnitName: "Bravo1", GroupID: "Bravo", Side: "EAST", IsPlayer: false, JoinFrame: 10}))
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{SoldierID: 1, CaptureFrame: 0, Position: core.Position3D{X: 100, Y: 100}, Lifestate: 1}))
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{SoldierID: 2, CaptureFrame: 5, Position: core.Position3D{X: 110, Y: 100}, Lifestate: 1}))
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{SoldierID: 3, CaptureFrame: 10, Position: core.Position3D{X: 500, Y: 500}, Lifestate: 1}))
+	require.NoError(t, b.AddVehicle(&core.Vehicle{ID: 10, DisplayName: "Hunter", OcapType: "car", JoinFrame: 0}))
+	require.NoError(t, b.AddVehicle(&core.Vehicle{ID: 11, DisplayName: "Heli", OcapType: "heli", JoinFrame: 20}))
+	require.NoError(t, b.RecordVehicleState(&core.VehicleState{VehicleID: 10, CaptureFrame: 0, Position: core.Position3D{X: 200, Y: 200}, IsAlive: true}))
+	require.NoError(t, b.RecordVehicleState(&core.VehicleState{VehicleID: 11, CaptureFrame: 20, Position: core.Position3D{X: 300, Y: 300}, IsAlive: true}))
 
 	export := b.buildExport()
 
-	// 3 soldiers + 2 vehicles = 5 entities
-	if len(export.Entities) != 5 {
-		t.Errorf("expected 5 entities, got %d", len(export.Entities))
-	}
+	require.Len(t, export.Entities, 5) // 3 soldiers + 2 vehicles
 
-	// Count by type
-	unitCount := 0
-	vehicleCount := 0
+	unitCount, vehicleCount := 0, 0
 	for _, e := range export.Entities {
 		if e.Type == "unit" {
 			unitCount++
@@ -906,184 +488,109 @@ func TestMultipleEntitiesExport(t *testing.T) {
 			vehicleCount++
 		}
 	}
-	if unitCount != 3 {
-		t.Errorf("expected 3 units, got %d", unitCount)
-	}
-	if vehicleCount != 2 {
-		t.Errorf("expected 2 vehicles, got %d", vehicleCount)
-	}
+	assert.Equal(t, 3, unitCount)
+	assert.Equal(t, 2, vehicleCount)
 }
 
 func TestEventWithoutExtraData(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
-	mission := &core.Mission{MissionName: "Test", StartTime: time.Now()}
-	world := &core.World{WorldName: "Test"}
-	_ = b.StartMission(mission, world)
-
-	// Event without ExtraData - tests the event export path
-	evt := &core.GeneralEvent{
-		CaptureFrame: 100,
-		Name:         "endMission",
-		Message:      "Mission ended",
-		ExtraData:    nil,
-	}
-	_ = b.RecordGeneralEvent(evt)
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
+	require.NoError(t, b.RecordGeneralEvent(&core.GeneralEvent{CaptureFrame: 100, Name: "endMission", Message: "Mission ended", ExtraData: nil}))
 
 	export := b.buildExport()
 
-	if len(export.Events) != 1 {
-		t.Fatalf("expected 1 event, got %d", len(export.Events))
-	}
-
-	if export.Events[0].Type != "endMission" {
-		t.Errorf("expected Type='endMission', got '%s'", export.Events[0].Type)
-	}
-	if export.Events[0].Frame != 100 {
-		t.Errorf("expected Frame=100, got %d", export.Events[0].Frame)
-	}
-	if export.Events[0].Message != "Mission ended" {
-		t.Errorf("expected Message='Mission ended', got '%s'", export.Events[0].Message)
-	}
+	require.Len(t, export.Events, 1)
+	assert.Equal(t, "endMission", export.Events[0].Type)
+	assert.Equal(t, uint(100), export.Events[0].Frame)
+	assert.Equal(t, "Mission ended", export.Events[0].Message)
 }
 
 func TestMultipleMarkersExport(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
-	mission := &core.Mission{MissionName: "Test", StartTime: time.Now()}
-	world := &core.World{WorldName: "Test"}
-	_ = b.StartMission(mission, world)
-
-	// Add multiple markers
-	marker1 := &core.Marker{
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
+	require.NoError(t, b.AddMarker(&core.Marker{
 		MarkerName: "obj_alpha", Text: "Alpha", MarkerType: "mil_objective", Color: "ColorBLUFOR", Side: "WEST", Shape: "ICON",
 		CaptureFrame: 0, Position: core.Position3D{X: 1000, Y: 1000}, Direction: 0, Alpha: 1.0,
-	}
-	marker2 := &core.Marker{
+	}))
+	require.NoError(t, b.AddMarker(&core.Marker{
 		MarkerName: "obj_bravo", Text: "Bravo", MarkerType: "mil_objective", Color: "ColorOPFOR", Side: "EAST", Shape: "ICON",
 		CaptureFrame: 0, Position: core.Position3D{X: 2000, Y: 2000}, Direction: 45, Alpha: 1.0,
-	}
-	_ = b.AddMarker(marker1)
-	_ = b.AddMarker(marker2)
-
-	// Add states to first marker only
-	_ = b.RecordMarkerState(&core.MarkerState{MarkerID: marker1.ID, CaptureFrame: 10, Position: core.Position3D{X: 1100, Y: 1100}, Direction: 90, Alpha: 0.8})
-	_ = b.RecordMarkerState(&core.MarkerState{MarkerID: marker1.ID, CaptureFrame: 20, Position: core.Position3D{X: 1200, Y: 1200}, Direction: 180, Alpha: 0.6})
+	}))
+	require.NoError(t, b.RecordMarkerState(&core.MarkerState{MarkerID: 0, CaptureFrame: 10, Position: core.Position3D{X: 1100, Y: 1100}, Direction: 90, Alpha: 0.8}))
+	require.NoError(t, b.RecordMarkerState(&core.MarkerState{MarkerID: 0, CaptureFrame: 20, Position: core.Position3D{X: 1200, Y: 1200}, Direction: 180, Alpha: 0.6}))
 
 	export := b.buildExport()
 
-	if len(export.Markers) != 2 {
-		t.Fatalf("expected 2 markers, got %d", len(export.Markers))
-	}
+	require.Len(t, export.Markers, 2)
 
-	// Find markers by name
 	var m1, m2 *MarkerJSON
 	for i := range export.Markers {
-		if export.Markers[i].Name == "Alpha" {
+		switch export.Markers[i].Name {
+		case "Alpha":
 			m1 = &export.Markers[i]
-		} else if export.Markers[i].Name == "Bravo" {
+		case "Bravo":
 			m2 = &export.Markers[i]
 		}
 	}
 
-	if m1 == nil || m2 == nil {
-		t.Fatal("markers not found by name")
-	}
-
-	// Marker1 should have 3 positions (initial + 2 states)
-	if len(m1.Positions) != 3 {
-		t.Errorf("expected 3 positions for marker1, got %d", len(m1.Positions))
-	}
-
-	// Marker2 should have only 1 position (initial, no states)
-	if len(m2.Positions) != 1 {
-		t.Errorf("expected 1 position for marker2, got %d", len(m2.Positions))
-	}
-
-	// Verify marker properties
-	if m1.Color != "ColorBLUFOR" {
-		t.Errorf("expected marker1 Color='ColorBLUFOR', got '%s'", m1.Color)
-	}
-	if m2.Side != "EAST" {
-		t.Errorf("expected marker2 Side='EAST', got '%s'", m2.Side)
-	}
+	require.NotNil(t, m1, "marker Alpha not found")
+	require.NotNil(t, m2, "marker Bravo not found")
+	assert.Len(t, m1.Positions, 3, "marker1 should have initial + 2 states")
+	assert.Len(t, m2.Positions, 1, "marker2 should have only initial position")
+	assert.Equal(t, "ColorBLUFOR", m1.Color)
+	assert.Equal(t, "EAST", m2.Side)
 }
 
 func TestMultipleFiredEvents(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
-	mission := &core.Mission{MissionName: "Test", StartTime: time.Now()}
-	world := &core.World{WorldName: "Test"}
-	_ = b.StartMission(mission, world)
-
-	soldier := &core.Soldier{ID: 1, UnitName: "Shooter"}
-	_ = b.AddSoldier(soldier)
-
-	// Multiple fired events for same soldier
-	_ = b.RecordFiredEvent(&core.FiredEvent{
-		SoldierID: soldier.ID, CaptureFrame: 10, Weapon: "arifle_MX_F", Magazine: "30Rnd_65x39", FiringMode: "Single",
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
+	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Shooter"}))
+	require.NoError(t, b.RecordFiredEvent(&core.FiredEvent{
+		SoldierID: 1, CaptureFrame: 10, Weapon: "arifle_MX_F", Magazine: "30Rnd_65x39", FiringMode: "Single",
 		StartPos: core.Position3D{X: 100, Y: 100}, EndPos: core.Position3D{X: 200, Y: 200},
-	})
-	_ = b.RecordFiredEvent(&core.FiredEvent{
-		SoldierID: soldier.ID, CaptureFrame: 15, Weapon: "arifle_MX_F", Magazine: "30Rnd_65x39", FiringMode: "FullAuto",
+	}))
+	require.NoError(t, b.RecordFiredEvent(&core.FiredEvent{
+		SoldierID: 1, CaptureFrame: 15, Weapon: "arifle_MX_F", Magazine: "30Rnd_65x39", FiringMode: "FullAuto",
 		StartPos: core.Position3D{X: 100, Y: 100}, EndPos: core.Position3D{X: 250, Y: 250},
-	})
-	_ = b.RecordFiredEvent(&core.FiredEvent{
-		SoldierID: soldier.ID, CaptureFrame: 50, Weapon: "launch_NLAW_F", Magazine: "NLAW_F", FiringMode: "Single",
+	}))
+	require.NoError(t, b.RecordFiredEvent(&core.FiredEvent{
+		SoldierID: 1, CaptureFrame: 50, Weapon: "launch_NLAW_F", Magazine: "NLAW_F", FiringMode: "Single",
 		StartPos: core.Position3D{X: 100, Y: 100}, EndPos: core.Position3D{X: 500, Y: 500},
-	})
+	}))
 
 	export := b.buildExport()
 
-	if len(export.Entities) != 1 {
-		t.Fatalf("expected 1 entity, got %d", len(export.Entities))
-	}
+	require.Len(t, export.Entities, 1)
+	require.Len(t, export.Entities[0].FramesFired, 3)
 
-	entity := export.Entities[0]
-	if len(entity.FramesFired) != 3 {
-		t.Errorf("expected 3 framesFired, got %d", len(entity.FramesFired))
-	}
-
-	// Verify different weapons are recorded
 	weapons := make(map[string]bool)
-	for _, ff := range entity.FramesFired {
+	for _, ff := range export.Entities[0].FramesFired {
 		weapons[ff[3].(string)] = true
 	}
-	if !weapons["arifle_MX_F"] || !weapons["launch_NLAW_F"] {
-		t.Errorf("expected both weapons recorded, got %v", weapons)
-	}
+	assert.True(t, weapons["arifle_MX_F"], "arifle_MX_F should be recorded")
+	assert.True(t, weapons["launch_NLAW_F"], "launch_NLAW_F should be recorded")
 }
 
 func TestVehicleWithJoinFrame(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
-	mission := &core.Mission{MissionName: "Test", StartTime: time.Now()}
-	world := &core.World{WorldName: "Test"}
-	_ = b.StartMission(mission, world)
-
-	vehicle := &core.Vehicle{
-		ID:      20,
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
+	require.NoError(t, b.AddVehicle(&core.Vehicle{
+		ID:          20,
 		DisplayName: "Late Arrival",
 		OcapType:    "plane",
 		ClassName:   "B_Plane_Fighter_01_F",
 		JoinFrame:   500, // Spawned late in the mission
-	}
-	_ = b.AddVehicle(vehicle)
+	}))
 
 	export := b.buildExport()
 
-	if len(export.Entities) != 1 {
-		t.Fatalf("expected 1 entity, got %d", len(export.Entities))
-	}
-
+	require.Len(t, export.Entities, 1)
 	entity := export.Entities[0]
-	if entity.StartFrameNum != 500 {
-		t.Errorf("expected StartFrameNum=500, got %d", entity.StartFrameNum)
-	}
-	if entity.Type != "plane" {
-		t.Errorf("expected Type='plane', got '%s'", entity.Type)
-	}
-	if entity.Class != "B_Plane_Fighter_01_F" {
-		t.Errorf("expected Class='B_Plane_Fighter_01_F', got '%s'", entity.Class)
-	}
+	assert.Equal(t, uint(500), entity.StartFrameNum)
+	assert.Equal(t, "plane", entity.Type)
+	assert.Equal(t, "B_Plane_Fighter_01_F", entity.Class)
 }

--- a/internal/storage/memory/export_test.go
+++ b/internal/storage/memory/export_test.go
@@ -50,7 +50,7 @@ func TestBuildExport(t *testing.T) {
 
 	// Add soldier with states and fired events
 	soldier := &core.Soldier{
-		OcapID:    1,
+		ID:    1,
 		UnitName:  "Player1",
 		GroupID:   "Alpha",
 		Side:      "WEST",
@@ -60,42 +60,42 @@ func TestBuildExport(t *testing.T) {
 	_ = b.AddSoldier(soldier)
 
 	state1 := &core.SoldierState{
-		SoldierID:    soldier.ID,
-		CaptureFrame: 0,
-		Position:     core.Position3D{X: 1000, Y: 2000, Z: 100},
-		Bearing:      90,
-		Lifestate:    1,
-		UnitName:     "Player1",
-		IsPlayer:     true,
-		CurrentRole:  "Rifleman",
+		SoldierID:     soldier.ID,
+				CaptureFrame:  0,
+		Position:      core.Position3D{X: 1000, Y: 2000, Z: 100},
+		Bearing:       90,
+		Lifestate:     1,
+		UnitName:      "Player1",
+		IsPlayer:      true,
+		CurrentRole:   "Rifleman",
 	}
 	state2 := &core.SoldierState{
-		SoldierID:    soldier.ID,
-		CaptureFrame: 10,
-		Position:     core.Position3D{X: 1050, Y: 2050, Z: 100},
-		Bearing:      95,
-		Lifestate:    1,
-		UnitName:     "Player1",
-		IsPlayer:     true,
-		CurrentRole:  "Rifleman",
+		SoldierID:     soldier.ID,
+				CaptureFrame:  10,
+		Position:      core.Position3D{X: 1050, Y: 2050, Z: 100},
+		Bearing:       95,
+		Lifestate:     1,
+		UnitName:      "Player1",
+		IsPlayer:      true,
+		CurrentRole:   "Rifleman",
 	}
 	_ = b.RecordSoldierState(state1)
 	_ = b.RecordSoldierState(state2)
 
 	fired := &core.FiredEvent{
-		SoldierID:    soldier.ID,
-		CaptureFrame: 5,
-		Weapon:       "arifle_MX_F",
-		Magazine:     "30Rnd_65x39_caseless_mag",
-		FiringMode:   "Single",
-		StartPos:     core.Position3D{X: 1000, Y: 2000, Z: 1.5},
-		EndPos:       core.Position3D{X: 1100, Y: 2100, Z: 1.5},
+		SoldierID:     soldier.ID,
+				CaptureFrame:  5,
+		Weapon:        "arifle_MX_F",
+		Magazine:      "30Rnd_65x39_caseless_mag",
+		FiringMode:    "Single",
+		StartPos:      core.Position3D{X: 1000, Y: 2000, Z: 1.5},
+		EndPos:        core.Position3D{X: 1100, Y: 2100, Z: 1.5},
 	}
 	_ = b.RecordFiredEvent(fired)
 
 	// Add vehicle with states
 	vehicle := &core.Vehicle{
-		OcapID:      10,
+		ID:      10,
 		ClassName:   "B_MRAP_01_F",
 		DisplayName: "Hunter",
 		OcapType:    "car",
@@ -104,12 +104,12 @@ func TestBuildExport(t *testing.T) {
 	_ = b.AddVehicle(vehicle)
 
 	vState := &core.VehicleState{
-		VehicleID:    vehicle.ID,
-		CaptureFrame: 5,
-		Position:     core.Position3D{X: 3000, Y: 4000, Z: 50},
-		Bearing:      180,
-		IsAlive:      true,
-		Crew:         "[[1,\"driver\"]]",
+		VehicleID:     vehicle.ID,
+				CaptureFrame:  5,
+		Position:      core.Position3D{X: 3000, Y: 4000, Z: 50},
+		Bearing:       180,
+		IsAlive:       true,
+		Crew:          "[[1,\"driver\"]]",
 	}
 	_ = b.RecordVehicleState(vState)
 
@@ -276,7 +276,7 @@ func TestExportJSON(t *testing.T) {
 	world := &core.World{WorldName: "Tanoa"}
 
 	_ = b.StartMission(mission, world)
-	_ = b.AddSoldier(&core.Soldier{OcapID: 1, UnitName: "Test"})
+	_ = b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Test"})
 
 	// EndMission triggers export
 	if err := b.EndMission(); err != nil {
@@ -325,7 +325,7 @@ func TestExportGzipJSON(t *testing.T) {
 	world := &core.World{WorldName: "Livonia"}
 
 	_ = b.StartMission(mission, world)
-	_ = b.AddSoldier(&core.Soldier{OcapID: 1, UnitName: "Test"})
+	_ = b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Test"})
 
 	if err := b.EndMission(); err != nil {
 		t.Fatalf("EndMission failed: %v", err)
@@ -452,10 +452,10 @@ func TestSoldierPositionFormat(t *testing.T) {
 	world := &core.World{WorldName: "Test"}
 	_ = b.StartMission(mission, world)
 
-	soldier := &core.Soldier{OcapID: 1, UnitName: "Player1", IsPlayer: true}
+	soldier := &core.Soldier{ID: 1, UnitName: "Player1", IsPlayer: true}
 	_ = b.AddSoldier(soldier)
 
-	inVehicleID := uint(100)
+	inVehicleID := uint16(100)
 	state := &core.SoldierState{
 		SoldierID:         soldier.ID,
 		CaptureFrame:      5,
@@ -518,16 +518,16 @@ func TestVehiclePositionFormat(t *testing.T) {
 	world := &core.World{WorldName: "Test"}
 	_ = b.StartMission(mission, world)
 
-	vehicle := &core.Vehicle{OcapID: 10, DisplayName: "Hunter", OcapType: "car"}
+	vehicle := &core.Vehicle{ID: 10, DisplayName: "Hunter", OcapType: "car"}
 	_ = b.AddVehicle(vehicle)
 
 	state := &core.VehicleState{
-		VehicleID:    vehicle.ID,
-		CaptureFrame: 3,
-		Position:     core.Position3D{X: 5000, Y: 6000, Z: 25},
-		Bearing:      45,
-		IsAlive:      true,
-		Crew:         "[[1,\"driver\"],[2,\"gunner\"]]",
+		VehicleID:     vehicle.ID,
+				CaptureFrame:  3,
+		Position:      core.Position3D{X: 5000, Y: 6000, Z: 25},
+		Bearing:       45,
+		IsAlive:       true,
+		Crew:          "[[1,\"driver\"],[2,\"gunner\"]]",
 	}
 	_ = b.RecordVehicleState(state)
 
@@ -570,17 +570,17 @@ func TestFiredEventFormat(t *testing.T) {
 	world := &core.World{WorldName: "Test"}
 	_ = b.StartMission(mission, world)
 
-	soldier := &core.Soldier{OcapID: 1}
+	soldier := &core.Soldier{ID: 1}
 	_ = b.AddSoldier(soldier)
 
 	fired := &core.FiredEvent{
-		SoldierID:    soldier.ID,
-		CaptureFrame: 100,
-		Weapon:       "arifle_MX_F",
-		Magazine:     "30Rnd_65x39_caseless_mag",
-		FiringMode:   "FullAuto",
-		StartPos:     core.Position3D{X: 100, Y: 200, Z: 1.5},
-		EndPos:       core.Position3D{X: 300, Y: 400, Z: 1.8},
+		SoldierID:     soldier.ID,
+				CaptureFrame:  100,
+		Weapon:        "arifle_MX_F",
+		Magazine:      "30Rnd_65x39_caseless_mag",
+		FiringMode:    "FullAuto",
+		StartPos:      core.Position3D{X: 100, Y: 200, Z: 1.5},
+		EndPos:        core.Position3D{X: 300, Y: 400, Z: 1.8},
 	}
 	_ = b.RecordFiredEvent(fired)
 
@@ -750,7 +750,7 @@ func TestMaxFrameCalculation(t *testing.T) {
 	_ = b.StartMission(mission, world)
 
 	// Add soldier with states at different frames
-	soldier := &core.Soldier{OcapID: 1}
+	soldier := &core.Soldier{ID: 1}
 	_ = b.AddSoldier(soldier)
 
 	_ = b.RecordSoldierState(&core.SoldierState{SoldierID: soldier.ID, CaptureFrame: 10})
@@ -758,7 +758,7 @@ func TestMaxFrameCalculation(t *testing.T) {
 	_ = b.RecordSoldierState(&core.SoldierState{SoldierID: soldier.ID, CaptureFrame: 30})
 
 	// Add vehicle with states at higher frames
-	vehicle := &core.Vehicle{OcapID: 10}
+	vehicle := &core.Vehicle{ID: 10}
 	_ = b.AddVehicle(vehicle)
 
 	_ = b.RecordVehicleState(&core.VehicleState{VehicleID: vehicle.ID, CaptureFrame: 100})
@@ -779,7 +779,7 @@ func TestSoldierWithoutVehicle(t *testing.T) {
 	world := &core.World{WorldName: "Test"}
 	_ = b.StartMission(mission, world)
 
-	soldier := &core.Soldier{OcapID: 1, UnitName: "Infantry", IsPlayer: false}
+	soldier := &core.Soldier{ID: 1, UnitName: "Infantry", IsPlayer: false}
 	_ = b.AddSoldier(soldier)
 
 	// State with nil InVehicleObjectID (soldier on foot)
@@ -805,8 +805,8 @@ func TestSoldierWithoutVehicle(t *testing.T) {
 	entity := export.Entities[0]
 	pos := entity.Positions[0]
 
-	// InVehicleObjectID should be nil (typed nil shows as <nil>)
-	if pos[3] != (*uint)(nil) {
+	// InVehicleObjectID should be nil (*uint16 nil stored in any)
+	if pos[3] != (*uint16)(nil) {
 		t.Errorf("expected InVehicleObjectID=nil, got %v", pos[3])
 	}
 
@@ -826,16 +826,16 @@ func TestDeadVehicle(t *testing.T) {
 	world := &core.World{WorldName: "Test"}
 	_ = b.StartMission(mission, world)
 
-	vehicle := &core.Vehicle{OcapID: 5, DisplayName: "Destroyed Tank", OcapType: "tank", ClassName: "B_MBT_01_cannon_F"}
+	vehicle := &core.Vehicle{ID: 5, DisplayName: "Destroyed Tank", OcapType: "tank", ClassName: "B_MBT_01_cannon_F"}
 	_ = b.AddVehicle(vehicle)
 
 	state := &core.VehicleState{
-		VehicleID:    vehicle.ID,
-		CaptureFrame: 50,
-		Position:     core.Position3D{X: 2000, Y: 3000, Z: 0},
-		Bearing:      90,
-		IsAlive:      false, // Destroyed
-		Crew:         "[]",  // Empty crew (everyone dead/bailed)
+		VehicleID:     vehicle.ID,
+				CaptureFrame:  50,
+		Position:      core.Position3D{X: 2000, Y: 3000, Z: 0},
+		Bearing:       90,
+		IsAlive:       false, // Destroyed
+		Crew:          "[]",  // Empty crew (everyone dead/bailed)
 	}
 	_ = b.RecordVehicleState(state)
 
@@ -868,9 +868,9 @@ func TestMultipleEntitiesExport(t *testing.T) {
 	_ = b.StartMission(mission, world)
 
 	// Add multiple soldiers
-	soldier1 := &core.Soldier{OcapID: 1, UnitName: "Alpha1", GroupID: "Alpha", Side: "WEST", IsPlayer: true, JoinFrame: 0}
-	soldier2 := &core.Soldier{OcapID: 2, UnitName: "Alpha2", GroupID: "Alpha", Side: "WEST", IsPlayer: false, JoinFrame: 5}
-	soldier3 := &core.Soldier{OcapID: 3, UnitName: "Bravo1", GroupID: "Bravo", Side: "EAST", IsPlayer: false, JoinFrame: 10}
+	soldier1 := &core.Soldier{ID: 1, UnitName: "Alpha1", GroupID: "Alpha", Side: "WEST", IsPlayer: true, JoinFrame: 0}
+	soldier2 := &core.Soldier{ID: 2, UnitName: "Alpha2", GroupID: "Alpha", Side: "WEST", IsPlayer: false, JoinFrame: 5}
+	soldier3 := &core.Soldier{ID: 3, UnitName: "Bravo1", GroupID: "Bravo", Side: "EAST", IsPlayer: false, JoinFrame: 10}
 	_ = b.AddSoldier(soldier1)
 	_ = b.AddSoldier(soldier2)
 	_ = b.AddSoldier(soldier3)
@@ -881,8 +881,8 @@ func TestMultipleEntitiesExport(t *testing.T) {
 	_ = b.RecordSoldierState(&core.SoldierState{SoldierID: soldier3.ID, CaptureFrame: 10, Position: core.Position3D{X: 500, Y: 500}, Lifestate: 1})
 
 	// Add multiple vehicles
-	vehicle1 := &core.Vehicle{OcapID: 10, DisplayName: "Hunter", OcapType: "car", JoinFrame: 0}
-	vehicle2 := &core.Vehicle{OcapID: 11, DisplayName: "Heli", OcapType: "heli", JoinFrame: 20}
+	vehicle1 := &core.Vehicle{ID: 10, DisplayName: "Hunter", OcapType: "car", JoinFrame: 0}
+	vehicle2 := &core.Vehicle{ID: 11, DisplayName: "Heli", OcapType: "heli", JoinFrame: 20}
 	_ = b.AddVehicle(vehicle1)
 	_ = b.AddVehicle(vehicle2)
 
@@ -1016,7 +1016,7 @@ func TestMultipleFiredEvents(t *testing.T) {
 	world := &core.World{WorldName: "Test"}
 	_ = b.StartMission(mission, world)
 
-	soldier := &core.Soldier{OcapID: 1, UnitName: "Shooter"}
+	soldier := &core.Soldier{ID: 1, UnitName: "Shooter"}
 	_ = b.AddSoldier(soldier)
 
 	// Multiple fired events for same soldier
@@ -1062,7 +1062,7 @@ func TestVehicleWithJoinFrame(t *testing.T) {
 	_ = b.StartMission(mission, world)
 
 	vehicle := &core.Vehicle{
-		OcapID:      20,
+		ID:      20,
 		DisplayName: "Late Arrival",
 		OcapType:    "plane",
 		ClassName:   "B_Plane_Fighter_01_F",

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -36,8 +36,8 @@ type Backend struct {
 
 	lastExportPath string // path to the last exported file
 
-	soldiers map[uint16]*SoldierRecord // keyed by OcapID
-	vehicles map[uint16]*VehicleRecord // keyed by OcapID
+	soldiers map[uint16]*SoldierRecord // keyed by ObjectID
+	vehicles map[uint16]*VehicleRecord // keyed by ObjectID
 	markers  map[string]*MarkerRecord  // keyed by MarkerName
 
 	generalEvents         []core.GeneralEvent
@@ -108,12 +108,12 @@ func (b *Backend) EndMission() error {
 }
 
 // AddSoldier registers a new soldier.
-// The soldier's ID is their OcapID (game identifier).
+// The soldier's ID is their ObjectID (game identifier).
 func (b *Backend) AddSoldier(s *core.Soldier) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	// ID is the OcapID, set by caller
+	// ID is the ObjectID, set by caller
 	b.soldiers[s.ID] = &SoldierRecord{
 		Soldier: *s,
 		States:  make([]core.SoldierState, 0),
@@ -122,12 +122,12 @@ func (b *Backend) AddSoldier(s *core.Soldier) error {
 }
 
 // AddVehicle registers a new vehicle.
-// The vehicle's ID is their OcapID (game identifier).
+// The vehicle's ID is their ObjectID (game identifier).
 func (b *Backend) AddVehicle(v *core.Vehicle) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	// ID is the OcapID, set by caller
+	// ID is the ObjectID, set by caller
 	b.vehicles[v.ID] = &VehicleRecord{
 		Vehicle: *v,
 		States:  make([]core.VehicleState, 0),
@@ -147,8 +147,8 @@ func (b *Backend) AddMarker(m *core.Marker) error {
 	return nil
 }
 
-// GetSoldierByOcapID looks up a soldier by their OcapID
-func (b *Backend) GetSoldierByOcapID(ocapID uint16) (*core.Soldier, bool) {
+// GetSoldierByObjectID looks up a soldier by their ObjectID
+func (b *Backend) GetSoldierByObjectID(ocapID uint16) (*core.Soldier, bool) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
@@ -158,8 +158,8 @@ func (b *Backend) GetSoldierByOcapID(ocapID uint16) (*core.Soldier, bool) {
 	return nil, false
 }
 
-// GetVehicleByOcapID looks up a vehicle by its OcapID
-func (b *Backend) GetVehicleByOcapID(ocapID uint16) (*core.Vehicle, bool) {
+// GetVehicleByObjectID looks up a vehicle by its ObjectID
+func (b *Backend) GetVehicleByObjectID(ocapID uint16) (*core.Vehicle, bool) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
@@ -181,12 +181,12 @@ func (b *Backend) GetMarkerByName(name string) (*core.Marker, bool) {
 }
 
 // RecordSoldierState records a soldier state update.
-// SoldierID must be set to the soldier's OcapID.
+// SoldierID must be set to the soldier's ObjectID.
 func (b *Backend) RecordSoldierState(s *core.SoldierState) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	// Find soldier by OcapID (SoldierState.SoldierID is the OcapID)
+	// Find soldier by ObjectID (SoldierState.SoldierID is the ObjectID)
 	if record, ok := b.soldiers[s.SoldierID]; ok {
 		record.States = append(record.States, *s)
 	}
@@ -194,12 +194,12 @@ func (b *Backend) RecordSoldierState(s *core.SoldierState) error {
 }
 
 // RecordVehicleState records a vehicle state update.
-// VehicleID must be set to the vehicle's OcapID.
+// VehicleID must be set to the vehicle's ObjectID.
 func (b *Backend) RecordVehicleState(v *core.VehicleState) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	// Find vehicle by OcapID (VehicleState.VehicleID is the OcapID)
+	// Find vehicle by ObjectID (VehicleState.VehicleID is the ObjectID)
 	if record, ok := b.vehicles[v.VehicleID]; ok {
 		record.States = append(record.States, *v)
 	}
@@ -221,12 +221,12 @@ func (b *Backend) RecordMarkerState(s *core.MarkerState) error {
 }
 
 // RecordFiredEvent records a fired event.
-// SoldierID must be set to the soldier's OcapID.
+// SoldierID must be set to the soldier's ObjectID.
 func (b *Backend) RecordFiredEvent(e *core.FiredEvent) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	// Find soldier by OcapID (FiredEvent.SoldierID is the OcapID)
+	// Find soldier by ObjectID (FiredEvent.SoldierID is the ObjectID)
 	if record, ok := b.soldiers[e.SoldierID]; ok {
 		record.FiredEvents = append(record.FiredEvents, *e)
 	}

--- a/internal/storage/memory/memory_test.go
+++ b/internal/storage/memory/memory_test.go
@@ -112,12 +112,12 @@ func TestAddSoldier(t *testing.T) {
 		t.Fatalf("AddSoldier failed: %v", err)
 	}
 
-	// IDs are OcapIDs set by caller, not auto-assigned
+	// IDs are ObjectIDs set by caller, not auto-assigned
 	if s1.ID != 1 {
-		t.Errorf("expected s1.ID=1 (OcapID), got %d", s1.ID)
+		t.Errorf("expected s1.ID=1 (ObjectID), got %d", s1.ID)
 	}
 	if s2.ID != 2 {
-		t.Errorf("expected s2.ID=2 (OcapID), got %d", s2.ID)
+		t.Errorf("expected s2.ID=2 (ObjectID), got %d", s2.ID)
 	}
 
 	// Check storage
@@ -153,12 +153,12 @@ func TestAddVehicle(t *testing.T) {
 		t.Fatalf("AddVehicle failed: %v", err)
 	}
 
-	// IDs are OcapIDs set by caller, not auto-assigned
+	// IDs are ObjectIDs set by caller, not auto-assigned
 	if v1.ID != 10 {
-		t.Errorf("expected v1.ID=10 (OcapID), got %d", v1.ID)
+		t.Errorf("expected v1.ID=10 (ObjectID), got %d", v1.ID)
 	}
 	if v2.ID != 20 {
-		t.Errorf("expected v2.ID=20 (OcapID), got %d", v2.ID)
+		t.Errorf("expected v2.ID=20 (ObjectID), got %d", v2.ID)
 	}
 
 	if len(b.vehicles) != 2 {
@@ -189,7 +189,7 @@ func TestAddMarker(t *testing.T) {
 		t.Fatalf("AddMarker failed: %v", err)
 	}
 
-	// Markers don't have OcapIDs; ID is not auto-assigned
+	// Markers don't have ObjectIDs; ID is not auto-assigned
 	// Just verify storage works
 
 	if len(b.markers) != 2 {
@@ -200,7 +200,7 @@ func TestAddMarker(t *testing.T) {
 	}
 }
 
-func TestGetSoldierByOcapID(t *testing.T) {
+func TestGetSoldierByObjectID(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
 	s := &core.Soldier{
@@ -210,7 +210,7 @@ func TestGetSoldierByOcapID(t *testing.T) {
 	_ = b.AddSoldier(s)
 
 	// Found case
-	found, ok := b.GetSoldierByOcapID(42)
+	found, ok := b.GetSoldierByObjectID(42)
 	if !ok {
 		t.Fatal("soldier not found")
 	}
@@ -219,13 +219,13 @@ func TestGetSoldierByOcapID(t *testing.T) {
 	}
 
 	// Not found case
-	_, ok = b.GetSoldierByOcapID(999)
+	_, ok = b.GetSoldierByObjectID(999)
 	if ok {
-		t.Error("expected not found for non-existent OcapID")
+		t.Error("expected not found for non-existent ObjectID")
 	}
 }
 
-func TestGetVehicleByOcapID(t *testing.T) {
+func TestGetVehicleByObjectID(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
 	v := &core.Vehicle{
@@ -235,7 +235,7 @@ func TestGetVehicleByOcapID(t *testing.T) {
 	_ = b.AddVehicle(v)
 
 	// Found case
-	found, ok := b.GetVehicleByOcapID(100)
+	found, ok := b.GetVehicleByObjectID(100)
 	if !ok {
 		t.Fatal("vehicle not found")
 	}
@@ -244,9 +244,9 @@ func TestGetVehicleByOcapID(t *testing.T) {
 	}
 
 	// Not found case
-	_, ok = b.GetVehicleByOcapID(999)
+	_, ok = b.GetVehicleByObjectID(999)
 	if ok {
-		t.Error("expected not found for non-existent OcapID")
+		t.Error("expected not found for non-existent ObjectID")
 	}
 }
 
@@ -637,7 +637,7 @@ func TestConcurrentAccess(t *testing.T) {
 			defer wg.Done()
 			for j := 0; j < numOperationsPerGoroutine; j++ {
 				ocapID := uint16(id*1000 + j)
-				_, _ = b.GetSoldierByOcapID(ocapID)
+				_, _ = b.GetSoldierByObjectID(ocapID)
 			}
 		}(i)
 	}
@@ -654,7 +654,7 @@ func TestConcurrentAccess(t *testing.T) {
 func TestIDsPreserved(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
-	// IDs are OcapIDs set by caller, not auto-assigned
+	// IDs are ObjectIDs set by caller, not auto-assigned
 	s := &core.Soldier{ID: 1}
 	v := &core.Vehicle{ID: 10}
 	m := &core.Marker{MarkerName: "test"}

--- a/internal/storage/memory/memory_test.go
+++ b/internal/storage/memory/memory_test.go
@@ -70,7 +70,7 @@ func TestStartMission(t *testing.T) {
 	}
 
 	// Add some data before starting
-	soldier := &core.Soldier{OcapID: 1, UnitName: "Old Soldier"}
+	soldier := &core.Soldier{ID: 1, UnitName: "Old Soldier"}
 	_ = b.AddSoldier(soldier)
 
 	// Start a new mission - should reset collections
@@ -87,22 +87,19 @@ func TestStartMission(t *testing.T) {
 	if len(b.soldiers) != 0 {
 		t.Error("soldiers not reset")
 	}
-	if b.idCounter != 0 {
-		t.Error("idCounter not reset")
-	}
 }
 
 func TestAddSoldier(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
 	s1 := &core.Soldier{
-		OcapID:   1,
+		ID:   1,
 		UnitName: "Soldier One",
 		Side:     "WEST",
 		IsPlayer: true,
 	}
 	s2 := &core.Soldier{
-		OcapID:   2,
+		ID:   2,
 		UnitName: "Soldier Two",
 		Side:     "EAST",
 		IsPlayer: false,
@@ -115,12 +112,12 @@ func TestAddSoldier(t *testing.T) {
 		t.Fatalf("AddSoldier failed: %v", err)
 	}
 
-	// Check IDs assigned
+	// IDs are OcapIDs set by caller, not auto-assigned
 	if s1.ID != 1 {
-		t.Errorf("expected s1.ID=1, got %d", s1.ID)
+		t.Errorf("expected s1.ID=1 (OcapID), got %d", s1.ID)
 	}
 	if s2.ID != 2 {
-		t.Errorf("expected s2.ID=2, got %d", s2.ID)
+		t.Errorf("expected s2.ID=2 (OcapID), got %d", s2.ID)
 	}
 
 	// Check storage
@@ -139,12 +136,12 @@ func TestAddVehicle(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
 	v1 := &core.Vehicle{
-		OcapID:      10,
+		ID:      10,
 		ClassName:   "B_MRAP_01_F",
 		DisplayName: "Hunter",
 	}
 	v2 := &core.Vehicle{
-		OcapID:      20,
+		ID:      20,
 		ClassName:   "B_Heli_Light_01_F",
 		DisplayName: "MH-9 Hummingbird",
 	}
@@ -156,11 +153,12 @@ func TestAddVehicle(t *testing.T) {
 		t.Fatalf("AddVehicle failed: %v", err)
 	}
 
-	if v1.ID != 1 {
-		t.Errorf("expected v1.ID=1, got %d", v1.ID)
+	// IDs are OcapIDs set by caller, not auto-assigned
+	if v1.ID != 10 {
+		t.Errorf("expected v1.ID=10 (OcapID), got %d", v1.ID)
 	}
-	if v2.ID != 2 {
-		t.Errorf("expected v2.ID=2, got %d", v2.ID)
+	if v2.ID != 20 {
+		t.Errorf("expected v2.ID=20 (OcapID), got %d", v2.ID)
 	}
 
 	if len(b.vehicles) != 2 {
@@ -191,12 +189,8 @@ func TestAddMarker(t *testing.T) {
 		t.Fatalf("AddMarker failed: %v", err)
 	}
 
-	if m1.ID != 1 {
-		t.Errorf("expected m1.ID=1, got %d", m1.ID)
-	}
-	if m2.ID != 2 {
-		t.Errorf("expected m2.ID=2, got %d", m2.ID)
-	}
+	// Markers don't have OcapIDs; ID is not auto-assigned
+	// Just verify storage works
 
 	if len(b.markers) != 2 {
 		t.Errorf("expected 2 markers, got %d", len(b.markers))
@@ -210,7 +204,7 @@ func TestGetSoldierByOcapID(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
 	s := &core.Soldier{
-		OcapID:   42,
+		ID:   42,
 		UnitName: "Test Soldier",
 	}
 	_ = b.AddSoldier(s)
@@ -235,7 +229,7 @@ func TestGetVehicleByOcapID(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
 	v := &core.Vehicle{
-		OcapID:    100,
+		ID:    100,
 		ClassName: "B_Truck_01_transport_F",
 	}
 	_ = b.AddVehicle(v)
@@ -284,22 +278,22 @@ func TestGetMarkerByName(t *testing.T) {
 func TestRecordSoldierState(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
-	s := &core.Soldier{OcapID: 1, UnitName: "Test"}
+	s := &core.Soldier{ID: 1, UnitName: "Test"}
 	_ = b.AddSoldier(s)
 
 	state1 := &core.SoldierState{
-		SoldierID:    s.ID,
-		CaptureFrame: 0,
-		Position:     core.Position3D{X: 100, Y: 200, Z: 0},
-		Bearing:      90,
-		Lifestate:    1,
+		SoldierID:     s.ID,
+				CaptureFrame:  0,
+		Position:      core.Position3D{X: 100, Y: 200, Z: 0},
+		Bearing:       90,
+		Lifestate:     1,
 	}
 	state2 := &core.SoldierState{
-		SoldierID:    s.ID,
-		CaptureFrame: 1,
-		Position:     core.Position3D{X: 105, Y: 205, Z: 0},
-		Bearing:      95,
-		Lifestate:    1,
+		SoldierID:     s.ID,
+				CaptureFrame:  1,
+		Position:      core.Position3D{X: 105, Y: 205, Z: 0},
+		Bearing:       95,
+		Lifestate:     1,
 	}
 
 	if err := b.RecordSoldierState(state1); err != nil {
@@ -309,7 +303,7 @@ func TestRecordSoldierState(t *testing.T) {
 		t.Fatalf("RecordSoldierState failed: %v", err)
 	}
 
-	record := b.soldiers[1]
+	record := b.soldiers[s.ID]
 	if len(record.States) != 2 {
 		t.Errorf("expected 2 states, got %d", len(record.States))
 	}
@@ -330,21 +324,21 @@ func TestRecordSoldierState(t *testing.T) {
 func TestRecordVehicleState(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
-	v := &core.Vehicle{OcapID: 10, ClassName: "Car"}
+	v := &core.Vehicle{ID: 10, ClassName: "Car"}
 	_ = b.AddVehicle(v)
 
 	state := &core.VehicleState{
-		VehicleID:    v.ID,
-		CaptureFrame: 5,
-		Position:     core.Position3D{X: 500, Y: 600, Z: 10},
-		IsAlive:      true,
+		VehicleID:     v.ID,
+				CaptureFrame:  5,
+		Position:      core.Position3D{X: 500, Y: 600, Z: 10},
+		IsAlive:       true,
 	}
 
 	if err := b.RecordVehicleState(state); err != nil {
 		t.Fatalf("RecordVehicleState failed: %v", err)
 	}
 
-	record := b.vehicles[10]
+	record := b.vehicles[v.ID]
 	if len(record.States) != 1 {
 		t.Errorf("expected 1 state, got %d", len(record.States))
 	}
@@ -389,24 +383,24 @@ func TestRecordMarkerState(t *testing.T) {
 func TestRecordFiredEvent(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
-	s := &core.Soldier{OcapID: 1}
+	s := &core.Soldier{ID: 1}
 	_ = b.AddSoldier(s)
 
 	fired := &core.FiredEvent{
-		SoldierID:    s.ID,
-		CaptureFrame: 100,
-		Weapon:       "arifle_MX_F",
-		Magazine:     "30Rnd_65x39_caseless_mag",
-		FiringMode:   "Single",
-		StartPos:     core.Position3D{X: 100, Y: 100, Z: 1},
-		EndPos:       core.Position3D{X: 200, Y: 200, Z: 1},
+		SoldierID:     s.ID,
+				CaptureFrame:  100,
+		Weapon:        "arifle_MX_F",
+		Magazine:      "30Rnd_65x39_caseless_mag",
+		FiringMode:    "Single",
+		StartPos:      core.Position3D{X: 100, Y: 100, Z: 1},
+		EndPos:        core.Position3D{X: 200, Y: 200, Z: 1},
 	}
 
 	if err := b.RecordFiredEvent(fired); err != nil {
 		t.Fatalf("RecordFiredEvent failed: %v", err)
 	}
 
-	record := b.soldiers[1]
+	record := b.soldiers[s.ID]
 	if len(record.FiredEvents) != 1 {
 		t.Errorf("expected 1 fired event, got %d", len(record.FiredEvents))
 	}
@@ -630,7 +624,7 @@ func TestConcurrentAccess(t *testing.T) {
 			defer wg.Done()
 			for j := 0; j < numOperationsPerGoroutine; j++ {
 				ocapID := uint16(id*1000 + j)
-				s := &core.Soldier{OcapID: ocapID, UnitName: "Concurrent"}
+				s := &core.Soldier{ID: ocapID, UnitName: "Concurrent"}
 				_ = b.AddSoldier(s)
 			}
 		}(i)
@@ -657,26 +651,28 @@ func TestConcurrentAccess(t *testing.T) {
 	}
 }
 
-func TestIDCounter(t *testing.T) {
+func TestIDsPreserved(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
-	// Add soldier, vehicle, marker - all should increment same counter
-	s := &core.Soldier{OcapID: 1}
-	v := &core.Vehicle{OcapID: 10}
+	// IDs are OcapIDs set by caller, not auto-assigned
+	s := &core.Soldier{ID: 1}
+	v := &core.Vehicle{ID: 10}
 	m := &core.Marker{MarkerName: "test"}
 
 	_ = b.AddSoldier(s)
 	_ = b.AddVehicle(v)
 	_ = b.AddMarker(m)
 
+	// IDs should be preserved as set
 	if s.ID != 1 {
 		t.Errorf("expected soldier ID=1, got %d", s.ID)
 	}
-	if v.ID != 2 {
-		t.Errorf("expected vehicle ID=2, got %d", v.ID)
+	if v.ID != 10 {
+		t.Errorf("expected vehicle ID=10, got %d", v.ID)
 	}
-	if m.ID != 3 {
-		t.Errorf("expected marker ID=3, got %d", m.ID)
+	// Markers are keyed by name, not ID
+	if b.markers["test"] == nil {
+		t.Error("marker not stored")
 	}
 }
 
@@ -684,8 +680,8 @@ func TestStartMissionResetsEverything(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
 	// Populate with data
-	_ = b.AddSoldier(&core.Soldier{OcapID: 1})
-	_ = b.AddVehicle(&core.Vehicle{OcapID: 10})
+	_ = b.AddSoldier(&core.Soldier{ID: 1})
+	_ = b.AddVehicle(&core.Vehicle{ID: 10})
 	_ = b.AddMarker(&core.Marker{MarkerName: "m1"})
 	_ = b.RecordGeneralEvent(&core.GeneralEvent{Name: "test"})
 	_ = b.RecordHitEvent(&core.HitEvent{})
@@ -737,9 +733,6 @@ func TestStartMissionResetsEverything(t *testing.T) {
 	}
 	if len(b.ace3UnconsciousEvents) != 0 {
 		t.Error("ace3UnconsciousEvents not reset")
-	}
-	if b.idCounter != 0 {
-		t.Error("idCounter not reset")
 	}
 }
 
@@ -826,11 +819,11 @@ func TestGetExportMetadata(t *testing.T) {
 	_ = b.StartMission(mission, world)
 
 	// Add some frames
-	s := &core.Soldier{OcapID: 1}
+	s := &core.Soldier{ID: 1}
 	_ = b.AddSoldier(s)
 	_ = b.RecordSoldierState(&core.SoldierState{
-		SoldierID:    s.ID,
-		CaptureFrame: 100,
+		SoldierID:     s.ID,
+				CaptureFrame:  100,
 	})
 
 	meta := b.GetExportMetadata()
@@ -863,19 +856,19 @@ func TestGetExportMetadata_VehicleEndFrame(t *testing.T) {
 	_ = b.StartMission(mission, world)
 
 	// Add soldier with lower frame
-	s := &core.Soldier{OcapID: 1}
+	s := &core.Soldier{ID: 1}
 	_ = b.AddSoldier(s)
 	_ = b.RecordSoldierState(&core.SoldierState{
-		SoldierID:    s.ID,
-		CaptureFrame: 50,
+		SoldierID:     s.ID,
+				CaptureFrame:  50,
 	})
 
 	// Add vehicle with higher frame - this should determine endFrame
-	v := &core.Vehicle{OcapID: 10}
+	v := &core.Vehicle{ID: 10}
 	_ = b.AddVehicle(v)
 	_ = b.RecordVehicleState(&core.VehicleState{
-		VehicleID:    v.ID,
-		CaptureFrame: 200,
+		VehicleID:     v.ID,
+				CaptureFrame:  200,
 	})
 
 	meta := b.GetExportMetadata()

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -35,9 +35,9 @@ type Backend interface {
 	RecordAce3DeathEvent(e *core.Ace3DeathEvent) error
 	RecordAce3UnconsciousEvent(e *core.Ace3UnconsciousEvent) error
 
-	// Cache lookups (needed by handlers to resolve OcapID -> internal ID)
-	GetSoldierByOcapID(ocapID uint16) (*core.Soldier, bool)
-	GetVehicleByOcapID(ocapID uint16) (*core.Vehicle, bool)
+	// Cache lookups (needed by handlers to resolve ObjectID -> internal ID)
+	GetSoldierByObjectID(ocapID uint16) (*core.Soldier, bool)
+	GetVehicleByObjectID(ocapID uint16) (*core.Vehicle, bool)
 	GetMarkerByName(name string) (*core.Marker, bool)
 }
 

--- a/internal/worker/dispatch_test.go
+++ b/internal/worker/dispatch_test.go
@@ -93,7 +93,7 @@ func (b *mockBackend) EndMission() error {
 func (b *mockBackend) AddSoldier(s *core.Soldier) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	s.ID = uint(len(b.soldiers) + 1)
+	// ID is the OcapID, already set by caller
 	b.soldiers = append(b.soldiers, s)
 	return nil
 }
@@ -101,7 +101,7 @@ func (b *mockBackend) AddSoldier(s *core.Soldier) error {
 func (b *mockBackend) AddVehicle(v *core.Vehicle) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	v.ID = uint(len(b.vehicles) + 1)
+	// ID is the OcapID, already set by caller
 	b.vehicles = append(b.vehicles, v)
 	return nil
 }
@@ -209,7 +209,7 @@ func (b *mockBackend) GetSoldierByOcapID(ocapID uint16) (*core.Soldier, bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	for _, s := range b.soldiers {
-		if s.OcapID == ocapID {
+		if s.ID == ocapID { // ID is the OcapID
 			return s, true
 		}
 	}
@@ -220,7 +220,7 @@ func (b *mockBackend) GetVehicleByOcapID(ocapID uint16) (*core.Vehicle, bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	for _, v := range b.vehicles {
-		if v.OcapID == ocapID {
+		if v.ID == ocapID { // ID is the OcapID
 			return v, true
 		}
 	}

--- a/internal/worker/dispatch_test.go
+++ b/internal/worker/dispatch_test.go
@@ -93,7 +93,7 @@ func (b *mockBackend) EndMission() error {
 func (b *mockBackend) AddSoldier(s *core.Soldier) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	// ID is the OcapID, already set by caller
+	// ID is the ObjectID, already set by caller
 	b.soldiers = append(b.soldiers, s)
 	return nil
 }
@@ -101,7 +101,7 @@ func (b *mockBackend) AddSoldier(s *core.Soldier) error {
 func (b *mockBackend) AddVehicle(v *core.Vehicle) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	// ID is the OcapID, already set by caller
+	// ID is the ObjectID, already set by caller
 	b.vehicles = append(b.vehicles, v)
 	return nil
 }
@@ -205,22 +205,22 @@ func (b *mockBackend) RecordAce3UnconsciousEvent(e *core.Ace3UnconsciousEvent) e
 	return nil
 }
 
-func (b *mockBackend) GetSoldierByOcapID(ocapID uint16) (*core.Soldier, bool) {
+func (b *mockBackend) GetSoldierByObjectID(ocapID uint16) (*core.Soldier, bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	for _, s := range b.soldiers {
-		if s.ID == ocapID { // ID is the OcapID
+		if s.ID == ocapID { // ID is the ObjectID
 			return s, true
 		}
 	}
 	return nil, false
 }
 
-func (b *mockBackend) GetVehicleByOcapID(ocapID uint16) (*core.Vehicle, bool) {
+func (b *mockBackend) GetVehicleByObjectID(ocapID uint16) (*core.Vehicle, bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	for _, v := range b.vehicles {
-		if v.ID == ocapID { // ID is the OcapID
+		if v.ID == ocapID { // ID is the ObjectID
 			return v, true
 		}
 	}
@@ -629,7 +629,7 @@ func TestHandleNewSoldier_CachesEntityWithBackend(t *testing.T) {
 	entityCache := cache.NewEntityCache()
 
 	handlerService := &mockHandlerService{
-		soldier: model.Soldier{OcapID: 42, UnitName: "Test Soldier"},
+		soldier: model.Soldier{ObjectID: 42, UnitName: "Test Soldier"},
 	}
 
 	deps := Dependencies{
@@ -676,7 +676,7 @@ func TestHandleNewVehicle_CachesEntityWithBackend(t *testing.T) {
 	entityCache := cache.NewEntityCache()
 
 	handlerService := &mockHandlerService{
-		vehicle: model.Vehicle{OcapID: 99, OcapType: "car"},
+		vehicle: model.Vehicle{ObjectID: 99, OcapType: "car"},
 	}
 
 	deps := Dependencies{
@@ -723,7 +723,7 @@ func TestHandleNewSoldier_CachesEntityWithoutBackend(t *testing.T) {
 	entityCache := cache.NewEntityCache()
 
 	handlerService := &mockHandlerService{
-		soldier: model.Soldier{OcapID: 55, UnitName: "Queue Soldier"},
+		soldier: model.Soldier{ObjectID: 55, UnitName: "Queue Soldier"},
 	}
 
 	deps := Dependencies{


### PR DESCRIPTION
## Summary

- Change Soldier and Vehicle GORM models to use composite PK `(MissionID, ObjectID)` instead of auto-increment ID
- Rename `OcapID` to `ObjectID` throughout codebase for clarity (OcapID was confusing since OCAP is the project name)
- Update all state/event FK references to use ObjectID-based fields directly
- Remove redundant relationship pointers from event models (HitEvent, KillEvent, ChatEvent, etc.)
- Simplify handlers to set FK fields directly from parsed ObjectIDs
- Update convert layer for direct ObjectID mapping
- Update export tests to use testify assertions for cleaner test code

This eliminates the ID mapping overhead and improves naming clarity.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Memory backend exports correct JSON with matching IDs
- [ ] Test against fresh database with auto-migration