### PR TITLE
refactor: use testify assertions in all test files

### DIFF
--- a/internal/cache/marker_test.go
+++ b/internal/cache/marker_test.go
@@ -3,17 +3,16 @@ package cache
 import (
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMarkerCache_NewMarkerCache(t *testing.T) {
 	cache := NewMarkerCache()
 
-	if cache == nil {
-		t.Fatal("expected non-nil cache")
-	}
-	if cache.markers == nil {
-		t.Error("expected markers map to be initialized")
-	}
+	require.NotNil(t, cache)
+	assert.NotNil(t, cache.markers)
 }
 
 func TestMarkerCache_SetAndGet(t *testing.T) {
@@ -22,21 +21,15 @@ func TestMarkerCache_SetAndGet(t *testing.T) {
 	cache.Set("marker1", 42)
 
 	id, ok := cache.Get("marker1")
-	if !ok {
-		t.Fatal("expected to find marker1")
-	}
-	if id != 42 {
-		t.Errorf("expected id 42, got %d", id)
-	}
+	require.True(t, ok, "expected to find marker1")
+	assert.Equal(t, uint(42), id)
 }
 
 func TestMarkerCache_Get_NotFound(t *testing.T) {
 	cache := NewMarkerCache()
 
 	_, ok := cache.Get("nonexistent")
-	if ok {
-		t.Error("expected not to find nonexistent marker")
-	}
+	assert.False(t, ok, "expected not to find nonexistent marker")
 }
 
 func TestMarkerCache_Delete(t *testing.T) {
@@ -47,24 +40,18 @@ func TestMarkerCache_Delete(t *testing.T) {
 
 	// Verify marker exists
 	_, ok := cache.Get("marker1")
-	if !ok {
-		t.Fatal("expected to find marker1 before delete")
-	}
+	require.True(t, ok, "expected to find marker1 before delete")
 
 	// Delete marker
 	cache.Delete("marker1")
 
 	// Verify marker is deleted
 	_, ok = cache.Get("marker1")
-	if ok {
-		t.Error("expected not to find marker1 after delete")
-	}
+	assert.False(t, ok, "expected not to find marker1 after delete")
 
 	// Verify other marker still exists
 	_, ok = cache.Get("marker2")
-	if !ok {
-		t.Error("expected marker2 to still exist")
-	}
+	assert.True(t, ok, "expected marker2 to still exist")
 }
 
 func TestMarkerCache_Delete_NonExistent(t *testing.T) {
@@ -84,21 +71,19 @@ func TestMarkerCache_Reset(t *testing.T) {
 	cache.Reset()
 
 	// Verify all markers are cleared
-	if _, ok := cache.Get("marker1"); ok {
-		t.Error("expected marker1 to be cleared after reset")
-	}
-	if _, ok := cache.Get("marker2"); ok {
-		t.Error("expected marker2 to be cleared after reset")
-	}
-	if _, ok := cache.Get("marker3"); ok {
-		t.Error("expected marker3 to be cleared after reset")
-	}
+	_, ok := cache.Get("marker1")
+	assert.False(t, ok, "expected marker1 to be cleared after reset")
+
+	_, ok = cache.Get("marker2")
+	assert.False(t, ok, "expected marker2 to be cleared after reset")
+
+	_, ok = cache.Get("marker3")
+	assert.False(t, ok, "expected marker3 to be cleared after reset")
 
 	// Verify we can still add markers after reset
 	cache.Set("marker4", 4)
-	if _, ok := cache.Get("marker4"); !ok {
-		t.Error("expected to find marker4 after reset")
-	}
+	_, ok = cache.Get("marker4")
+	assert.True(t, ok, "expected to find marker4 after reset")
 }
 
 func TestMarkerCache_OverwriteExisting(t *testing.T) {
@@ -108,12 +93,8 @@ func TestMarkerCache_OverwriteExisting(t *testing.T) {
 	cache.Set("marker1", 100)
 
 	id, ok := cache.Get("marker1")
-	if !ok {
-		t.Fatal("expected to find marker1")
-	}
-	if id != 100 {
-		t.Errorf("expected id to be overwritten to 100, got %d", id)
-	}
+	require.True(t, ok, "expected to find marker1")
+	assert.Equal(t, uint(100), id)
 }
 
 func TestMarkerCache_Concurrent(t *testing.T) {

--- a/internal/geo/geo_test.go
+++ b/internal/geo/geo_test.go
@@ -1,231 +1,139 @@
 package geo
 
 import (
-	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCoord3857FromString_ValidWithElevation(t *testing.T) {
 	point, elev, err := Coord3857FromString("100.5,200.25,50.0")
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	coords, ok := point.Coordinates()
-	if !ok {
-		t.Fatal("expected valid coordinates")
-	}
-	if coords.X != 100.5 {
-		t.Errorf("expected X=100.5, got %f", coords.X)
-	}
-	if coords.Y != 200.25 {
-		t.Errorf("expected Y=200.25, got %f", coords.Y)
-	}
-	if elev != 50.0 {
-		t.Errorf("expected elevation=50.0, got %f", elev)
-	}
+	require.True(t, ok, "expected valid coordinates")
+	assert.Equal(t, 100.5, coords.X)
+	assert.Equal(t, 200.25, coords.Y)
+	assert.Equal(t, 50.0, elev)
 }
 
 func TestCoord3857FromString_ValidWithoutElevation(t *testing.T) {
 	point, elev, err := Coord3857FromString("100.5,200.25")
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	coords, ok := point.Coordinates()
-	if !ok {
-		t.Fatal("expected valid coordinates")
-	}
-	if coords.X != 100.5 {
-		t.Errorf("expected X=100.5, got %f", coords.X)
-	}
-	if coords.Y != 200.25 {
-		t.Errorf("expected Y=200.25, got %f", coords.Y)
-	}
-	if elev != 0 {
-		t.Errorf("expected elevation=0, got %f", elev)
-	}
+	require.True(t, ok, "expected valid coordinates")
+	assert.Equal(t, 100.5, coords.X)
+	assert.Equal(t, 200.25, coords.Y)
+	assert.Equal(t, 0.0, elev)
 }
 
 func TestCoord3857FromString_NegativeCoordinates(t *testing.T) {
 	point, elev, err := Coord3857FromString("-100.5,-200.25,-50.0")
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	coords, ok := point.Coordinates()
-	if !ok {
-		t.Fatal("expected valid coordinates")
-	}
-	if coords.X != -100.5 {
-		t.Errorf("expected X=-100.5, got %f", coords.X)
-	}
-	if coords.Y != -200.25 {
-		t.Errorf("expected Y=-200.25, got %f", coords.Y)
-	}
-	if elev != -50.0 {
-		t.Errorf("expected elevation=-50.0, got %f", elev)
-	}
+	require.True(t, ok, "expected valid coordinates")
+	assert.Equal(t, -100.5, coords.X)
+	assert.Equal(t, -200.25, coords.Y)
+	assert.Equal(t, -50.0, elev)
 }
 
 func TestCoord3857FromString_IntegerCoordinates(t *testing.T) {
 	point, _, err := Coord3857FromString("100,200")
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	coords, ok := point.Coordinates()
-	if !ok {
-		t.Fatal("expected valid coordinates")
-	}
-	if coords.X != 100 {
-		t.Errorf("expected X=100, got %f", coords.X)
-	}
-	if coords.Y != 200 {
-		t.Errorf("expected Y=200, got %f", coords.Y)
-	}
+	require.True(t, ok, "expected valid coordinates")
+	assert.Equal(t, 100.0, coords.X)
+	assert.Equal(t, 200.0, coords.Y)
 }
 
 func TestCoord3857FromString_ZeroCoordinates(t *testing.T) {
 	point, elev, err := Coord3857FromString("0,0,0")
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	coords, ok := point.Coordinates()
-	if !ok {
-		t.Fatal("expected valid coordinates")
-	}
-	if coords.X != 0 {
-		t.Errorf("expected X=0, got %f", coords.X)
-	}
-	if coords.Y != 0 {
-		t.Errorf("expected Y=0, got %f", coords.Y)
-	}
-	if elev != 0 {
-		t.Errorf("expected elevation=0, got %f", elev)
-	}
+	require.True(t, ok, "expected valid coordinates")
+	assert.Equal(t, 0.0, coords.X)
+	assert.Equal(t, 0.0, coords.Y)
+	assert.Equal(t, 0.0, elev)
 }
 
 func TestCoord3857FromString_InvalidTooFewComponents(t *testing.T) {
 	_, _, err := Coord3857FromString("100.5")
 
-	if err == nil {
-		t.Fatal("expected error for invalid coordinates")
-	}
-	if !errors.Is(err, ErrInvalidCoordinates) {
-		t.Errorf("expected ErrInvalidCoordinates, got %v", err)
-	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidCoordinates)
 }
 
 func TestCoord3857FromString_InvalidEmptyString(t *testing.T) {
 	_, _, err := Coord3857FromString("")
 
-	if err == nil {
-		t.Fatal("expected error for empty string")
-	}
-	if !errors.Is(err, ErrInvalidCoordinates) {
-		t.Errorf("expected ErrInvalidCoordinates, got %v", err)
-	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidCoordinates)
 }
 
 func TestCoord3857FromString_InvalidLongitude(t *testing.T) {
 	_, _, err := Coord3857FromString("abc,200.25")
 
-	if err == nil {
-		t.Fatal("expected error for invalid longitude")
-	}
-	if !errors.Is(err, ErrInvalidCoordinates) {
-		t.Errorf("expected ErrInvalidCoordinates, got %v", err)
-	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidCoordinates)
 }
 
 func TestCoord3857FromString_InvalidLatitude(t *testing.T) {
 	_, _, err := Coord3857FromString("100.5,xyz")
 
-	if err == nil {
-		t.Fatal("expected error for invalid latitude")
-	}
-	if !errors.Is(err, ErrInvalidCoordinates) {
-		t.Errorf("expected ErrInvalidCoordinates, got %v", err)
-	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidCoordinates)
 }
 
 func TestCoord3857FromString_InvalidElevation(t *testing.T) {
 	_, _, err := Coord3857FromString("100.5,200.25,invalid")
 
-	if err == nil {
-		t.Fatal("expected error for invalid elevation")
-	}
-	if !errors.Is(err, ErrInvalidCoordinates) {
-		t.Errorf("expected ErrInvalidCoordinates, got %v", err)
-	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidCoordinates)
 }
 
 func TestCoord3857FromString_ExtraComponents(t *testing.T) {
 	// Extra components beyond 3 should be ignored
 	point, elev, err := Coord3857FromString("100.5,200.25,50.0,extra,ignored")
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	coords, ok := point.Coordinates()
-	if !ok {
-		t.Fatal("expected valid coordinates")
-	}
-	if coords.X != 100.5 {
-		t.Errorf("expected X=100.5, got %f", coords.X)
-	}
-	if coords.Y != 200.25 {
-		t.Errorf("expected Y=200.25, got %f", coords.Y)
-	}
-	if elev != 50.0 {
-		t.Errorf("expected elevation=50.0, got %f", elev)
-	}
+	require.True(t, ok, "expected valid coordinates")
+	assert.Equal(t, 100.5, coords.X)
+	assert.Equal(t, 200.25, coords.Y)
+	assert.Equal(t, 50.0, elev)
 }
 
 func TestCoord3857FromString_ScientificNotation(t *testing.T) {
 	point, _, err := Coord3857FromString("1e2,2e3")
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	coords, ok := point.Coordinates()
-	if !ok {
-		t.Fatal("expected valid coordinates")
-	}
-	if coords.X != 100 {
-		t.Errorf("expected X=100, got %f", coords.X)
-	}
-	if coords.Y != 2000 {
-		t.Errorf("expected Y=2000, got %f", coords.Y)
-	}
+	require.True(t, ok, "expected valid coordinates")
+	assert.Equal(t, 100.0, coords.X)
+	assert.Equal(t, 2000.0, coords.Y)
 }
 
 func TestCoord3857FromString_LargeCoordinates(t *testing.T) {
 	point, _, err := Coord3857FromString("1000000.123456,2000000.654321")
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	coords, ok := point.Coordinates()
-	if !ok {
-		t.Fatal("expected valid coordinates")
-	}
-	if coords.X != 1000000.123456 {
-		t.Errorf("expected X=1000000.123456, got %f", coords.X)
-	}
-	if coords.Y != 2000000.654321 {
-		t.Errorf("expected Y=2000000.654321, got %f", coords.Y)
-	}
+	require.True(t, ok, "expected valid coordinates")
+	assert.Equal(t, 1000000.123456, coords.X)
+	assert.Equal(t, 2000000.654321, coords.Y)
 }
 
 func TestCoords3857From4326_ValidCoordinates(t *testing.T) {
@@ -233,60 +141,36 @@ func TestCoords3857From4326_ValidCoordinates(t *testing.T) {
 	// Approximate coordinates for a point
 	point, err := Coords3857From4326(0, 0)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	coords, ok := point.Coordinates()
-	if !ok {
-		t.Fatal("expected valid coordinates")
-	}
+	require.True(t, ok, "expected valid coordinates")
 	// At (0, 0) in 4326, the 3857 coordinates should also be (0, 0)
-	if coords.X != 0 {
-		t.Errorf("expected X=0 at origin, got %f", coords.X)
-	}
-	if coords.Y != 0 {
-		t.Errorf("expected Y=0 at origin, got %f", coords.Y)
-	}
+	assert.Equal(t, 0.0, coords.X)
+	assert.Equal(t, 0.0, coords.Y)
 }
 
 func TestCoords3857From4326_NonZeroCoordinates(t *testing.T) {
 	// Test a point at 10 degrees longitude, 10 degrees latitude
 	point, err := Coords3857From4326(10, 10)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	coords, ok := point.Coordinates()
-	if !ok {
-		t.Fatal("expected valid coordinates")
-	}
+	require.True(t, ok, "expected valid coordinates")
 	// In Web Mercator, these should be non-zero positive values
-	if coords.X <= 0 {
-		t.Errorf("expected positive X, got %f", coords.X)
-	}
-	if coords.Y <= 0 {
-		t.Errorf("expected positive Y, got %f", coords.Y)
-	}
+	assert.Greater(t, coords.X, 0.0)
+	assert.Greater(t, coords.Y, 0.0)
 }
 
 func TestCoords3857From4326_NegativeCoordinates(t *testing.T) {
 	// Test a point in the Southern/Western hemisphere
 	point, err := Coords3857From4326(-45, -30)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	coords, ok := point.Coordinates()
-	if !ok {
-		t.Fatal("expected valid coordinates")
-	}
-	if coords.X >= 0 {
-		t.Errorf("expected negative X for western hemisphere, got %f", coords.X)
-	}
-	if coords.Y >= 0 {
-		t.Errorf("expected negative Y for southern hemisphere, got %f", coords.Y)
-	}
+	require.True(t, ok, "expected valid coordinates")
+	assert.Less(t, coords.X, 0.0)
+	assert.Less(t, coords.Y, 0.0)
 }

--- a/internal/geo/polyline_test.go
+++ b/internal/geo/polyline_test.go
@@ -2,6 +2,9 @@ package geo
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParsePolyline_Valid(t *testing.T) {
@@ -9,14 +12,10 @@ func TestParsePolyline_Valid(t *testing.T) {
 
 	ls, err := ParsePolyline(input)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	seq := ls.Coordinates()
-	if seq.Length() != 3 {
-		t.Fatalf("expected 3 points, got %d", seq.Length())
-	}
+	require.Equal(t, 3, seq.Length())
 
 	expected := [][2]float64{
 		{100.5, 200.25},
@@ -25,9 +24,8 @@ func TestParsePolyline_Valid(t *testing.T) {
 	}
 	for i := 0; i < seq.Length(); i++ {
 		pt := seq.GetXY(i)
-		if pt.X != expected[i][0] || pt.Y != expected[i][1] {
-			t.Errorf("point %d: expected (%f,%f), got (%f,%f)", i, expected[i][0], expected[i][1], pt.X, pt.Y)
-		}
+		assert.Equal(t, expected[i][0], pt.X)
+		assert.Equal(t, expected[i][1], pt.Y)
 	}
 }
 
@@ -36,12 +34,8 @@ func TestParsePolyline_TwoPoints(t *testing.T) {
 
 	ls, err := ParsePolyline(input)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if ls.Coordinates().Length() != 2 {
-		t.Fatalf("expected 2 points, got %d", ls.Coordinates().Length())
-	}
+	require.NoError(t, err)
+	require.Equal(t, 2, ls.Coordinates().Length())
 }
 
 func TestParsePolyline_InvalidJSON(t *testing.T) {
@@ -49,9 +43,7 @@ func TestParsePolyline_InvalidJSON(t *testing.T) {
 
 	_, err := ParsePolyline(input)
 
-	if err == nil {
-		t.Fatal("expected error for invalid JSON")
-	}
+	require.Error(t, err)
 }
 
 func TestParsePolyline_TooFewPoints(t *testing.T) {
@@ -59,9 +51,7 @@ func TestParsePolyline_TooFewPoints(t *testing.T) {
 
 	_, err := ParsePolyline(input)
 
-	if err == nil {
-		t.Fatal("expected error for single point")
-	}
+	require.Error(t, err)
 }
 
 func TestParsePolyline_EmptyArray(t *testing.T) {
@@ -69,9 +59,7 @@ func TestParsePolyline_EmptyArray(t *testing.T) {
 
 	_, err := ParsePolyline(input)
 
-	if err == nil {
-		t.Fatal("expected error for empty array")
-	}
+	require.Error(t, err)
 }
 
 func TestParsePolyline_InsufficientCoordinates(t *testing.T) {
@@ -79,7 +67,5 @@ func TestParsePolyline_InsufficientCoordinates(t *testing.T) {
 
 	_, err := ParsePolyline(input)
 
-	if err == nil {
-		t.Fatal("expected error for coordinate with single value")
-	}
+	require.Error(t, err)
 }

--- a/internal/logging/dispatcher_test.go
+++ b/internal/logging/dispatcher_test.go
@@ -5,15 +5,16 @@ import (
 	"encoding/json"
 	"log/slog"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewDispatcherLogger(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 	dl := NewDispatcherLogger(logger)
 
-	if dl == nil {
-		t.Fatal("expected non-nil DispatcherLogger")
-	}
+	require.NotNil(t, dl)
 }
 
 func TestDispatcherLogger_Debug(t *testing.T) {
@@ -24,22 +25,12 @@ func TestDispatcherLogger_Debug(t *testing.T) {
 	dl.Debug("test message", "key1", "value1", "key2", 42)
 
 	var logEntry map[string]any
-	if err := json.Unmarshal(buf.Bytes(), &logEntry); err != nil {
-		t.Fatalf("failed to parse log output: %v", err)
-	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &logEntry))
 
-	if logEntry["level"] != "DEBUG" {
-		t.Errorf("expected level 'DEBUG', got %v", logEntry["level"])
-	}
-	if logEntry["msg"] != "test message" {
-		t.Errorf("expected msg 'test message', got %v", logEntry["msg"])
-	}
-	if logEntry["key1"] != "value1" {
-		t.Errorf("expected key1='value1', got %v", logEntry["key1"])
-	}
-	if logEntry["key2"] != float64(42) { // JSON numbers are float64
-		t.Errorf("expected key2=42, got %v", logEntry["key2"])
-	}
+	assert.Equal(t, "DEBUG", logEntry["level"])
+	assert.Equal(t, "test message", logEntry["msg"])
+	assert.Equal(t, "value1", logEntry["key1"])
+	assert.Equal(t, float64(42), logEntry["key2"])
 }
 
 func TestDispatcherLogger_Info(t *testing.T) {
@@ -50,19 +41,11 @@ func TestDispatcherLogger_Info(t *testing.T) {
 	dl.Info("info message", "status", "ok")
 
 	var logEntry map[string]any
-	if err := json.Unmarshal(buf.Bytes(), &logEntry); err != nil {
-		t.Fatalf("failed to parse log output: %v", err)
-	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &logEntry))
 
-	if logEntry["level"] != "INFO" {
-		t.Errorf("expected level 'INFO', got %v", logEntry["level"])
-	}
-	if logEntry["msg"] != "info message" {
-		t.Errorf("expected msg 'info message', got %v", logEntry["msg"])
-	}
-	if logEntry["status"] != "ok" {
-		t.Errorf("expected status='ok', got %v", logEntry["status"])
-	}
+	assert.Equal(t, "INFO", logEntry["level"])
+	assert.Equal(t, "info message", logEntry["msg"])
+	assert.Equal(t, "ok", logEntry["status"])
 }
 
 func TestDispatcherLogger_Error(t *testing.T) {
@@ -73,22 +56,12 @@ func TestDispatcherLogger_Error(t *testing.T) {
 	dl.Error("error occurred", "code", 500, "reason", "internal")
 
 	var logEntry map[string]any
-	if err := json.Unmarshal(buf.Bytes(), &logEntry); err != nil {
-		t.Fatalf("failed to parse log output: %v", err)
-	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &logEntry))
 
-	if logEntry["level"] != "ERROR" {
-		t.Errorf("expected level 'ERROR', got %v", logEntry["level"])
-	}
-	if logEntry["msg"] != "error occurred" {
-		t.Errorf("expected msg 'error occurred', got %v", logEntry["msg"])
-	}
-	if logEntry["code"] != float64(500) {
-		t.Errorf("expected code=500, got %v", logEntry["code"])
-	}
-	if logEntry["reason"] != "internal" {
-		t.Errorf("expected reason='internal', got %v", logEntry["reason"])
-	}
+	assert.Equal(t, "ERROR", logEntry["level"])
+	assert.Equal(t, "error occurred", logEntry["msg"])
+	assert.Equal(t, float64(500), logEntry["code"])
+	assert.Equal(t, "internal", logEntry["reason"])
 }
 
 func TestDispatcherLogger_NoKeyValues(t *testing.T) {
@@ -99,23 +72,16 @@ func TestDispatcherLogger_NoKeyValues(t *testing.T) {
 	dl.Debug("simple message")
 
 	var logEntry map[string]any
-	if err := json.Unmarshal(buf.Bytes(), &logEntry); err != nil {
-		t.Fatalf("failed to parse log output: %v", err)
-	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &logEntry))
 
-	if logEntry["msg"] != "simple message" {
-		t.Errorf("expected msg 'simple message', got %v", logEntry["msg"])
-	}
+	assert.Equal(t, "simple message", logEntry["msg"])
 }
 
 func TestDispatcherLogger_ImplementsInterface(t *testing.T) {
-	// Verify DispatcherLogger satisfies the dispatcher.Logger interface
-	// by ensuring the methods exist with correct signatures
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 	dl := NewDispatcherLogger(logger)
 
-	// These calls would fail to compile if the interface isn't satisfied
 	var _ interface {
 		Debug(msg string, keysAndValues ...any)
 		Info(msg string, keysAndValues ...any)

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLogFilePath(t *testing.T) {
@@ -38,9 +40,7 @@ func TestLogFilePath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := LogFilePath(tt.logsDir, tt.extensionName, sessionStart)
-			if got != tt.want {
-				t.Errorf("LogFilePath() = %q, want %q", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/model/convert/convert_test.go
+++ b/internal/model/convert/convert_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/OCAP2/extension/v5/internal/model"
 	"github.com/OCAP2/extension/v5/internal/model/core"
 	geom "github.com/peterstace/simplefeatures/geom"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gorm.io/datatypes"
 )
 
@@ -23,15 +25,9 @@ func TestPointToPosition3D(t *testing.T) {
 	pt := makePoint(100.5, 200.5, 50.0)
 	pos := pointToPosition3D(pt)
 
-	if pos.X != 100.5 {
-		t.Errorf("expected X=100.5, got %f", pos.X)
-	}
-	if pos.Y != 200.5 {
-		t.Errorf("expected Y=200.5, got %f", pos.Y)
-	}
-	if pos.Z != 50.0 {
-		t.Errorf("expected Z=50.0, got %f", pos.Z)
-	}
+	assert.Equal(t, 100.5, pos.X)
+	assert.Equal(t, 200.5, pos.Y)
+	assert.Equal(t, 50.0, pos.Z)
 }
 
 func TestSoldierToCore(t *testing.T) {
@@ -58,21 +54,11 @@ func TestSoldierToCore(t *testing.T) {
 	coreSoldier := SoldierToCore(gormSoldier)
 
 	// Core ID = GORM ObjectID (not GORM ID)
-	if coreSoldier.ID != 42 {
-		t.Errorf("expected ID=42 (ObjectID), got %d", coreSoldier.ID)
-	}
-	if coreSoldier.MissionID != 1 {
-		t.Errorf("expected MissionID=1, got %d", coreSoldier.MissionID)
-	}
-	if coreSoldier.UnitName != "TestUnit" {
-		t.Errorf("expected UnitName=TestUnit, got %s", coreSoldier.UnitName)
-	}
-	if !coreSoldier.IsPlayer {
-		t.Error("expected IsPlayer=true")
-	}
-	if coreSoldier.Side != "WEST" {
-		t.Errorf("expected Side=WEST, got %s", coreSoldier.Side)
-	}
+	assert.Equal(t, uint16(42), coreSoldier.ID)
+	assert.Equal(t, uint(1), coreSoldier.MissionID)
+	assert.Equal(t, "TestUnit", coreSoldier.UnitName)
+	assert.True(t, coreSoldier.IsPlayer)
+	assert.Equal(t, "WEST", coreSoldier.Side)
 }
 
 func TestSoldierStateToCore(t *testing.T) {
@@ -111,24 +97,13 @@ func TestSoldierStateToCore(t *testing.T) {
 	coreState := SoldierStateToCore(gormState)
 
 	// SoldierID maps from SoldierObjectID
-	if coreState.SoldierID != 2 {
-		t.Errorf("expected SoldierID=2 (from SoldierObjectID), got %d", coreState.SoldierID)
-	}
-	if coreState.CaptureFrame != 100 {
-		t.Errorf("expected CaptureFrame=100, got %d", coreState.CaptureFrame)
-	}
-	if coreState.Position.X != 1000.0 {
-		t.Errorf("expected Position.X=1000.0, got %f", coreState.Position.X)
-	}
-	if coreState.Bearing != 90 {
-		t.Errorf("expected Bearing=90, got %d", coreState.Bearing)
-	}
-	if coreState.InVehicleObjectID == nil || *coreState.InVehicleObjectID != 5 {
-		t.Error("expected InVehicleObjectID=5")
-	}
-	if coreState.Scores.InfantryKills != 5 {
-		t.Errorf("expected Scores.InfantryKills=5, got %d", coreState.Scores.InfantryKills)
-	}
+	assert.Equal(t, uint16(2), coreState.SoldierID)
+	assert.Equal(t, uint(100), coreState.CaptureFrame)
+	assert.Equal(t, 1000.0, coreState.Position.X)
+	assert.Equal(t, uint16(90), coreState.Bearing)
+	require.NotNil(t, coreState.InVehicleObjectID)
+	assert.Equal(t, uint16(5), *coreState.InVehicleObjectID)
+	assert.Equal(t, uint8(5), coreState.Scores.InfantryKills)
 }
 
 func TestVehicleToCore(t *testing.T) {
@@ -148,15 +123,9 @@ func TestVehicleToCore(t *testing.T) {
 	coreVehicle := VehicleToCore(gormVehicle)
 
 	// Core ID = GORM ObjectID (not GORM ID)
-	if coreVehicle.ID != 10 {
-		t.Errorf("expected ID=10 (ObjectID), got %d", coreVehicle.ID)
-	}
-	if coreVehicle.OcapType != "car" {
-		t.Errorf("expected OcapType=car, got %s", coreVehicle.OcapType)
-	}
-	if coreVehicle.DisplayName != "Hunter" {
-		t.Errorf("expected DisplayName=Hunter, got %s", coreVehicle.DisplayName)
-	}
+	assert.Equal(t, uint16(10), coreVehicle.ID)
+	assert.Equal(t, "car", coreVehicle.OcapType)
+	assert.Equal(t, "Hunter", coreVehicle.DisplayName)
 }
 
 func TestVehicleStateToCore(t *testing.T) {
@@ -187,18 +156,10 @@ func TestVehicleStateToCore(t *testing.T) {
 	coreState := VehicleStateToCore(gormState)
 
 	// VehicleID maps from VehicleObjectID
-	if coreState.VehicleID != 5 {
-		t.Errorf("expected VehicleID=5 (from VehicleObjectID), got %d", coreState.VehicleID)
-	}
-	if coreState.Position.X != 500.0 {
-		t.Errorf("expected Position.X=500.0, got %f", coreState.Position.X)
-	}
-	if coreState.Fuel != 0.8 {
-		t.Errorf("expected Fuel=0.8, got %f", coreState.Fuel)
-	}
-	if !coreState.EngineOn {
-		t.Error("expected EngineOn=true")
-	}
+	assert.Equal(t, uint16(5), coreState.VehicleID)
+	assert.Equal(t, 500.0, coreState.Position.X)
+	assert.Equal(t, float32(0.8), coreState.Fuel)
+	assert.True(t, coreState.EngineOn)
 }
 
 func TestFiredEventToCore(t *testing.T) {
@@ -222,18 +183,10 @@ func TestFiredEventToCore(t *testing.T) {
 	coreEvent := FiredEventToCore(gormEvent)
 
 	// SoldierID maps from SoldierObjectID
-	if coreEvent.SoldierID != 2 {
-		t.Errorf("expected SoldierID=2 (from SoldierObjectID), got %d", coreEvent.SoldierID)
-	}
-	if coreEvent.Weapon != "arifle_MX_F" {
-		t.Errorf("expected Weapon=arifle_MX_F, got %s", coreEvent.Weapon)
-	}
-	if coreEvent.StartPos.X != 100.0 {
-		t.Errorf("expected StartPos.X=100.0, got %f", coreEvent.StartPos.X)
-	}
-	if coreEvent.EndPos.X != 200.0 {
-		t.Errorf("expected EndPos.X=200.0, got %f", coreEvent.EndPos.X)
-	}
+	assert.Equal(t, uint16(2), coreEvent.SoldierID)
+	assert.Equal(t, "arifle_MX_F", coreEvent.Weapon)
+	assert.Equal(t, 100.0, coreEvent.StartPos.X)
+	assert.Equal(t, 200.0, coreEvent.EndPos.X)
 }
 
 func TestHitEventToCore(t *testing.T) {
@@ -252,15 +205,11 @@ func TestHitEventToCore(t *testing.T) {
 
 	coreEvent := HitEventToCore(gormEvent)
 
-	if coreEvent.VictimSoldierID == nil || *coreEvent.VictimSoldierID != 5 {
-		t.Error("expected VictimSoldierID=5")
-	}
-	if coreEvent.ShooterSoldierID == nil || *coreEvent.ShooterSoldierID != 10 {
-		t.Error("expected ShooterSoldierID=10")
-	}
-	if coreEvent.Distance != 50.5 {
-		t.Errorf("expected Distance=50.5, got %f", coreEvent.Distance)
-	}
+	require.NotNil(t, coreEvent.VictimSoldierID)
+	assert.Equal(t, uint(5), *coreEvent.VictimSoldierID)
+	require.NotNil(t, coreEvent.ShooterSoldierID)
+	assert.Equal(t, uint(10), *coreEvent.ShooterSoldierID)
+	assert.Equal(t, float32(50.5), coreEvent.Distance)
 }
 
 func TestKillEventToCore(t *testing.T) {
@@ -279,12 +228,10 @@ func TestKillEventToCore(t *testing.T) {
 
 	coreEvent := KillEventToCore(gormEvent)
 
-	if coreEvent.VictimSoldierID == nil || *coreEvent.VictimSoldierID != 5 {
-		t.Error("expected VictimSoldierID=5")
-	}
-	if coreEvent.KillerSoldierID == nil || *coreEvent.KillerSoldierID != 10 {
-		t.Error("expected KillerSoldierID=10")
-	}
+	require.NotNil(t, coreEvent.VictimSoldierID)
+	assert.Equal(t, uint(5), *coreEvent.VictimSoldierID)
+	require.NotNil(t, coreEvent.KillerSoldierID)
+	assert.Equal(t, uint(10), *coreEvent.KillerSoldierID)
 }
 
 func TestMarkerToCore(t *testing.T) {
@@ -312,15 +259,9 @@ func TestMarkerToCore(t *testing.T) {
 
 	coreMarker := MarkerToCore(gormMarker)
 
-	if coreMarker.MarkerName != "TestMarker" {
-		t.Errorf("expected MarkerName=TestMarker, got %s", coreMarker.MarkerName)
-	}
-	if coreMarker.Direction != 45.0 {
-		t.Errorf("expected Direction=45.0, got %f", coreMarker.Direction)
-	}
-	if coreMarker.Position.X != 100.0 {
-		t.Errorf("expected Position.X=100.0, got %f", coreMarker.Position.X)
-	}
+	assert.Equal(t, "TestMarker", coreMarker.MarkerName)
+	assert.Equal(t, float32(45.0), coreMarker.Direction)
+	assert.Equal(t, 100.0, coreMarker.Position.X)
 }
 
 func TestMissionToCore(t *testing.T) {
@@ -343,18 +284,11 @@ func TestMissionToCore(t *testing.T) {
 
 	coreMission := MissionToCore(gormMission)
 
-	if coreMission.ID != 1 {
-		t.Errorf("expected ID=1, got %d", coreMission.ID)
-	}
-	if coreMission.MissionName != "Test Mission" {
-		t.Errorf("expected MissionName=Test Mission, got %s", coreMission.MissionName)
-	}
-	if coreMission.PlayableSlots.West != 10 {
-		t.Errorf("expected PlayableSlots.West=10, got %d", coreMission.PlayableSlots.West)
-	}
-	if len(coreMission.Addons) != 1 || coreMission.Addons[0].Name != "TestAddon" {
-		t.Error("expected 1 addon with name TestAddon")
-	}
+	assert.Equal(t, uint(1), coreMission.ID)
+	assert.Equal(t, "Test Mission", coreMission.MissionName)
+	assert.Equal(t, uint8(10), coreMission.PlayableSlots.West)
+	require.Len(t, coreMission.Addons, 1)
+	assert.Equal(t, "TestAddon", coreMission.Addons[0].Name)
 }
 
 func TestWorldToCore(t *testing.T) {
@@ -373,15 +307,9 @@ func TestWorldToCore(t *testing.T) {
 
 	coreWorld := WorldToCore(gormWorld)
 
-	if coreWorld.ID != 1 {
-		t.Errorf("expected ID=1, got %d", coreWorld.ID)
-	}
-	if coreWorld.WorldName != "altis" {
-		t.Errorf("expected WorldName=altis, got %s", coreWorld.WorldName)
-	}
-	if coreWorld.WorldSize != 30720 {
-		t.Errorf("expected WorldSize=30720, got %f", coreWorld.WorldSize)
-	}
+	assert.Equal(t, uint(1), coreWorld.ID)
+	assert.Equal(t, "altis", coreWorld.WorldName)
+	assert.Equal(t, float32(30720), coreWorld.WorldSize)
 }
 
 func TestGeneralEventToCore(t *testing.T) {
@@ -400,15 +328,9 @@ func TestGeneralEventToCore(t *testing.T) {
 
 	coreEvent := GeneralEventToCore(gormEvent)
 
-	if coreEvent.Name != "TestEvent" {
-		t.Errorf("expected Name=TestEvent, got %s", coreEvent.Name)
-	}
-	if coreEvent.Message != "Test message" {
-		t.Errorf("expected Message=Test message, got %s", coreEvent.Message)
-	}
-	if coreEvent.ExtraData["key"] != "value" {
-		t.Error("expected ExtraData[key]=value")
-	}
+	assert.Equal(t, "TestEvent", coreEvent.Name)
+	assert.Equal(t, "Test message", coreEvent.Message)
+	assert.Equal(t, "value", coreEvent.ExtraData["key"])
 }
 
 func TestChatEventToCore(t *testing.T) {
@@ -429,15 +351,10 @@ func TestChatEventToCore(t *testing.T) {
 
 	coreEvent := ChatEventToCore(gormEvent)
 
-	if coreEvent.SoldierID == nil || *coreEvent.SoldierID != 5 {
-		t.Error("expected SoldierID=5")
-	}
-	if coreEvent.Channel != "Global" {
-		t.Errorf("expected Channel=Global, got %s", coreEvent.Channel)
-	}
-	if coreEvent.Message != "Hello world" {
-		t.Errorf("expected Message=Hello world, got %s", coreEvent.Message)
-	}
+	require.NotNil(t, coreEvent.SoldierID)
+	assert.Equal(t, uint(5), *coreEvent.SoldierID)
+	assert.Equal(t, "Global", coreEvent.Channel)
+	assert.Equal(t, "Hello world", coreEvent.Message)
 }
 
 func TestRadioEventToCore(t *testing.T) {
@@ -460,12 +377,8 @@ func TestRadioEventToCore(t *testing.T) {
 
 	coreEvent := RadioEventToCore(gormEvent)
 
-	if coreEvent.Radio != "AN/PRC-152" {
-		t.Errorf("expected Radio=AN/PRC-152, got %s", coreEvent.Radio)
-	}
-	if coreEvent.Frequency != 100.0 {
-		t.Errorf("expected Frequency=100.0, got %f", coreEvent.Frequency)
-	}
+	assert.Equal(t, "AN/PRC-152", coreEvent.Radio)
+	assert.Equal(t, float32(100.0), coreEvent.Frequency)
 }
 
 func TestServerFpsEventToCore(t *testing.T) {
@@ -481,12 +394,8 @@ func TestServerFpsEventToCore(t *testing.T) {
 
 	coreEvent := ServerFpsEventToCore(gormEvent)
 
-	if coreEvent.FpsAverage != 50.5 {
-		t.Errorf("expected FpsAverage=50.5, got %f", coreEvent.FpsAverage)
-	}
-	if coreEvent.FpsMin != 30.0 {
-		t.Errorf("expected FpsMin=30.0, got %f", coreEvent.FpsMin)
-	}
+	assert.Equal(t, float32(50.5), coreEvent.FpsAverage)
+	assert.Equal(t, float32(30.0), coreEvent.FpsMin)
 }
 
 func TestTimeStateToCore(t *testing.T) {
@@ -504,24 +413,12 @@ func TestTimeStateToCore(t *testing.T) {
 
 	coreState := TimeStateToCore(gormState)
 
-	if coreState.MissionID != 1 {
-		t.Errorf("expected MissionID=1, got %d", coreState.MissionID)
-	}
-	if coreState.CaptureFrame != 100 {
-		t.Errorf("expected CaptureFrame=100, got %d", coreState.CaptureFrame)
-	}
-	if coreState.SystemTimeUTC != "2024-01-15T14:30:45.123" {
-		t.Errorf("expected SystemTimeUTC=2024-01-15T14:30:45.123, got %s", coreState.SystemTimeUTC)
-	}
-	if coreState.MissionDate != "2035-06-15T06:00:00" {
-		t.Errorf("expected MissionDate=2035-06-15T06:00:00, got %s", coreState.MissionDate)
-	}
-	if coreState.TimeMultiplier != 2.0 {
-		t.Errorf("expected TimeMultiplier=2.0, got %f", coreState.TimeMultiplier)
-	}
-	if coreState.MissionTime != 3600.5 {
-		t.Errorf("expected MissionTime=3600.5, got %f", coreState.MissionTime)
-	}
+	assert.Equal(t, uint(1), coreState.MissionID)
+	assert.Equal(t, uint(100), coreState.CaptureFrame)
+	assert.Equal(t, "2024-01-15T14:30:45.123", coreState.SystemTimeUTC)
+	assert.Equal(t, "2035-06-15T06:00:00", coreState.MissionDate)
+	assert.Equal(t, float32(2.0), coreState.TimeMultiplier)
+	assert.Equal(t, float32(3600.5), coreState.MissionTime)
 }
 
 func TestAce3DeathEventToCore(t *testing.T) {
@@ -539,12 +436,9 @@ func TestAce3DeathEventToCore(t *testing.T) {
 
 	coreEvent := Ace3DeathEventToCore(gormEvent)
 
-	if coreEvent.Reason != "BLOODLOSS" {
-		t.Errorf("expected Reason=BLOODLOSS, got %s", coreEvent.Reason)
-	}
-	if coreEvent.LastDamageSourceID == nil || *coreEvent.LastDamageSourceID != 10 {
-		t.Error("expected LastDamageSourceID=10")
-	}
+	assert.Equal(t, "BLOODLOSS", coreEvent.Reason)
+	require.NotNil(t, coreEvent.LastDamageSourceID)
+	assert.Equal(t, uint(10), *coreEvent.LastDamageSourceID)
 }
 
 func TestAce3UnconsciousEventToCore(t *testing.T) {
@@ -561,12 +455,8 @@ func TestAce3UnconsciousEventToCore(t *testing.T) {
 
 	coreEvent := Ace3UnconsciousEventToCore(gormEvent)
 
-	if coreEvent.SoldierID != 5 {
-		t.Errorf("expected SoldierID=5, got %d", coreEvent.SoldierID)
-	}
-	if !coreEvent.IsUnconscious {
-		t.Error("expected IsUnconscious=true")
-	}
+	assert.Equal(t, uint(5), coreEvent.SoldierID)
+	assert.True(t, coreEvent.IsUnconscious)
 }
 
 func TestMarkerStateToCore(t *testing.T) {
@@ -585,15 +475,9 @@ func TestMarkerStateToCore(t *testing.T) {
 
 	coreState := MarkerStateToCore(gormState)
 
-	if coreState.MarkerID != 5 {
-		t.Errorf("expected MarkerID=5, got %d", coreState.MarkerID)
-	}
-	if coreState.Position.X != 150.0 {
-		t.Errorf("expected Position.X=150.0, got %f", coreState.Position.X)
-	}
-	if coreState.Alpha != 0.5 {
-		t.Errorf("expected Alpha=0.5, got %f", coreState.Alpha)
-	}
+	assert.Equal(t, uint(5), coreState.MarkerID)
+	assert.Equal(t, 150.0, coreState.Position.X)
+	assert.Equal(t, float32(0.5), coreState.Alpha)
 }
 
 // Test with nil/invalid values
@@ -604,9 +488,7 @@ func TestSoldierStateToCore_NilInVehicleID(t *testing.T) {
 
 	coreState := SoldierStateToCore(gormState)
 
-	if coreState.InVehicleObjectID != nil {
-		t.Error("expected InVehicleObjectID=nil")
-	}
+	assert.Nil(t, coreState.InVehicleObjectID)
 }
 
 func TestHitEventToCore_NilIDs(t *testing.T) {
@@ -617,12 +499,8 @@ func TestHitEventToCore_NilIDs(t *testing.T) {
 
 	coreEvent := HitEventToCore(gormEvent)
 
-	if coreEvent.VictimSoldierID != nil {
-		t.Error("expected VictimSoldierID=nil")
-	}
-	if coreEvent.ShooterSoldierID != nil {
-		t.Error("expected ShooterSoldierID=nil")
-	}
+	assert.Nil(t, coreEvent.VictimSoldierID)
+	assert.Nil(t, coreEvent.ShooterSoldierID)
 }
 
 func TestProjectileEventToFiredEvent(t *testing.T) {
@@ -651,36 +529,22 @@ func TestProjectileEventToFiredEvent(t *testing.T) {
 
 	coreEvent := ProjectileEventToFiredEvent(gormEvent)
 
-	if coreEvent.MissionID != 1 {
-		t.Errorf("expected MissionID=1, got %d", coreEvent.MissionID)
-	}
-	if coreEvent.SoldierID != 42 {
-		t.Errorf("expected SoldierID=42, got %d", coreEvent.SoldierID)
-	}
-	if coreEvent.CaptureFrame != 100 {
-		t.Errorf("expected CaptureFrame=100, got %d", coreEvent.CaptureFrame)
-	}
-	if coreEvent.Weapon != "throw" {
-		t.Errorf("expected Weapon=throw, got %s", coreEvent.Weapon)
-	}
-	if coreEvent.Magazine != "HandGrenade" {
-		t.Errorf("expected Magazine=HandGrenade, got %s", coreEvent.Magazine)
-	}
-	if coreEvent.FiringMode != "HandGrenadeMuzzle" {
-		t.Errorf("expected FiringMode=HandGrenadeMuzzle, got %s", coreEvent.FiringMode)
-	}
+	assert.Equal(t, uint(1), coreEvent.MissionID)
+	assert.Equal(t, uint16(42), coreEvent.SoldierID)
+	assert.Equal(t, uint(100), coreEvent.CaptureFrame)
+	assert.Equal(t, "throw", coreEvent.Weapon)
+	assert.Equal(t, "HandGrenade", coreEvent.Magazine)
+	assert.Equal(t, "HandGrenadeMuzzle", coreEvent.FiringMode)
 
 	// Start position should be first point
-	if coreEvent.StartPos.X != 100.0 || coreEvent.StartPos.Y != 200.0 || coreEvent.StartPos.Z != 10.0 {
-		t.Errorf("expected StartPos=(100,200,10), got (%f,%f,%f)",
-			coreEvent.StartPos.X, coreEvent.StartPos.Y, coreEvent.StartPos.Z)
-	}
+	assert.Equal(t, 100.0, coreEvent.StartPos.X)
+	assert.Equal(t, 200.0, coreEvent.StartPos.Y)
+	assert.Equal(t, 10.0, coreEvent.StartPos.Z)
 
 	// End position should be last point
-	if coreEvent.EndPos.X != 200.0 || coreEvent.EndPos.Y != 300.0 || coreEvent.EndPos.Z != 5.0 {
-		t.Errorf("expected EndPos=(200,300,5), got (%f,%f,%f)",
-			coreEvent.EndPos.X, coreEvent.EndPos.Y, coreEvent.EndPos.Z)
-	}
+	assert.Equal(t, 200.0, coreEvent.EndPos.X)
+	assert.Equal(t, 300.0, coreEvent.EndPos.Y)
+	assert.Equal(t, 5.0, coreEvent.EndPos.Z)
 }
 
 func TestProjectileEventToFiredEvent_EmptyPositions(t *testing.T) {
@@ -695,14 +559,10 @@ func TestProjectileEventToFiredEvent_EmptyPositions(t *testing.T) {
 	coreEvent := ProjectileEventToFiredEvent(gormEvent)
 
 	// Should handle empty positions gracefully
-	if coreEvent.StartPos.X != 0 || coreEvent.StartPos.Y != 0 {
-		t.Errorf("expected zero StartPos for empty geometry, got (%f,%f)",
-			coreEvent.StartPos.X, coreEvent.StartPos.Y)
-	}
-	if coreEvent.EndPos.X != 0 || coreEvent.EndPos.Y != 0 {
-		t.Errorf("expected zero EndPos for empty geometry, got (%f,%f)",
-			coreEvent.EndPos.X, coreEvent.EndPos.Y)
-	}
+	assert.Equal(t, 0.0, coreEvent.StartPos.X)
+	assert.Equal(t, 0.0, coreEvent.StartPos.Y)
+	assert.Equal(t, 0.0, coreEvent.EndPos.X)
+	assert.Equal(t, 0.0, coreEvent.EndPos.Y)
 }
 
 func TestProjectileEventToProjectileMarker(t *testing.T) {
@@ -729,61 +589,33 @@ func TestProjectileEventToProjectileMarker(t *testing.T) {
 	marker, states := ProjectileEventToProjectileMarker(gormEvent)
 
 	// Check marker fields
-	if marker.MarkerType != "magIcons/gear_smokegrenade_white_ca.paa" {
-		t.Errorf("expected MarkerType=magIcons/gear_smokegrenade_white_ca.paa, got %s", marker.MarkerType)
-	}
-	if marker.Text != "Smoke Grenade (White)" {
-		t.Errorf("expected Text=Smoke Grenade (White), got %s", marker.Text)
-	}
-	if marker.OwnerID != 42 {
-		t.Errorf("expected OwnerID=42, got %d", marker.OwnerID)
-	}
-	if marker.Side != "GLOBAL" {
-		t.Errorf("expected Side=GLOBAL, got %s", marker.Side)
-	}
-	if marker.Shape != "ICON" {
-		t.Errorf("expected Shape=ICON, got %s", marker.Shape)
-	}
-	if marker.MarkerName != "projectile_100_42" {
-		t.Errorf("expected MarkerName=projectile_100_42, got %s", marker.MarkerName)
-	}
+	assert.Equal(t, "magIcons/gear_smokegrenade_white_ca.paa", marker.MarkerType)
+	assert.Equal(t, "Smoke Grenade (White)", marker.Text)
+	assert.Equal(t, 42, marker.OwnerID)
+	assert.Equal(t, "GLOBAL", marker.Side)
+	assert.Equal(t, "ICON", marker.Shape)
+	assert.Equal(t, "projectile_100_42", marker.MarkerName)
 
 	// EndFrame should be the last position's frame (303)
-	if marker.EndFrame != 303 {
-		t.Errorf("expected EndFrame=303, got %d", marker.EndFrame)
-	}
+	assert.Equal(t, 303, marker.EndFrame)
 
 	// First position should be in marker
-	if marker.Position.X != 100.0 || marker.Position.Y != 200.0 {
-		t.Errorf("expected marker Position=(100,200), got (%f,%f)",
-			marker.Position.X, marker.Position.Y)
-	}
+	assert.Equal(t, 100.0, marker.Position.X)
+	assert.Equal(t, 200.0, marker.Position.Y)
 
 	// Remaining positions should be in states
-	if len(states) != 2 {
-		t.Fatalf("expected 2 states, got %d", len(states))
-	}
-	if states[0].Position.X != 150.0 || states[0].Position.Y != 250.0 {
-		t.Errorf("expected state[0] Position=(150,250), got (%f,%f)",
-			states[0].Position.X, states[0].Position.Y)
-	}
-	if states[1].Position.X != 200.0 || states[1].Position.Y != 300.0 {
-		t.Errorf("expected state[1] Position=(200,300), got (%f,%f)",
-			states[1].Position.X, states[1].Position.Y)
-	}
+	require.Len(t, states, 2)
+	assert.Equal(t, 150.0, states[0].Position.X)
+	assert.Equal(t, 250.0, states[0].Position.Y)
+	assert.Equal(t, 200.0, states[1].Position.X)
+	assert.Equal(t, 300.0, states[1].Position.Y)
 
 	// States should have correct frame numbers from M coordinate
-	if states[0].CaptureFrame != 245 {
-		t.Errorf("expected state[0] CaptureFrame=245, got %d", states[0].CaptureFrame)
-	}
-	if states[1].CaptureFrame != 303 {
-		t.Errorf("expected state[1] CaptureFrame=303, got %d", states[1].CaptureFrame)
-	}
+	assert.Equal(t, uint(245), states[0].CaptureFrame)
+	assert.Equal(t, uint(303), states[1].CaptureFrame)
 
 	// States should reference marker ID
-	if states[0].MarkerID != marker.ID {
-		t.Errorf("expected state MarkerID=%d, got %d", marker.ID, states[0].MarkerID)
-	}
+	assert.Equal(t, marker.ID, states[0].MarkerID)
 }
 
 func TestProjectileEventToProjectileMarker_EmptyIcon(t *testing.T) {
@@ -800,9 +632,7 @@ func TestProjectileEventToProjectileMarker_EmptyIcon(t *testing.T) {
 	marker, _ := ProjectileEventToProjectileMarker(gormEvent)
 
 	// Should use fallback icon
-	if marker.MarkerType != "magIcons/gear_unknown_ca.paa" {
-		t.Errorf("expected fallback MarkerType=magIcons/gear_unknown_ca.paa, got %s", marker.MarkerType)
-	}
+	assert.Equal(t, "magIcons/gear_unknown_ca.paa", marker.MarkerType)
 }
 
 // Compile-time interface checks

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/OCAP2/extension/v5/internal/storage"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUploadMetadataFields(t *testing.T) {
@@ -15,16 +16,8 @@ func TestUploadMetadataFields(t *testing.T) {
 		Tag:             "TvT",
 	}
 
-	if meta.WorldName != "Altis" {
-		t.Errorf("expected WorldName=Altis, got %s", meta.WorldName)
-	}
-	if meta.MissionName != "Test Mission" {
-		t.Errorf("expected MissionName=Test Mission, got %s", meta.MissionName)
-	}
-	if meta.MissionDuration != 3600.5 {
-		t.Errorf("expected MissionDuration=3600.5, got %f", meta.MissionDuration)
-	}
-	if meta.Tag != "TvT" {
-		t.Errorf("expected Tag=TvT, got %s", meta.Tag)
-	}
+	assert.Equal(t, "Altis", meta.WorldName)
+	assert.Equal(t, "Test Mission", meta.MissionName)
+	assert.Equal(t, 3600.5, meta.MissionDuration)
+	assert.Equal(t, "TvT", meta.Tag)
 }

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,6 +1,10 @@
 package util
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestTrimQuotes(t *testing.T) {
 	tests := []struct {
@@ -19,9 +23,7 @@ func TestTrimQuotes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := TrimQuotes(tt.input)
-			if result != tt.expected {
-				t.Errorf("TrimQuotes(%q) = %q, want %q", tt.input, result, tt.expected)
-			}
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
@@ -42,9 +44,7 @@ func TestFixEscapeQuotes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := FixEscapeQuotes(tt.input)
-			if result != tt.expected {
-				t.Errorf("FixEscapeQuotes(%q) = %q, want %q", tt.input, result, tt.expected)
-			}
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/internal/worker/dispatch_test.go
+++ b/internal/worker/dispatch_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/OCAP2/extension/v5/internal/handlers"
 	"github.com/OCAP2/extension/v5/internal/model"
 	"github.com/OCAP2/extension/v5/internal/model/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // mockLogger implements dispatcher.Logger for testing
@@ -470,9 +472,7 @@ func newTestDispatcher(t *testing.T) (*dispatcher.Dispatcher, *mockLogger) {
 	logger := &mockLogger{}
 
 	d, err := dispatcher.New(logger)
-	if err != nil {
-		t.Fatalf("failed to create dispatcher: %v", err)
-	}
+	require.NoError(t, err, "failed to create dispatcher")
 
 	return d, logger
 }
@@ -511,9 +511,7 @@ func TestRegisterHandlers_RegistersAllCommands(t *testing.T) {
 	}
 
 	for _, cmd := range expectedCommands {
-		if !d.HasHandler(cmd) {
-			t.Errorf("expected handler for %s to be registered", cmd)
-		}
+		assert.True(t, d.HasHandler(cmd), "expected handler for %s to be registered", cmd)
 	}
 }
 
@@ -532,12 +530,8 @@ func TestHandler_NoDatabaseNoBackend_ReturnsNil(t *testing.T) {
 	// Test that handlers do nothing when there's no valid database or backend
 	result, err := d.Dispatch(dispatcher.Event{Command: ":NEW:SOLDIER:", Args: []string{}})
 
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if result != nil {
-		t.Errorf("expected nil result when no database/backend, got %v", result)
-	}
+	assert.NoError(t, err)
+	assert.Nil(t, result, "expected nil result when no database/backend")
 }
 
 func TestSetBackend(t *testing.T) {
@@ -549,72 +543,34 @@ func TestSetBackend(t *testing.T) {
 	queues := NewQueues()
 	manager := NewManager(deps, queues)
 
-	if manager.hasBackend() {
-		t.Error("expected no backend initially")
-	}
+	assert.False(t, manager.hasBackend(), "expected no backend initially")
 
 	backend := &mockBackend{}
 	manager.SetBackend(backend)
 
-	if !manager.hasBackend() {
-		t.Error("expected backend to be set")
-	}
+	assert.True(t, manager.hasBackend(), "expected backend to be set")
 }
 
 func TestNewQueues(t *testing.T) {
 	queues := NewQueues()
 
-	if queues == nil {
-		t.Fatal("expected non-nil queues")
-	}
-	if queues.Soldiers == nil {
-		t.Error("expected Soldiers queue to be initialized")
-	}
-	if queues.SoldierStates == nil {
-		t.Error("expected SoldierStates queue to be initialized")
-	}
-	if queues.Vehicles == nil {
-		t.Error("expected Vehicles queue to be initialized")
-	}
-	if queues.VehicleStates == nil {
-		t.Error("expected VehicleStates queue to be initialized")
-	}
-	if queues.FiredEvents == nil {
-		t.Error("expected FiredEvents queue to be initialized")
-	}
-	if queues.ProjectileEvents == nil {
-		t.Error("expected ProjectileEvents queue to be initialized")
-	}
-	if queues.GeneralEvents == nil {
-		t.Error("expected GeneralEvents queue to be initialized")
-	}
-	if queues.HitEvents == nil {
-		t.Error("expected HitEvents queue to be initialized")
-	}
-	if queues.KillEvents == nil {
-		t.Error("expected KillEvents queue to be initialized")
-	}
-	if queues.ChatEvents == nil {
-		t.Error("expected ChatEvents queue to be initialized")
-	}
-	if queues.RadioEvents == nil {
-		t.Error("expected RadioEvents queue to be initialized")
-	}
-	if queues.FpsEvents == nil {
-		t.Error("expected FpsEvents queue to be initialized")
-	}
-	if queues.Ace3DeathEvents == nil {
-		t.Error("expected Ace3DeathEvents queue to be initialized")
-	}
-	if queues.Ace3UnconsciousEvents == nil {
-		t.Error("expected Ace3UnconsciousEvents queue to be initialized")
-	}
-	if queues.Markers == nil {
-		t.Error("expected Markers queue to be initialized")
-	}
-	if queues.MarkerStates == nil {
-		t.Error("expected MarkerStates queue to be initialized")
-	}
+	require.NotNil(t, queues, "expected non-nil queues")
+	assert.NotNil(t, queues.Soldiers, "expected Soldiers queue to be initialized")
+	assert.NotNil(t, queues.SoldierStates, "expected SoldierStates queue to be initialized")
+	assert.NotNil(t, queues.Vehicles, "expected Vehicles queue to be initialized")
+	assert.NotNil(t, queues.VehicleStates, "expected VehicleStates queue to be initialized")
+	assert.NotNil(t, queues.FiredEvents, "expected FiredEvents queue to be initialized")
+	assert.NotNil(t, queues.ProjectileEvents, "expected ProjectileEvents queue to be initialized")
+	assert.NotNil(t, queues.GeneralEvents, "expected GeneralEvents queue to be initialized")
+	assert.NotNil(t, queues.HitEvents, "expected HitEvents queue to be initialized")
+	assert.NotNil(t, queues.KillEvents, "expected KillEvents queue to be initialized")
+	assert.NotNil(t, queues.ChatEvents, "expected ChatEvents queue to be initialized")
+	assert.NotNil(t, queues.RadioEvents, "expected RadioEvents queue to be initialized")
+	assert.NotNil(t, queues.FpsEvents, "expected FpsEvents queue to be initialized")
+	assert.NotNil(t, queues.Ace3DeathEvents, "expected Ace3DeathEvents queue to be initialized")
+	assert.NotNil(t, queues.Ace3UnconsciousEvents, "expected Ace3UnconsciousEvents queue to be initialized")
+	assert.NotNil(t, queues.Markers, "expected Markers queue to be initialized")
+	assert.NotNil(t, queues.MarkerStates, "expected MarkerStates queue to be initialized")
 }
 
 func TestNewManager(t *testing.T) {
@@ -627,12 +583,8 @@ func TestNewManager(t *testing.T) {
 
 	manager := NewManager(deps, queues)
 
-	if manager == nil {
-		t.Fatal("expected non-nil manager")
-	}
-	if manager.hasBackend() {
-		t.Error("expected no backend initially")
-	}
+	require.NotNil(t, manager, "expected non-nil manager")
+	assert.False(t, manager.hasBackend(), "expected no backend initially")
 }
 
 func TestHandleNewSoldier_CachesEntityWithBackend(t *testing.T) {
@@ -660,26 +612,16 @@ func TestHandleNewSoldier_CachesEntityWithBackend(t *testing.T) {
 	// Dispatch new soldier event
 	result, err := d.Dispatch(dispatcher.Event{Command: ":NEW:SOLDIER:", Args: []string{}})
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result != nil {
-		t.Errorf("expected nil result, got %v", result)
-	}
+	require.NoError(t, err)
+	assert.Nil(t, result, "expected nil result")
 
 	// Verify soldier is in backend
-	if len(backend.soldiers) != 1 {
-		t.Errorf("expected 1 soldier in backend, got %d", len(backend.soldiers))
-	}
+	assert.Equal(t, 1, len(backend.soldiers), "expected 1 soldier in backend")
 
 	// Verify soldier is also in EntityCache
 	cachedSoldier, found := entityCache.GetSoldier(42)
-	if !found {
-		t.Error("expected soldier to be cached in EntityCache")
-	}
-	if cachedSoldier.UnitName != "Test Soldier" {
-		t.Errorf("expected cached soldier name 'Test Soldier', got '%s'", cachedSoldier.UnitName)
-	}
+	assert.True(t, found, "expected soldier to be cached in EntityCache")
+	assert.Equal(t, "Test Soldier", cachedSoldier.UnitName)
 }
 
 func TestHandleNewVehicle_CachesEntityWithBackend(t *testing.T) {
@@ -707,26 +649,16 @@ func TestHandleNewVehicle_CachesEntityWithBackend(t *testing.T) {
 	// Dispatch new vehicle event
 	result, err := d.Dispatch(dispatcher.Event{Command: ":NEW:VEHICLE:", Args: []string{}})
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result != nil {
-		t.Errorf("expected nil result, got %v", result)
-	}
+	require.NoError(t, err)
+	assert.Nil(t, result, "expected nil result")
 
 	// Verify vehicle is in backend
-	if len(backend.vehicles) != 1 {
-		t.Errorf("expected 1 vehicle in backend, got %d", len(backend.vehicles))
-	}
+	assert.Equal(t, 1, len(backend.vehicles), "expected 1 vehicle in backend")
 
 	// Verify vehicle is also in EntityCache
 	cachedVehicle, found := entityCache.GetVehicle(99)
-	if !found {
-		t.Error("expected vehicle to be cached in EntityCache")
-	}
-	if cachedVehicle.OcapType != "car" {
-		t.Errorf("expected cached vehicle type 'car', got '%s'", cachedVehicle.OcapType)
-	}
+	assert.True(t, found, "expected vehicle to be cached in EntityCache")
+	assert.Equal(t, "car", cachedVehicle.OcapType)
 }
 
 func TestHandleNewSoldier_CachesEntityWithoutBackend(t *testing.T) {
@@ -752,23 +684,15 @@ func TestHandleNewSoldier_CachesEntityWithoutBackend(t *testing.T) {
 	// Dispatch new soldier event
 	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:SOLDIER:", Args: []string{}})
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Verify soldier is in queue
-	if queues.Soldiers.Len() != 1 {
-		t.Errorf("expected 1 soldier in queue, got %d", queues.Soldiers.Len())
-	}
+	assert.Equal(t, 1, queues.Soldiers.Len(), "expected 1 soldier in queue")
 
 	// Verify soldier is also in EntityCache
 	cachedSoldier, found := entityCache.GetSoldier(55)
-	if !found {
-		t.Error("expected soldier to be cached in EntityCache even when using queue")
-	}
-	if cachedSoldier.UnitName != "Queue Soldier" {
-		t.Errorf("expected cached soldier name 'Queue Soldier', got '%s'", cachedSoldier.UnitName)
-	}
+	assert.True(t, found, "expected soldier to be cached in EntityCache even when using queue")
+	assert.Equal(t, "Queue Soldier", cachedSoldier.UnitName)
 }
 
 func TestHandleMarkerDelete_WithBackend(t *testing.T) {
@@ -798,15 +722,11 @@ func TestHandleMarkerDelete_WithBackend(t *testing.T) {
 
 	// First create a marker so it exists in cache (sync handler)
 	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:MARKER:", Args: []string{}})
-	if err != nil {
-		t.Fatalf("failed to create marker: %v", err)
-	}
+	require.NoError(t, err, "failed to create marker")
 
 	// Now delete it (buffered handler - processes asynchronously)
 	_, err = d.Dispatch(dispatcher.Event{Command: ":DELETE:MARKER:", Args: []string{}})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Wait for the buffered handler to process
 	deadline := time.After(2 * time.Second)
@@ -816,15 +736,13 @@ func TestHandleMarkerDelete_WithBackend(t *testing.T) {
 		backend.mu.Unlock()
 
 		if ok {
-			if endFrame != 500 {
-				t.Errorf("expected endFrame=500, got %d", endFrame)
-			}
+			assert.Equal(t, uint(500), endFrame)
 			return
 		}
 
 		select {
 		case <-deadline:
-			t.Fatal("timed out waiting for marker delete to be processed")
+			require.Fail(t, "timed out waiting for marker delete to be processed")
 		default:
 			time.Sleep(10 * time.Millisecond)
 		}

--- a/pkg/a3interface/rvextension_test.go
+++ b/pkg/a3interface/rvextension_test.go
@@ -2,7 +2,10 @@ package a3interface
 
 import (
 	"errors"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFormatDispatchResponse(t *testing.T) {
@@ -74,16 +77,12 @@ func TestFormatDispatchResponse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := formatDispatchResponse(tt.command, tt.result, tt.err)
-			if got != tt.expected {
-				t.Errorf("formatDispatchResponse() = %q, want %q", got, tt.expected)
-			}
+			assert.Equal(t, tt.expected, got)
 		})
 	}
 }
 
 func TestResponseFormatConsistency(t *testing.T) {
-	// Test that all responses follow the ["ok", result] or ["error", message] format
-
 	t.Run("success responses start with ok", func(t *testing.T) {
 		responses := []struct {
 			result any
@@ -96,17 +95,13 @@ func TestResponseFormatConsistency(t *testing.T) {
 
 		for _, r := range responses {
 			got := formatDispatchResponse(":TEST:", r.result, nil)
-			if len(got) < 5 || got[:5] != `["ok"` {
-				t.Errorf("success response should start with [\"ok\", got %q", got)
-			}
+			assert.True(t, strings.HasPrefix(got, `["ok"`))
 		}
 	})
 
 	t.Run("error responses start with error", func(t *testing.T) {
 		got := formatDispatchResponse(":TEST:", nil, errors.New("test error"))
 		expected := `["error", "test error"]`
-		if got != expected {
-			t.Errorf("error response = %q, want %q", got, expected)
-		}
+		assert.Equal(t, expected, got)
 	})
 }


### PR DESCRIPTION
## Summary
- Replace manual `if/t.Errorf` and `if/t.Fatal` assertion patterns with testify `assert` and `require` across all 16 test files that were using stdlib-only testing
- Standardizes test assertion style to match the 2 files that already used testify (`export_test.go`, `builder_test.go`)
- Fix type mismatches surfaced by testify's strict type checking in `assert.Equal`

## Test plan
- [x] All existing tests pass (`go test ./...`)