### PR TITLE
fix: deduplicate coverage blocks in CI workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,7 +32,22 @@ jobs:
         run: go vet ./internal/...
 
       - name: Run tests
-        run: go test -coverprofile=cover.out -coverpkg=./internal/... ./internal/...
+        run: go test -coverprofile=cover.out.raw -coverpkg=./internal/... ./internal/...
+
+      - name: Deduplicate coverage blocks
+        # Workaround for fgrosse/go-coverage-report#61: merge duplicate coverage blocks
+        # When using -coverpkg, Go creates duplicate entries for each test package
+        run: |
+          head -1 cover.out.raw > cover.out
+          tail -n +2 cover.out.raw | awk '{
+            key = $1
+            stmt = $2
+            count = $3 + 0
+            if (count > counts[key]) counts[key] = count
+            stmts[key] = stmt
+          } END {
+            for (key in stmts) print key, stmts[key], counts[key] + 0
+          }' | sort >> cover.out
 
       - name: Archive code coverage results
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v4


### PR DESCRIPTION
## Summary
Fix incorrect coverage percentages in PR comments caused by a known bug in `fgrosse/go-coverage-report` ([#61](https://github.com/fgrosse/go-coverage-report/issues/61)).

## Problem
When using `-coverpkg=./internal/...`, Go creates duplicate coverage entries for each code block (one per test package). The action counts these duplicates multiple times instead of merging them, resulting in grossly incorrect percentages.

**Example from PR #75:**
| File | Actual Coverage | Reported Coverage |
|------|----------------|-------------------|
| v1/builder.go | 100% (100/100 statements) | 20.96% (267/1274 statements) |

The "1274 statements" was actually 100 unique statements × ~13 test packages.

## Fix
Add an awk step to merge duplicate coverage blocks before uploading the artifact. For each code block, we keep only the maximum execution count across all duplicates.

## Test plan
- [x] Tested locally: `go tool cover -func` shows correct 100% coverage after deduplication
- [x] CI should now report accurate coverage percentages