### PR TITLE
fix: convert Arma 3 lifestate to OCAP2 web UI format

### DIFF
--- a/internal/storage/memory/export.go
+++ b/internal/storage/memory/export.go
@@ -154,7 +154,7 @@ func (b *Backend) buildExport() OcapExport {
 			pos := []any{
 				[]float64{state.Position.X, state.Position.Y},
 				state.Bearing,
-				state.Lifestate,
+				convertLifestate(state.Lifestate),
 				inVehicleID,
 				state.UnitName,
 				boolToInt(state.IsPlayer),
@@ -361,4 +361,20 @@ func boolToInt(b bool) int {
 		return 1
 	}
 	return 0
+}
+
+// convertLifestate converts Arma 3 lifestate to OCAP2 web UI format
+// Arma 3: 0=ALIVE, 1=INCAPACITATED, 2=DEAD
+// Web UI: 0=DEAD, 1=ALIVE, 2=UNCONSCIOUS
+func convertLifestate(armaLifestate uint8) uint8 {
+	switch armaLifestate {
+	case 0:
+		return 1 // ALIVE
+	case 1:
+		return 2 // INCAPACITATED → UNCONSCIOUS
+	case 2:
+		return 0 // DEAD
+	default:
+		return 1 // fallback to alive
+	}
 }


### PR DESCRIPTION
## Summary

- Convert Arma 3 lifestate values to OCAP2 web UI format during JSON export
- Arma 3 uses: 0=ALIVE, 1=INCAPACITATED, 2=DEAD
- Web UI expects: 0=DEAD, 1=ALIVE, 2=UNCONSCIOUS

This fixes dead units appearing as yellow (unconscious) instead of showing the death marker in the web playback.

## Test plan

- [x] Unit test for `convertLifestate()` function
- [x] Integration test verifying all three lifestate conversions in export
- [x] Updated existing `TestSoldierPositionFormat` to expect converted value
- [x] All tests pass