### PR TITLE
fix: align JSON export format with OCAP2 web expectations

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -923,23 +923,8 @@ func (s *Service) LogHitEvent(data []string) (model.HitEvent, error) {
 
 	hitEvent.Time = time.Now()
 
-	// parse data in array
-	victimObjectID, err := strconv.ParseUint(data[1], 10, 64)
-	if err != nil {
-		return hitEvent, fmt.Errorf(`error converting victim ocap id to uint: %v`, err)
-	}
-
-	// Set victim ObjectID - check if soldier or vehicle
-	if _, ok := s.deps.EntityCache.GetSoldier(uint16(victimObjectID)); ok {
-		hitEvent.VictimSoldierObjectID = sql.NullInt32{Int32: int32(victimObjectID), Valid: true}
-	} else if _, ok := s.deps.EntityCache.GetVehicle(uint16(victimObjectID)); ok {
-		hitEvent.VictimVehicleObjectID = sql.NullInt32{Int32: int32(victimObjectID), Valid: true}
-	} else {
-		return hitEvent, fmt.Errorf(`victim ocap id not found in cache: %d`, victimObjectID)
-	}
-
-	// parse shooter ObjectID
-	shooterObjectID, err := strconv.ParseUint(data[2], 10, 64)
+	// parse shooter ObjectID (data[1] = shooter/causedBy)
+	shooterObjectID, err := strconv.ParseUint(data[1], 10, 64)
 	if err != nil {
 		return hitEvent, fmt.Errorf(`error converting shooter ocap id to uint: %v`, err)
 	}
@@ -951,6 +936,21 @@ func (s *Service) LogHitEvent(data []string) (model.HitEvent, error) {
 		hitEvent.ShooterVehicleObjectID = sql.NullInt32{Int32: int32(shooterObjectID), Valid: true}
 	} else {
 		return hitEvent, fmt.Errorf(`shooter ocap id not found in cache: %d`, shooterObjectID)
+	}
+
+	// parse victim ObjectID (data[2] = victim)
+	victimObjectID, err := strconv.ParseUint(data[2], 10, 64)
+	if err != nil {
+		return hitEvent, fmt.Errorf(`error converting victim ocap id to uint: %v`, err)
+	}
+
+	// Set victim ObjectID - check if soldier or vehicle
+	if _, ok := s.deps.EntityCache.GetSoldier(uint16(victimObjectID)); ok {
+		hitEvent.VictimSoldierObjectID = sql.NullInt32{Int32: int32(victimObjectID), Valid: true}
+	} else if _, ok := s.deps.EntityCache.GetVehicle(uint16(victimObjectID)); ok {
+		hitEvent.VictimVehicleObjectID = sql.NullInt32{Int32: int32(victimObjectID), Valid: true}
+	} else {
+		return hitEvent, fmt.Errorf(`victim ocap id not found in cache: %d`, victimObjectID)
 	}
 
 	// get event text
@@ -987,23 +987,8 @@ func (s *Service) LogKillEvent(data []string) (model.KillEvent, error) {
 	killEvent.CaptureFrame = uint(capframe)
 	killEvent.Mission = *s.ctx.GetMission()
 
-	// parse data in array
-	victimObjectID, err := strconv.ParseUint(data[1], 10, 64)
-	if err != nil {
-		return killEvent, fmt.Errorf(`error converting victim ocap id to uint: %v`, err)
-	}
-
-	// Set victim ObjectID - check if soldier or vehicle
-	if _, ok := s.deps.EntityCache.GetSoldier(uint16(victimObjectID)); ok {
-		killEvent.VictimSoldierObjectID = sql.NullInt32{Int32: int32(victimObjectID), Valid: true}
-	} else if _, ok := s.deps.EntityCache.GetVehicle(uint16(victimObjectID)); ok {
-		killEvent.VictimVehicleObjectID = sql.NullInt32{Int32: int32(victimObjectID), Valid: true}
-	} else {
-		return killEvent, fmt.Errorf(`victim ocap id not found in cache: %d`, victimObjectID)
-	}
-
-	// parse killer ObjectID
-	killerObjectID, err := strconv.ParseUint(data[2], 10, 64)
+	// parse killer ObjectID (data[1] = killer/causedBy)
+	killerObjectID, err := strconv.ParseUint(data[1], 10, 64)
 	if err != nil {
 		return killEvent, fmt.Errorf(`error converting killer ocap id to uint: %v`, err)
 	}
@@ -1015,6 +1000,21 @@ func (s *Service) LogKillEvent(data []string) (model.KillEvent, error) {
 		killEvent.KillerVehicleObjectID = sql.NullInt32{Int32: int32(killerObjectID), Valid: true}
 	} else {
 		return killEvent, fmt.Errorf(`killer ocap id not found in cache: %d`, killerObjectID)
+	}
+
+	// parse victim ObjectID (data[2] = victim)
+	victimObjectID, err := strconv.ParseUint(data[2], 10, 64)
+	if err != nil {
+		return killEvent, fmt.Errorf(`error converting victim ocap id to uint: %v`, err)
+	}
+
+	// Set victim ObjectID - check if soldier or vehicle
+	if _, ok := s.deps.EntityCache.GetSoldier(uint16(victimObjectID)); ok {
+		killEvent.VictimSoldierObjectID = sql.NullInt32{Int32: int32(victimObjectID), Valid: true}
+	} else if _, ok := s.deps.EntityCache.GetVehicle(uint16(victimObjectID)); ok {
+		killEvent.VictimVehicleObjectID = sql.NullInt32{Int32: int32(victimObjectID), Valid: true}
+	} else {
+		return killEvent, fmt.Errorf(`victim ocap id not found in cache: %d`, victimObjectID)
 	}
 
 	// get event text

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -923,23 +923,8 @@ func (s *Service) LogHitEvent(data []string) (model.HitEvent, error) {
 
 	hitEvent.Time = time.Now()
 
-	// parse shooter ObjectID (data[1] = shooter/causedBy)
-	shooterObjectID, err := strconv.ParseUint(data[1], 10, 64)
-	if err != nil {
-		return hitEvent, fmt.Errorf(`error converting shooter ocap id to uint: %v`, err)
-	}
-
-	// Set shooter ObjectID - check if soldier or vehicle
-	if _, ok := s.deps.EntityCache.GetSoldier(uint16(shooterObjectID)); ok {
-		hitEvent.ShooterSoldierObjectID = sql.NullInt32{Int32: int32(shooterObjectID), Valid: true}
-	} else if _, ok := s.deps.EntityCache.GetVehicle(uint16(shooterObjectID)); ok {
-		hitEvent.ShooterVehicleObjectID = sql.NullInt32{Int32: int32(shooterObjectID), Valid: true}
-	} else {
-		return hitEvent, fmt.Errorf(`shooter ocap id not found in cache: %d`, shooterObjectID)
-	}
-
-	// parse victim ObjectID (data[2] = victim)
-	victimObjectID, err := strconv.ParseUint(data[2], 10, 64)
+	// parse data in array
+	victimObjectID, err := strconv.ParseUint(data[1], 10, 64)
 	if err != nil {
 		return hitEvent, fmt.Errorf(`error converting victim ocap id to uint: %v`, err)
 	}
@@ -951,6 +936,21 @@ func (s *Service) LogHitEvent(data []string) (model.HitEvent, error) {
 		hitEvent.VictimVehicleObjectID = sql.NullInt32{Int32: int32(victimObjectID), Valid: true}
 	} else {
 		return hitEvent, fmt.Errorf(`victim ocap id not found in cache: %d`, victimObjectID)
+	}
+
+	// parse shooter ObjectID
+	shooterObjectID, err := strconv.ParseUint(data[2], 10, 64)
+	if err != nil {
+		return hitEvent, fmt.Errorf(`error converting shooter ocap id to uint: %v`, err)
+	}
+
+	// Set shooter ObjectID - check if soldier or vehicle
+	if _, ok := s.deps.EntityCache.GetSoldier(uint16(shooterObjectID)); ok {
+		hitEvent.ShooterSoldierObjectID = sql.NullInt32{Int32: int32(shooterObjectID), Valid: true}
+	} else if _, ok := s.deps.EntityCache.GetVehicle(uint16(shooterObjectID)); ok {
+		hitEvent.ShooterVehicleObjectID = sql.NullInt32{Int32: int32(shooterObjectID), Valid: true}
+	} else {
+		return hitEvent, fmt.Errorf(`shooter ocap id not found in cache: %d`, shooterObjectID)
 	}
 
 	// get event text
@@ -987,23 +987,8 @@ func (s *Service) LogKillEvent(data []string) (model.KillEvent, error) {
 	killEvent.CaptureFrame = uint(capframe)
 	killEvent.Mission = *s.ctx.GetMission()
 
-	// parse killer ObjectID (data[1] = killer/causedBy)
-	killerObjectID, err := strconv.ParseUint(data[1], 10, 64)
-	if err != nil {
-		return killEvent, fmt.Errorf(`error converting killer ocap id to uint: %v`, err)
-	}
-
-	// Set killer ObjectID - check if soldier or vehicle
-	if _, ok := s.deps.EntityCache.GetSoldier(uint16(killerObjectID)); ok {
-		killEvent.KillerSoldierObjectID = sql.NullInt32{Int32: int32(killerObjectID), Valid: true}
-	} else if _, ok := s.deps.EntityCache.GetVehicle(uint16(killerObjectID)); ok {
-		killEvent.KillerVehicleObjectID = sql.NullInt32{Int32: int32(killerObjectID), Valid: true}
-	} else {
-		return killEvent, fmt.Errorf(`killer ocap id not found in cache: %d`, killerObjectID)
-	}
-
-	// parse victim ObjectID (data[2] = victim)
-	victimObjectID, err := strconv.ParseUint(data[2], 10, 64)
+	// parse data in array
+	victimObjectID, err := strconv.ParseUint(data[1], 10, 64)
 	if err != nil {
 		return killEvent, fmt.Errorf(`error converting victim ocap id to uint: %v`, err)
 	}
@@ -1015,6 +1000,21 @@ func (s *Service) LogKillEvent(data []string) (model.KillEvent, error) {
 		killEvent.VictimVehicleObjectID = sql.NullInt32{Int32: int32(victimObjectID), Valid: true}
 	} else {
 		return killEvent, fmt.Errorf(`victim ocap id not found in cache: %d`, victimObjectID)
+	}
+
+	// parse killer ObjectID
+	killerObjectID, err := strconv.ParseUint(data[2], 10, 64)
+	if err != nil {
+		return killEvent, fmt.Errorf(`error converting killer ocap id to uint: %v`, err)
+	}
+
+	// Set killer ObjectID - check if soldier or vehicle
+	if _, ok := s.deps.EntityCache.GetSoldier(uint16(killerObjectID)); ok {
+		killEvent.KillerSoldierObjectID = sql.NullInt32{Int32: int32(killerObjectID), Valid: true}
+	} else if _, ok := s.deps.EntityCache.GetVehicle(uint16(killerObjectID)); ok {
+		killEvent.KillerVehicleObjectID = sql.NullInt32{Int32: int32(killerObjectID), Valid: true}
+	} else {
+		return killEvent, fmt.Errorf(`killer ocap id not found in cache: %d`, killerObjectID)
 	}
 
 	// get event text

--- a/internal/storage/memory/export.go
+++ b/internal/storage/memory/export.go
@@ -145,11 +145,17 @@ func (b *Backend) buildExport() OcapExport {
 		}
 
 		for _, state := range record.States {
+			// Convert nil InVehicleObjectID to 0 (old C++ extension uses 0 for "not in vehicle")
+			var inVehicleID any = 0
+			if state.InVehicleObjectID != nil {
+				inVehicleID = *state.InVehicleObjectID
+			}
+
 			pos := []any{
 				[]float64{state.Position.X, state.Position.Y},
 				state.Bearing,
 				state.Lifestate,
-				state.InVehicleObjectID,
+				inVehicleID,
 				state.UnitName,
 				boolToInt(state.IsPlayer),
 				state.CurrentRole,

--- a/internal/storage/memory/export_test.go
+++ b/internal/storage/memory/export_test.go
@@ -441,7 +441,7 @@ func TestSoldierWithoutVehicle(t *testing.T) {
 	entity := export.Entities[1]
 	pos := entity.Positions[0]
 
-	assert.Equal(t, (*uint16)(nil), pos[3], "InVehicleObjectID should be nil")
+	assert.Equal(t, 0, pos[3], "InVehicleObjectID should be 0 when not in vehicle")
 	assert.Equal(t, 0, entity.IsPlayer)
 	assert.Equal(t, 0, pos[5])
 }

--- a/internal/storage/memory/export_test.go
+++ b/internal/storage/memory/export_test.go
@@ -145,12 +145,12 @@ func TestIntegrationFullExport(t *testing.T) {
 	// Verify events
 	require.Len(t, export.Events, 1)
 	assert.Equal(t, "connected", export.Events[0].Type)
-	assert.Equal(t, uint(15), export.Events[0].Frame)
+	assert.Equal(t, uint(15), export.Events[0].FrameNum)
 	assert.Equal(t, "Player1 connected", export.Events[0].Message)
 
 	// Verify markers
 	require.Len(t, export.Markers, 1)
-	assert.Equal(t, "Objective Alpha", export.Markers[0].Name)
+	assert.Equal(t, "Objective Alpha", export.Markers[0].Text)
 	assert.Equal(t, "mil_objective", export.Markers[0].Type)
 	assert.Equal(t, "ColorBLUFOR", export.Markers[0].Color)
 	assert.Equal(t, "WEST", export.Markers[0].Side)
@@ -375,15 +375,11 @@ func TestMarkerPositionFormat(t *testing.T) {
 	require.Len(t, export.Markers[0].Positions, 2) // initial + 1 state
 
 	initialPos := export.Markers[0].Positions[0]
-	require.Len(t, initialPos, 4) // [frame, [x, y], direction, alpha]
-	assert.Equal(t, uint(0), initialPos[0])
+	assert.Equal(t, uint(0), initialPos.FrameNum)
+	assert.Equal(t, 1000.0, initialPos.PosX)
+	assert.Equal(t, 2000.0, initialPos.PosY)
 
-	coords, ok := initialPos[1].([]float64)
-	require.True(t, ok, "coords should be []float64")
-	assert.Equal(t, 1000.0, coords[0])
-	assert.Equal(t, 2000.0, coords[1])
-
-	assert.Equal(t, uint(50), export.Markers[0].Positions[1][0])
+	assert.Equal(t, uint(50), export.Markers[0].Positions[1].FrameNum)
 }
 
 func TestEmptyExport(t *testing.T) {
@@ -502,7 +498,7 @@ func TestEventWithoutExtraData(t *testing.T) {
 
 	require.Len(t, export.Events, 1)
 	assert.Equal(t, "endMission", export.Events[0].Type)
-	assert.Equal(t, uint(100), export.Events[0].Frame)
+	assert.Equal(t, uint(100), export.Events[0].FrameNum)
 	assert.Equal(t, "Mission ended", export.Events[0].Message)
 }
 
@@ -527,7 +523,7 @@ func TestMultipleMarkersExport(t *testing.T) {
 
 	var m1, m2 *MarkerJSON
 	for i := range export.Markers {
-		switch export.Markers[i].Name {
+		switch export.Markers[i].Text {
 		case "Alpha":
 			m1 = &export.Markers[i]
 		case "Bravo":


### PR DESCRIPTION
## Summary

Aligns the JSON export format with what OCAP2 web expects, based on the protobuf schema and frontend parser analysis.

### Events
- Change `frame` to `frameNum`
- Move `causedBy`/`killer` to top-level `sourceId`
- Move `victim` to top-level `targetId`
- Move `distance` to top-level field
- Remove nested `data` object

### Markers
- Change `name` to `text`
- Remove `id` field (not needed by web)
- Add `startFrame`, `endFrame`, `playerId`, `size`, `brush` fields
- Change positions from nested arrays to objects with named fields:
  `{frameNum, posX, posY, posZ, direction, alpha}`

## Test plan

- [x] All existing tests pass
- [ ] Record a mission and verify JSON format matches OCAP2 web expectations
- [ ] Upload to OCAP web and verify events/markers display correctly