### PR TITLE
fix: preserve brackets in vehicle crew data to fix side coloring

### DIFF
--- a/cmd/ocap_recorder/main.go
+++ b/cmd/ocap_recorder/main.go
@@ -1467,11 +1467,7 @@ func getOcapRecording(missionIDs []string) (err error) {
 			for _, state := range vehicleStates {
 				coord, _ := state.Position.Coordinates()
 				var crew any
-				if state.Crew != "" {
-					if err := json.Unmarshal([]byte(state.Crew), &crew); err != nil {
-						crew = []any{}
-					}
-				} else {
+				if err := json.Unmarshal([]byte(state.Crew), &crew); err != nil {
 					crew = []any{}
 				}
 				position := []any{

--- a/cmd/ocap_recorder/main.go
+++ b/cmd/ocap_recorder/main.go
@@ -1463,15 +1463,22 @@ func getOcapRecording(missionIDs []string) (err error) {
 			if err != nil {
 				return fmt.Errorf("error getting vehicle states: %w", err)
 			}
-
 			positions := []any{}
 			for _, state := range vehicleStates {
 				coord, _ := state.Position.Coordinates()
+				var crew any
+				if state.Crew != "" {
+					if err := json.Unmarshal([]byte(state.Crew), &crew); err != nil {
+						crew = []any{}
+					}
+				} else {
+					crew = []any{}
+				}
 				position := []any{
 					[]float64{coord.XY.X, coord.XY.Y},
 					state.Bearing,
 					state.IsAlive,
-					state.Crew,
+					crew,
 				}
 				positions = append(positions, position)
 			}

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -542,11 +542,8 @@ func (s *Service) LogVehicleState(data []string) (model.VehicleState, error) {
 	// is alive
 	isAlive, _ := strconv.ParseBool(data[3])
 	vehicleState.IsAlive = isAlive
-	// parse crew, which is an array of ocap ids of soldiers
-	crew := data[4]
-	crew = strings.TrimPrefix(crew, "[")
-	crew = strings.TrimSuffix(crew, "]")
-	vehicleState.Crew = crew
+	// parse crew, which is a JSON array of ocap ids of soldiers (e.g. "[202,203]")
+	vehicleState.Crew = data[4]
 
 	// fuel
 	fuel, err := strconv.ParseFloat(data[6], 32)


### PR DESCRIPTION
## Summary

- Vehicle crew arrays from the game (e.g. `[20,21]`) had their brackets stripped by the handler, storing `20,21` instead
- During JSON export, `json.Unmarshal("20,21")` failed for multi-crew vehicles → empty crew `[]` in output
- Single-crew vehicles exported a bare scalar (`108`) instead of an array (`[108]`)
- The web frontend derives vehicle side/color from crew members' factions, so all vehicles appeared without side colors

**Root cause**: `handlers.go` line 546-548 stripped `[` and `]` from crew data before storing

**Fix**:
- Stop stripping brackets in `LogVehicleState` — store the raw JSON array string as received from the game
- Parse crew as JSON in the legacy DB export path (`main.go`) to match the memory export path

## Test plan

- [x] `TestLogVehicleState_CrewPreservesBrackets` — handler preserves brackets for multi-crew, single-crew, empty, and large arrays
- [x] `TestBuildWithVehicleCrewIDArray` — builder correctly parses `[20,21]`, `[20]`, and `[]` crew formats
- [x] `TestVehicleCrewExportIntegration` — full pipeline (memory backend → builder → JSON file → JSON parse) with crew array round-trip
- [x] Full test suite passes (`go test ./...`)