### PR TITLE
fix: use Debian Bullseye for Linux build to fix glibc compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,14 +9,14 @@ Go native DLL extension for ArmA 3 that records gameplay/mission replay data to 
 ## Build Commands
 
 ```bash
-# Pull Docker image
-docker pull x1unix/go-mingw:1.24
-
 # Build x64 Windows DLL
 docker run --rm -v ${PWD}:/go/work -w /go/work x1unix/go-mingw:1.24 go build -buildvcs=false -o dist/ocap_recorder_x64.dll -buildmode=c-shared ./cmd/ocap_recorder
+
+# Build x64 Linux .so (uses Bullseye for glibc 2.31 compatibility)
+docker run --rm -v ${PWD}:/go/work -w /go/work golang:1.24-bullseye go build -buildvcs=false -o dist/ocap_recorder_x64.so -buildmode=c-shared ./cmd/ocap_recorder
 ```
 
-**Output:** `dist/ocap_recorder_x64.dll`
+**Output:** `dist/ocap_recorder_x64.dll`, `dist/ocap_recorder_x64.so`
 
 ## Project Structure (Go Standard Layout)
 

--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ docker run --rm -v ${PWD}:/go/work -w /go/work x1unix/go-mingw:1.24 \
 ### Linux .so
 
 ```bash
-docker build -t indifox926/build-a3go:linux-so -f ./Dockerfile .
-
-docker run --rm -v ${PWD}:/app -e GOOS=linux -e GOARCH=amd64 -e CGO_ENABLED=1 -e CC=gcc \
-  indifox926/build-a3go:linux-so go build -o dist/ocap_recorder_x64.so -linkshared ./cmd/ocap_recorder
+docker run --rm -v ${PWD}:/go/work -w /go/work golang:1.24-bullseye \
+  go build -buildvcs=false -o dist/ocap_recorder_x64.so -buildmode=c-shared ./cmd/ocap_recorder
 ```
+
+Uses Debian Bullseye (glibc 2.31) for broad compatibility with Linux game servers.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- Replace custom Dockerfile-based Linux build with `golang:1.24-bullseye` (glibc 2.31)
- Fixes `GLIBC_2.32` / `GLIBC_2.34` not found errors reported by users on Linux game servers
- Update build instructions in README.md and CLAUDE.md

## Test plan
- [x] Built .so with `golang:1.24-bullseye` and verified max glibc requirement is 2.14 via `objdump`