### PR TITLE
fix: prevent nil pointer panic when mission init fails

### DIFF
--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -2,6 +2,7 @@
 package memory
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/OCAP2/extension/v5/internal/config"
@@ -103,6 +104,10 @@ func (b *Backend) StartMission(mission *core.Mission, world *core.World) error {
 func (b *Backend) EndMission() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	if b.mission == nil {
+		return fmt.Errorf("no mission to end: mission was never started")
+	}
 
 	return b.exportJSON()
 }
@@ -313,9 +318,14 @@ func (b *Backend) GetExportedFilePath() string {
 }
 
 // GetExportMetadata returns metadata about the last export.
+// Returns empty metadata if no mission was started.
 func (b *Backend) GetExportMetadata() storage.UploadMetadata {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
+
+	if b.mission == nil || b.world == nil {
+		return storage.UploadMetadata{}
+	}
 
 	var endFrame uint
 	for _, record := range b.soldiers {

--- a/internal/storage/memory/memory_test.go
+++ b/internal/storage/memory/memory_test.go
@@ -934,3 +934,36 @@ func TestStartMissionResetsExportPath(t *testing.T) {
 		t.Errorf("expected empty path after StartMission, got %s", path)
 	}
 }
+
+func TestEndMissionWithoutStartMission(t *testing.T) {
+	b := New(config.MemoryConfig{})
+
+	// EndMission without StartMission should return an error, not panic
+	err := b.EndMission()
+	if err == nil {
+		t.Error("expected error when ending mission that was never started")
+	}
+	if !strings.Contains(err.Error(), "no mission to end") {
+		t.Errorf("expected error message to contain 'no mission to end', got: %s", err.Error())
+	}
+}
+
+func TestGetExportMetadataWithoutStartMission(t *testing.T) {
+	b := New(config.MemoryConfig{})
+
+	// GetExportMetadata without StartMission should return empty metadata, not panic
+	meta := b.GetExportMetadata()
+
+	if meta.WorldName != "" {
+		t.Errorf("expected empty WorldName, got %s", meta.WorldName)
+	}
+	if meta.MissionName != "" {
+		t.Errorf("expected empty MissionName, got %s", meta.MissionName)
+	}
+	if meta.Tag != "" {
+		t.Errorf("expected empty Tag, got %s", meta.Tag)
+	}
+	if meta.MissionDuration != 0 {
+		t.Errorf("expected MissionDuration=0, got %f", meta.MissionDuration)
+	}
+}


### PR DESCRIPTION
## Summary
- Add nil check in `EndMission()` to return error instead of panic when no mission was started
- Add nil check in `GetExportMetadata()` to return empty metadata instead of panic
- Add tests for both nil mission scenarios

## Problem
When `:INIT:` fails (e.g., Arma addon passes `any` instead of an array), no mission is started. However, subsequent commands like `:SAVE:MISSION:` still execute. When `EndMission()` or `GetExportMetadata()` tried to access `b.mission` fields, it caused a nil pointer dereference panic:

```
["error", "panic in RVExtensionArgs: runtime error: invalid memory address or nil pointer dereference"]
```

## Test plan
- [x] `TestEndMissionWithoutStartMission` - verifies error returned instead of panic
- [x] `TestGetExportMetadataWithoutStartMission` - verifies empty metadata returned instead of panic
- [x] All existing tests pass