### PR TITLE
feat: add projectile marker support for grenades and smokes

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -772,10 +772,10 @@ func (s *Service) LogProjectileEvent(data []string) (model.ProjectileEvent, erro
 			continue
 		}
 
-		// posArr[0] = tickTime (float)
-		tickTime, ok := posArr[0].(float64)
+		// posArr[1] = frameNo (float64 from JSON)
+		frameNo, ok := posArr[1].(float64)
 		if !ok {
-			logger.Warn("Invalid tickTime in position", "value", posArr[0])
+			logger.Warn("Invalid frameNo in position", "value", posArr[1])
 			continue
 		}
 
@@ -793,12 +793,13 @@ func (s *Service) LogProjectileEvent(data []string) (model.ProjectileEvent, erro
 		}
 		coords, _ := point.Coordinates()
 
+		// Store as XYZM where M = frame number (used by projectile markers)
 		positionSequence = append(
 			positionSequence,
 			coords.XY.X,
 			coords.XY.Y,
 			coords.Z,
-			tickTime,
+			frameNo,
 		)
 	}
 

--- a/internal/model/convert/convert.go
+++ b/internal/model/convert/convert.go
@@ -442,17 +442,15 @@ func ProjectileEventToProjectileMarker(p model.ProjectileEvent) (core.Marker, []
 	var frames []uint
 
 	// Extract positions from the LineStringZM geometry
-	// Format: [x, y, z, tickTime] where we use tickTime's frame approximation
+	// Format: [x, y, z, frameNo] where M coordinate contains the frame number
 	if !p.Positions.IsEmpty() {
 		if ls, ok := p.Positions.AsLineString(); ok {
 			seq := ls.Coordinates()
 			for i := 0; i < seq.Length(); i++ {
 				pt := seq.Get(i)
 				positions = append(positions, core.Position3D{X: pt.X, Y: pt.Y, Z: pt.Z})
-				// M coordinate contains tickTime, but we need frame numbers
-				// The frame numbers are embedded in the original positions array from SQF
-				// For now, estimate frame offset from start
-				frames = append(frames, p.CaptureFrame+uint(i))
+				// M coordinate contains the frame number
+				frames = append(frames, uint(pt.M))
 			}
 		}
 	}

--- a/internal/model/convert/convert.go
+++ b/internal/model/convert/convert.go
@@ -3,6 +3,7 @@ package convert
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/OCAP2/extension/v5/internal/model"
 	"github.com/OCAP2/extension/v5/internal/model/core"
@@ -403,6 +404,100 @@ func ProjectileEventToFiredEvent(p model.ProjectileEvent) core.FiredEvent {
 		StartPos:     startPos,
 		EndPos:       endPos,
 	}
+}
+
+// ProjectileEventToProjectileMarker converts a thrown projectile (grenade, smoke) to a marker
+// for the web viewer. Returns the marker and any state changes for trajectory positions.
+// Only call this for projectiles where Weapon == "throw".
+func ProjectileEventToProjectileMarker(p model.ProjectileEvent) (core.Marker, []core.MarkerState) {
+	// Extract filename from icon path: "\A3\...\gear_smokegrenade_white_ca.paa" → "magIcons/gear_smokegrenade_white_ca.paa"
+	// Handle both forward and backslash separators (Arma uses backslashes)
+	iconPath := p.MagazineIcon
+	// Find last separator (either / or \)
+	lastSep := -1
+	for i := len(iconPath) - 1; i >= 0; i-- {
+		if iconPath[i] == '/' || iconPath[i] == '\\' {
+			lastSep = i
+			break
+		}
+	}
+	var iconFilename string
+	if lastSep >= 0 {
+		iconFilename = iconPath[lastSep+1:]
+	} else {
+		iconFilename = iconPath
+	}
+	markerType := "magIcons/" + iconFilename
+	if iconFilename == "" {
+		// Fallback for missing icon
+		markerType = "magIcons/gear_unknown_ca.paa"
+	}
+
+	// Generate unique marker name and ID
+	// ID combines frame and firer to ensure uniqueness
+	markerName := fmt.Sprintf("projectile_%d_%d", p.CaptureFrame, p.FirerObjectID)
+	markerID := uint(p.CaptureFrame)<<16 | uint(p.FirerObjectID)
+
+	var positions []core.Position3D
+	var frames []uint
+
+	// Extract positions from the LineStringZM geometry
+	// Format: [x, y, z, tickTime] where we use tickTime's frame approximation
+	if !p.Positions.IsEmpty() {
+		if ls, ok := p.Positions.AsLineString(); ok {
+			seq := ls.Coordinates()
+			for i := 0; i < seq.Length(); i++ {
+				pt := seq.Get(i)
+				positions = append(positions, core.Position3D{X: pt.X, Y: pt.Y, Z: pt.Z})
+				// M coordinate contains tickTime, but we need frame numbers
+				// The frame numbers are embedded in the original positions array from SQF
+				// For now, estimate frame offset from start
+				frames = append(frames, p.CaptureFrame+uint(i))
+			}
+		}
+	}
+
+	// Use first position for the marker, rest become states
+	var firstPos core.Position3D
+	if len(positions) > 0 {
+		firstPos = positions[0]
+	}
+
+	marker := core.Marker{
+		ID:           markerID,
+		MissionID:    p.MissionID,
+		CaptureFrame: p.CaptureFrame,
+		MarkerName:   markerName,
+		MarkerType:   markerType,
+		Text:         p.MagazineDisplay,
+		OwnerID:      int(p.FirerObjectID),
+		Color:        "FFFFFF",
+		Side:         "GLOBAL",
+		Position:     firstPos,
+		Size:         "[1,1]",
+		Shape:        "ICON",
+		Alpha:        1.0,
+		Brush:        "Solid",
+	}
+
+	// Create states for remaining positions (trajectory)
+	var states []core.MarkerState
+	for i := 1; i < len(positions); i++ {
+		frame := frames[i]
+		if i < len(frames) {
+			frame = frames[i]
+		}
+		states = append(states, core.MarkerState{
+			MarkerID:     markerID,
+			MissionID:    p.MissionID,
+			CaptureFrame: frame,
+			Position:     positions[i],
+			Direction:    0,
+			Alpha:        1.0,
+		})
+	}
+
+	return marker, states
 }
 
 // MissionToCore converts a GORM Mission to a core.Mission

--- a/internal/model/convert/convert.go
+++ b/internal/model/convert/convert.go
@@ -341,6 +341,7 @@ func MarkerToCore(m model.Marker) core.Marker {
 		MissionID:    m.MissionID,
 		Time:         m.Time,
 		CaptureFrame: m.CaptureFrame,
+		EndFrame:     -1, // Regular markers persist until end
 		MarkerName:   m.MarkerName,
 		Direction:    m.Direction,
 		MarkerType:   m.MarkerType,
@@ -461,10 +462,17 @@ func ProjectileEventToProjectileMarker(p model.ProjectileEvent) (core.Marker, []
 		firstPos = positions[0]
 	}
 
+	// EndFrame is the last position's frame (when grenade explodes/dissipates)
+	endFrame := -1
+	if len(frames) > 0 {
+		endFrame = int(frames[len(frames)-1])
+	}
+
 	marker := core.Marker{
 		ID:           markerID,
 		MissionID:    p.MissionID,
 		CaptureFrame: p.CaptureFrame,
+		EndFrame:     endFrame,
 		MarkerName:   markerName,
 		MarkerType:   markerType,
 		Text:         p.MagazineDisplay,

--- a/internal/model/convert/convert_test.go
+++ b/internal/model/convert/convert_test.go
@@ -707,10 +707,11 @@ func TestProjectileEventToFiredEvent_EmptyPositions(t *testing.T) {
 
 func TestProjectileEventToProjectileMarker(t *testing.T) {
 	// Create a LineStringZM with 3 points (thrown, mid-flight, impact)
+	// Format: [x, y, z, frameNo] where M = frame number
 	coords := []float64{
-		100.0, 200.0, 10.0, 1000.0, // thrown position
-		150.0, 250.0, 15.0, 1001.0, // mid-flight
-		200.0, 300.0, 5.0, 1002.0,  // impact position
+		100.0, 200.0, 10.0, 243.0, // thrown position at frame 243
+		150.0, 250.0, 15.0, 245.0, // mid-flight at frame 245
+		200.0, 300.0, 5.0, 303.0,  // impact position at frame 303
 	}
 	seq := geom.NewSequence(coords, geom.DimXYZM)
 	ls, _ := geom.NewLineString(seq)
@@ -764,6 +765,14 @@ func TestProjectileEventToProjectileMarker(t *testing.T) {
 	if states[1].Position.X != 200.0 || states[1].Position.Y != 300.0 {
 		t.Errorf("expected state[1] Position=(200,300), got (%f,%f)",
 			states[1].Position.X, states[1].Position.Y)
+	}
+
+	// States should have correct frame numbers from M coordinate
+	if states[0].CaptureFrame != 245 {
+		t.Errorf("expected state[0] CaptureFrame=245, got %d", states[0].CaptureFrame)
+	}
+	if states[1].CaptureFrame != 303 {
+		t.Errorf("expected state[1] CaptureFrame=303, got %d", states[1].CaptureFrame)
 	}
 
 	// States should reference marker ID

--- a/internal/model/convert/convert_test.go
+++ b/internal/model/convert/convert_test.go
@@ -748,6 +748,11 @@ func TestProjectileEventToProjectileMarker(t *testing.T) {
 		t.Errorf("expected MarkerName=projectile_100_42, got %s", marker.MarkerName)
 	}
 
+	// EndFrame should be the last position's frame (303)
+	if marker.EndFrame != 303 {
+		t.Errorf("expected EndFrame=303, got %d", marker.EndFrame)
+	}
+
 	// First position should be in marker
 	if marker.Position.X != 100.0 || marker.Position.Y != 200.0 {
 		t.Errorf("expected marker Position=(100,200), got (%f,%f)",

--- a/internal/model/core/marker.go
+++ b/internal/model/core/marker.go
@@ -9,6 +9,7 @@ type Marker struct {
 	MissionID    uint
 	Time         time.Time
 	CaptureFrame uint
+	EndFrame     int // -1 means persist until end, otherwise frame when marker disappears
 	MarkerName   string
 	Direction    float32
 	MarkerType   string

--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -297,11 +297,17 @@ func Build(data *MissionData) Export {
 		// With "#" prefix, browsers interpret the fragment as an anchor, causing 404s
 		markerColor := strings.TrimPrefix(record.Marker.Color, "#")
 
+		// EndFrame: 0 means not set (use -1 to persist), positive means specific end frame
+		endFrame := record.Marker.EndFrame
+		if endFrame == 0 {
+			endFrame = -1
+		}
+
 		marker := []any{
 			record.Marker.MarkerType,            // [0] type
 			record.Marker.Text,                  // [1] text
 			record.Marker.CaptureFrame,          // [2] startFrame
-			-1,                                  // [3] endFrame (-1 = persists until end)
+			endFrame,                            // [3] endFrame (-1 = persists until end, otherwise frame when marker disappears)
 			record.Marker.OwnerID,               // [4] playerId (entity ID of creating player, -1 for system markers)
 			markerColor,                         // [5] color (# prefix stripped for URL compatibility)
 			sideToIndex(record.Marker.Side),     // [6] sideIndex


### PR DESCRIPTION
## Summary

- Thrown projectiles (grenades, smokes) are now exported as markers in the v1 JSON format
- Enables the web viewer to display grenade/smoke icons with trajectory positions
- Other projectiles (bullets, rockets) continue to use fire lines

## Changes

- Add `ProjectileEventToProjectileMarker` converter that extracts icon filename from Arma path and creates marker with trajectory states
- Modify `handleProjectileEvent` to route thrown projectiles (`Weapon="throw"`) to `AddMarker` instead of `RecordFiredEvent`
- Add tests for projectile marker conversion

## Marker Format

The marker format follows web viewer expectations:
- **Type**: `magIcons/<icon_filename>.paa`
- **Side**: `GLOBAL` (-1)
- **OwnerID**: firer's OCAP ID
- **Positions**: trajectory from throw to impact

## Example Output

```json
[
  "magIcons/gear_smokegrenade_white_ca.paa",
  "Smoke Grenade (White)",
  243,
  -1,
  5,
  "FFFFFF",
  -1,
  [[243, [8345.61, 18302.5], 0, 1], [245, [8364.59, 18331.1], 0, 1]],
  [1, 1],
  "ICON",
  "Solid"
]
```

## Test plan

- [x] Unit tests for `ProjectileEventToProjectileMarker` pass
- [x] Unit tests for empty icon fallback pass
- [x] Full test suite passes
- [x] Manual test with Arma 3 recording containing grenades/smokes