### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,14 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
----
-
-THIRD-PARTY CONTENT NOTICE
-
-This software is designed to work with Arma 3 by Bohemia Interactive.
-Map imagery, terrain data, and other game assets extracted or displayed by this
-software remain the intellectual property of Bohemia Interactive a.s. and are
-subject to Bohemia Interactive's End User License Agreement and Tools License.
-This license (MIT) applies solely to the OCAP2 source code, not to any
-Bohemia Interactive content.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,32 @@
+MIT License
+
+Copyright (c) 2021 OCAP2 Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+THIRD-PARTY CONTENT NOTICE
+
+This software is designed to work with Arma 3 by Bohemia Interactive.
+Map imagery, terrain data, and other game assets extracted or displayed by this
+software remain the intellectual property of Bohemia Interactive a.s. and are
+subject to Bohemia Interactive's End User License Agreement and Tools License.
+This license (MIT) applies solely to the OCAP2 source code, not to any
+Bohemia Interactive content.


### PR DESCRIPTION
## Summary
- Adds MIT LICENSE file to satisfy GitHub community standards
- Copyright attributed to OCAP2 Contributors
- Includes third-party content notice clarifying that Bohemia Interactive game assets (map tiles, terrain data) are BI's intellectual property and not covered by this license

## Test plan
- [ ] Verify LICENSE renders correctly on GitHub repo page
- [ ] Confirm GitHub community standards checklist shows license as present