### PR TITLE
fix: parse JSON arrays in general event messages for export

### DIFF
--- a/internal/storage/memory/export.go
+++ b/internal/storage/memory/export.go
@@ -236,10 +236,19 @@ func (b *Backend) buildExport() OcapExport {
 	// Convert general events
 	// Format: [frameNum, "type", message]
 	for _, evt := range b.generalEvents {
+		// Try to parse message as JSON - if it's a valid JSON array/object, use parsed value
+		// Otherwise keep as string
+		var message any = evt.Message
+		if len(evt.Message) > 0 && (evt.Message[0] == '[' || evt.Message[0] == '{') {
+			var parsed any
+			if err := json.Unmarshal([]byte(evt.Message), &parsed); err == nil {
+				message = parsed
+			}
+		}
 		export.Events = append(export.Events, []any{
 			evt.CaptureFrame,
 			evt.Name,
-			evt.Message,
+			message,
 		})
 	}
 


### PR DESCRIPTION
## Summary
- Events like `respawnTickets` send array data as strings (e.g., `"[-1,-1,-1,-1]"`)
- Previously exported as string literals in JSON: `[30, "respawnTickets", "[-1,-1,-1,-1]"]`
- Now properly parsed and exported as native JSON arrays: `[30, "respawnTickets", [-1,-1,-1,-1]]`

## Test plan
- [x] Existing tests pass
- [ ] Verify respawnTickets and similar events export as native JSON arrays