### PR TITLE
fix: export hit and kill events to JSON

### DIFF
--- a/cmd/ocap_recorder/main.go
+++ b/cmd/ocap_recorder/main.go
@@ -528,12 +528,13 @@ func startGoroutines() (err error) {
 
 	// Initialize handler service
 	handlerService = handlers.NewService(handlers.Dependencies{
-		DB:            DB,
-		EntityCache:   EntityCache,
-		MarkerCache:   MarkerCache,
-		LogManager:    SlogManager,
-		ExtensionName: ExtensionName,
-		AddonVersion:  addonVersion,
+		DB:               DB,
+		EntityCache:      EntityCache,
+		MarkerCache:      MarkerCache,
+		LogManager:       SlogManager,
+		ExtensionName:    ExtensionName,
+		AddonVersion:     addonVersion,
+		ExtensionVersion: CurrentExtensionVersion,
 	}, missionCtx)
 
 	// Initialize worker manager

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -63,12 +63,13 @@ func (mc *MissionContext) SetMission(mission *model.Mission, world *model.World)
 
 // Dependencies holds all dependencies needed by handlers
 type Dependencies struct {
-	DB            *gorm.DB
-	EntityCache   *cache.EntityCache
-	MarkerCache   *cache.MarkerCache
-	LogManager    *logging.SlogManager
-	ExtensionName string
-	AddonVersion  string
+	DB               *gorm.DB
+	EntityCache      *cache.EntityCache
+	MarkerCache      *cache.MarkerCache
+	LogManager       *logging.SlogManager
+	ExtensionName    string
+	AddonVersion     string
+	ExtensionVersion string
 }
 
 // Service provides handler methods for processing game data
@@ -206,6 +207,7 @@ func (s *Service) LogNewMission(data []string) error {
 
 	// received at extension init and saved to local memory
 	mission.AddonVersion = s.deps.AddonVersion
+	mission.ExtensionVersion = s.deps.ExtensionVersion
 
 	logger := s.deps.LogManager.Logger()
 

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -60,12 +60,13 @@ func newTestService() *Service {
 	logManager.Setup(nil, "info", nil)
 
 	deps := Dependencies{
-		DB:            nil, // memory-only mode
-		EntityCache:   cache.NewEntityCache(),
-		MarkerCache:   cache.NewMarkerCache(),
-		LogManager:    logManager,
-		ExtensionName: "test",
-		AddonVersion:  "1.0.0",
+		DB:               nil, // memory-only mode
+		EntityCache:      cache.NewEntityCache(),
+		MarkerCache:      cache.NewMarkerCache(),
+		LogManager:       logManager,
+		ExtensionName:    "test",
+		AddonVersion:     "1.0.0",
+		ExtensionVersion: "2.0.0",
 	}
 
 	ctx := NewMissionContext()

--- a/internal/storage/memory/export.go
+++ b/internal/storage/memory/export.go
@@ -197,6 +197,48 @@ func (b *Backend) buildExport() OcapExport {
 		})
 	}
 
+	// Convert hit events
+	for _, evt := range b.hitEvents {
+		data := map[string]any{
+			"causedBy": evt.ShooterSoldierID,
+			"victim":   evt.VictimSoldierID,
+			"distance": evt.Distance,
+		}
+		if evt.ShooterVehicleID != nil {
+			data["causedBy"] = evt.ShooterVehicleID
+		}
+		if evt.VictimVehicleID != nil {
+			data["victim"] = evt.VictimVehicleID
+		}
+		export.Events = append(export.Events, EventJSON{
+			Frame:   evt.CaptureFrame,
+			Type:    "hit",
+			Message: evt.EventText,
+			Data:    data,
+		})
+	}
+
+	// Convert kill events
+	for _, evt := range b.killEvents {
+		data := map[string]any{
+			"killer":   evt.KillerSoldierID,
+			"victim":   evt.VictimSoldierID,
+			"distance": evt.Distance,
+		}
+		if evt.KillerVehicleID != nil {
+			data["killer"] = evt.KillerVehicleID
+		}
+		if evt.VictimVehicleID != nil {
+			data["victim"] = evt.VictimVehicleID
+		}
+		export.Events = append(export.Events, EventJSON{
+			Frame:   evt.CaptureFrame,
+			Type:    "killed",
+			Message: evt.EventText,
+			Data:    data,
+		})
+	}
+
 	// Convert markers
 	for _, record := range b.markers {
 		marker := MarkerJSON{


### PR DESCRIPTION
## Summary

- Add export of hit events (type "hit") to JSON output
- Add export of kill events (type "killed") to JSON output

The `buildExport` function was only exporting `generalEvents` but not `hitEvents` or `killEvents`, causing kills and hits to be missing from the mission replay in OCAP web.

## Test plan

- [x] All existing tests pass
- [ ] Record a mission with kills/hits and verify they appear in the JSON
- [ ] Upload to OCAP web and verify kill events are visible in the UI