### PR TITLE
fix: revert incorrect lifestate conversion

### DIFF
--- a/internal/storage/memory/export.go
+++ b/internal/storage/memory/export.go
@@ -164,7 +164,7 @@ func (b *Backend) buildExport() OcapExport {
 			pos := []any{
 				[]float64{state.Position.X, state.Position.Y},
 				state.Bearing,
-				convertLifestate(state.Lifestate),
+				state.Lifestate,
 				inVehicleID,
 				state.UnitName,
 				boolToInt(state.IsPlayer),
@@ -371,20 +371,4 @@ func boolToInt(b bool) int {
 		return 1
 	}
 	return 0
-}
-
-// convertLifestate converts Arma 3 lifestate to OCAP2 web UI format
-// Arma 3: 0=ALIVE, 1=INCAPACITATED, 2=DEAD
-// Web UI: 0=DEAD, 1=ALIVE, 2=UNCONSCIOUS
-func convertLifestate(armaLifestate uint8) uint8 {
-	switch armaLifestate {
-	case 0:
-		return 1 // ALIVE
-	case 1:
-		return 2 // INCAPACITATED → UNCONSCIOUS
-	case 2:
-		return 0 // DEAD
-	default:
-		return 1 // fallback to alive
-	}
 }

--- a/internal/storage/memory/export_test.go
+++ b/internal/storage/memory/export_test.go
@@ -21,27 +21,6 @@ func TestBoolToInt(t *testing.T) {
 	assert.Equal(t, 0, boolToInt(false))
 }
 
-func TestConvertLifestate(t *testing.T) {
-	// Arma 3: 0=ALIVE, 1=INCAPACITATED, 2=DEAD
-	// Web UI: 0=DEAD, 1=ALIVE, 2=UNCONSCIOUS
-	tests := []struct {
-		armaValue    uint8
-		expectedWeb  uint8
-		description  string
-	}{
-		{0, 1, "ALIVE converts to 1"},
-		{1, 2, "INCAPACITATED converts to 2 (UNCONSCIOUS)"},
-		{2, 0, "DEAD converts to 0"},
-		{255, 1, "unknown value defaults to ALIVE"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.description, func(t *testing.T) {
-			assert.Equal(t, tt.expectedWeb, convertLifestate(tt.armaValue))
-		})
-	}
-}
-
 // TestIntegrationFullExport is a comprehensive integration test that verifies the full flow:
 // start mission -> add entities (soldier, vehicle, marker) -> record states/events -> export JSON -> verify output
 func TestIntegrationFullExport(t *testing.T) {
@@ -315,8 +294,7 @@ func TestSoldierPositionFormat(t *testing.T) {
 	assert.Equal(t, 1234.56, coords[0])
 	assert.Equal(t, 7890.12, coords[1])
 	assert.Equal(t, uint16(270), pos[1])
-	// Arma lifestate 1 (INCAPACITATED) converts to web UI 2 (UNCONSCIOUS)
-	assert.Equal(t, uint8(2), pos[2])
+	assert.Equal(t, uint8(1), pos[2])
 	assert.Equal(t, 1, pos[5])
 }
 
@@ -758,48 +736,6 @@ func TestJSONFormatValidation(t *testing.T) {
 
 func ptrUint(v uint) *uint {
 	return &v
-}
-
-func TestLifestateConversionInExport(t *testing.T) {
-	b := New(config.MemoryConfig{})
-
-	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
-
-	// Add three soldiers with different lifestates
-	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Alive"}))
-	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 2, UnitName: "Incapacitated"}))
-	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 3, UnitName: "Dead"}))
-
-	// Record states with Arma lifestates: 0=ALIVE, 1=INCAPACITATED, 2=DEAD
-	require.NoError(t, b.RecordSoldierState(&core.SoldierState{
-		SoldierID: 1, CaptureFrame: 0, Position: core.Position3D{X: 100, Y: 100},
-		Lifestate: 0, // Arma ALIVE
-	}))
-	require.NoError(t, b.RecordSoldierState(&core.SoldierState{
-		SoldierID: 2, CaptureFrame: 0, Position: core.Position3D{X: 200, Y: 200},
-		Lifestate: 1, // Arma INCAPACITATED
-	}))
-	require.NoError(t, b.RecordSoldierState(&core.SoldierState{
-		SoldierID: 3, CaptureFrame: 0, Position: core.Position3D{X: 300, Y: 300},
-		Lifestate: 2, // Arma DEAD
-	}))
-
-	export := b.buildExport()
-
-	// Verify conversion to web UI format: 0=DEAD, 1=ALIVE, 2=UNCONSCIOUS
-	require.Len(t, export.Entities, 4) // indices 0-3
-
-	// Entity 1: Arma ALIVE (0) -> Web ALIVE (1)
-	pos1 := export.Entities[1].Positions[0]
-	assert.Equal(t, uint8(1), pos1[2], "Arma ALIVE should convert to web UI 1")
-
-	// Entity 2: Arma INCAPACITATED (1) -> Web UNCONSCIOUS (2)
-	pos2 := export.Entities[2].Positions[0]
-	assert.Equal(t, uint8(2), pos2[2], "Arma INCAPACITATED should convert to web UI 2 (UNCONSCIOUS)")
-
-	// Entity 3: Arma DEAD (2) -> Web DEAD (0)
-	pos3 := export.Entities[3].Positions[0]
-	assert.Equal(t, uint8(0), pos3[2], "Arma DEAD should convert to web UI 0")
 }
 
 func TestMarkerTextHashPrefixIsStripped(t *testing.T) {


### PR DESCRIPTION
## Summary

- Reverts commit 5ccfa9d which introduced an incorrect lifestate conversion
- The addon already sends lifestate values in the correct web UI format

## Root Cause

The reverted commit was based on a wrong assumption about what values the addon sends:

| Assumed (wrong) | Actual (from addon) |
|-----------------|---------------------|
| 0 = ALIVE | 0 = DEAD |
| 1 = INCAPACITATED | 1 = ALIVE |
| 2 = DEAD | 2 = UNCONSCIOUS |

The addon (`fnc_captureLoop.sqf`) already converts Arma's string lifestate to the numeric format expected by the web UI:

```sqf
private _lifeState = 0;           // 0 = DEAD (default)
if (alive _x) then {
    _lifeState = if (conscious) then {1} else {2};  // 1=ALIVE, 2=UNCONSCIOUS
};
```

The conversion function was inverting correct values into incorrect ones.

## Test plan

- [ ] Build the DLL and test in-game
- [ ] Verify dead units show death marker (not yellow/unconscious)
- [ ] Verify alive units appear normal (not faded/dead)
- [ ] Verify unconscious units show yellow marker