### PR TITLE
fix: use filepath.Join for log path to support Linux

### DIFF
--- a/cmd/ocap_recorder/main.go
+++ b/cmd/ocap_recorder/main.go
@@ -256,7 +256,7 @@ func init() {
 		return false
 	}
 
-	SqliteDBFilePath = fmt.Sprintf(`%s\%s_%s.db`, AddonFolder, ExtensionName, SessionStartTime.Format("20060102_150405"))
+	SqliteDBFilePath = filepath.Join(AddonFolder, fmt.Sprintf("%s_%s.db", ExtensionName, SessionStartTime.Format("20060102_150405")))
 	// set up a3interfaces
 	Logger.Info("Setting up a3interface...")
 	err = setupA3Interface()

--- a/cmd/ocap_recorder/main.go
+++ b/cmd/ocap_recorder/main.go
@@ -188,10 +188,7 @@ func init() {
 		os.Mkdir(viper.GetString("logsDir"), 0755)
 	}
 
-	OcapLogFilePath = filepath.Join(
-		viper.GetString("logsDir"),
-		fmt.Sprintf("%s.%s.log", ExtensionName, SessionStartTime.Format("20060102_150405")),
-	)
+	OcapLogFilePath = logging.LogFilePath(viper.GetString("logsDir"), ExtensionName, SessionStartTime)
 
 	// check if OcapLogFilePath exists
 	// if it does, move it to OcapLogFilePath.old

--- a/cmd/ocap_recorder/main.go
+++ b/cmd/ocap_recorder/main.go
@@ -188,11 +188,9 @@ func init() {
 		os.Mkdir(viper.GetString("logsDir"), 0755)
 	}
 
-	OcapLogFilePath = fmt.Sprintf(
-		`%s\%s.%s.log`,
+	OcapLogFilePath = filepath.Join(
 		viper.GetString("logsDir"),
-		ExtensionName,
-		SessionStartTime.Format("20060102_150405"),
+		fmt.Sprintf("%s.%s.log", ExtensionName, SessionStartTime.Format("20060102_150405")),
 	)
 
 	// check if OcapLogFilePath exists

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,4 +1,15 @@
 package logging
 
-// This file is kept for potential future utilities
-// The main logging implementation is in slog.go
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+)
+
+// LogFilePath builds a log file path using OS-appropriate path separators.
+func LogFilePath(logsDir, extensionName string, sessionStart time.Time) string {
+	return filepath.Join(
+		logsDir,
+		fmt.Sprintf("%s.%s.log", extensionName, sessionStart.Format("20060102_150405")),
+	)
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,46 @@
+package logging
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLogFilePath(t *testing.T) {
+	sessionStart := time.Date(2026, 2, 12, 21, 38, 36, 0, time.UTC)
+
+	tests := []struct {
+		name          string
+		logsDir       string
+		extensionName string
+		want          string
+	}{
+		{
+			name:          "basic path",
+			logsDir:       "ocaplogs",
+			extensionName: "ocap_recorder",
+			want:          filepath.Join("ocaplogs", "ocap_recorder.20260212_213836.log"),
+		},
+		{
+			name:          "relative path with dot",
+			logsDir:       "./ocaplogs",
+			extensionName: "ocap_recorder",
+			want:          filepath.Join(".", "ocaplogs", "ocap_recorder.20260212_213836.log"),
+		},
+		{
+			name:          "absolute path",
+			logsDir:       filepath.Join("/var", "log", "ocap"),
+			extensionName: "ocap_recorder",
+			want:          filepath.Join("/var", "log", "ocap", "ocap_recorder.20260212_213836.log"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := LogFilePath(tt.logsDir, tt.extensionName, sessionStart)
+			if got != tt.want {
+				t.Errorf("LogFilePath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Log file path was constructed using a hardcoded `\` separator (`fmt.Sprintf("%s\%s.%s.log", ...)`) which broke on Linux
- Replaced with `filepath.Join` which uses the correct OS-specific path separator

## Test plan
- [x] Verify log file is created correctly on Linux
- [x] Verify log file is created correctly on Windows