### PR TITLE
fix: match old C++ extension v1 JSON export format

### DIFF
--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -100,6 +100,7 @@ func Build(data *MissionData) Export {
 			Side:          record.Soldier.Side,
 			IsPlayer:      boolToInt(record.Soldier.IsPlayer),
 			Type:          "unit",
+			Role:          record.Soldier.RoleDescription,
 			StartFrameNum: record.Soldier.JoinFrame,
 			Positions:     make([][]any, 0, len(record.States)),
 			FramesFired:   make([][]any, 0, len(record.FiredEvents)),
@@ -113,7 +114,7 @@ func Build(data *MissionData) Export {
 			}
 
 			pos := []any{
-				[]float64{state.Position.X, state.Position.Y},
+				[]float64{state.Position.X, state.Position.Y, state.Position.Z},
 				state.Bearing,
 				state.Lifestate,
 				inVehicleID,
@@ -165,10 +166,11 @@ func Build(data *MissionData) Export {
 			}
 
 			pos := []any{
-				[]float64{state.Position.X, state.Position.Y},
+				[]float64{state.Position.X, state.Position.Y, state.Position.Z},
 				state.Bearing,
 				boolToInt(state.IsAlive),
 				crew,
+				[]uint{state.CaptureFrame, state.CaptureFrame},
 			}
 			entity.Positions = append(entity.Positions, pos)
 			if state.CaptureFrame > maxFrame {
@@ -276,7 +278,7 @@ func Build(data *MissionData) Export {
 			// For other shapes: pos is a single coordinate
 			posArray = append(posArray, []any{
 				record.Marker.CaptureFrame,
-				[]float64{record.Marker.Position.X, record.Marker.Position.Y},
+				[]float64{record.Marker.Position.X, record.Marker.Position.Y, record.Marker.Position.Z},
 				record.Marker.Direction,
 				record.Marker.Alpha,
 			})
@@ -285,7 +287,7 @@ func Build(data *MissionData) Export {
 			for _, state := range record.States {
 				posArray = append(posArray, []any{
 					state.CaptureFrame,
-					[]float64{state.Position.X, state.Position.Y},
+					[]float64{state.Position.X, state.Position.Y, state.Position.Z},
 					state.Direction,
 					state.Alpha,
 				})

--- a/internal/storage/memory/export/v1/builder_test.go
+++ b/internal/storage/memory/export/v1/builder_test.go
@@ -154,7 +154,7 @@ func TestBuildWithSoldier(t *testing.T) {
 		Soldiers: map[uint16]*SoldierRecord{
 			5: {
 				Soldier: core.Soldier{
-					ID: 5, UnitName: "Player1", GroupID: "Alpha", Side: "WEST", IsPlayer: true, JoinFrame: 10,
+					ID: 5, UnitName: "Player1", GroupID: "Alpha", Side: "WEST", IsPlayer: true, JoinFrame: 10, RoleDescription: "Rifleman",
 				},
 				States: []core.SoldierState{
 					{SoldierID: 5, CaptureFrame: 10, Position: core.Position3D{X: 1000, Y: 2000}, Bearing: 90, Lifestate: 1, UnitName: "Player1", IsPlayer: true, CurrentRole: "Rifleman"},
@@ -181,14 +181,17 @@ func TestBuildWithSoldier(t *testing.T) {
 	assert.Equal(t, "WEST", entity.Side)
 	assert.Equal(t, 1, entity.IsPlayer)
 	assert.Equal(t, "unit", entity.Type)
+	assert.Equal(t, "Rifleman", entity.Role)
 	assert.Equal(t, uint(10), entity.StartFrameNum)
 
 	// Check positions
 	require.Len(t, entity.Positions, 2)
 	pos := entity.Positions[0]
 	coords := pos[0].([]float64)
+	require.Len(t, coords, 3)
 	assert.Equal(t, 1000.0, coords[0])
 	assert.Equal(t, 2000.0, coords[1])
+	assert.Equal(t, 0.0, coords[2])
 	assert.Equal(t, uint16(90), pos[1])  // bearing
 	assert.Equal(t, uint8(1), pos[2])    // lifestate
 	assert.Equal(t, 0, pos[3])           // inVehicleID (nil -> 0)
@@ -272,8 +275,10 @@ func TestBuildWithVehicle(t *testing.T) {
 	require.Len(t, entity.Positions, 2)
 	pos := entity.Positions[0]
 	coords := pos[0].([]float64)
+	require.Len(t, coords, 3)
 	assert.Equal(t, 3000.0, coords[0])
 	assert.Equal(t, 4000.0, coords[1])
+	assert.Equal(t, 0.0, coords[2])
 	assert.Equal(t, uint16(180), pos[1]) // bearing
 	assert.Equal(t, 1, pos[2])           // isAlive
 
@@ -282,6 +287,10 @@ func TestBuildWithVehicle(t *testing.T) {
 	require.Len(t, crew, 1)
 	crewEntry := crew[0].([]any)
 	assert.Equal(t, float64(1), crewEntry[0])
+
+	// Frame range
+	frameRange := pos[4].([]uint)
+	assert.Equal(t, []uint{5, 5}, frameRange)
 
 	assert.Equal(t, uint(15), export.EndFrame)
 }

--- a/internal/storage/memory/export/v1/types.go
+++ b/internal/storage/memory/export/v1/types.go
@@ -37,6 +37,7 @@ type Entity struct {
 	Side          string  `json:"side"`
 	IsPlayer      int     `json:"isPlayer"`
 	Type          string  `json:"type"`
+	Role          string  `json:"role,omitempty"`
 	Class         string  `json:"class,omitempty"`
 	StartFrameNum uint    `json:"startFrameNum"`
 	Positions     [][]any `json:"positions"`

--- a/internal/storage/memory/export_test.go
+++ b/internal/storage/memory/export_test.go
@@ -776,6 +776,9 @@ func TestJSONFormatValidation(t *testing.T) {
 	require.Len(t, crew, 1)
 	crewEntry := crew[0].([]any)
 	assert.Equal(t, float64(5), crewEntry[0]) // driver ID
+	// Frame range
+	frameRange := vehPos[4].([]any)
+	assert.Equal(t, []any{float64(0), float64(0)}, frameRange)
 
 	// Validate event format: [frameNum, "killed", victimId, [killerId, weapon], distance]
 	events := raw["events"].([]any)

--- a/internal/storage/memory/export_test.go
+++ b/internal/storage/memory/export_test.go
@@ -129,8 +129,10 @@ func TestIntegrationFullExport(t *testing.T) {
 	// Verify soldier position coordinates after JSON round-trip
 	coords, ok := soldierEntity.Positions[0][0].([]any)
 	require.True(t, ok, "position coords should be []any after JSON unmarshal")
+	require.Len(t, coords, 3)
 	assert.Equal(t, 1000.0, coords[0])
 	assert.Equal(t, 2000.0, coords[1])
+	assert.Equal(t, 100.0, coords[2])
 
 	// Verify fired event - v1 format: [frameNum, [x, y, z]]
 	ff := soldierEntity.FramesFired[0]
@@ -302,8 +304,10 @@ func TestSoldierPositionFormat(t *testing.T) {
 
 	coords, ok := pos[0].([]float64)
 	require.True(t, ok, "position[0] should be []float64")
+	require.Len(t, coords, 3)
 	assert.Equal(t, 1234.56, coords[0])
 	assert.Equal(t, 7890.12, coords[1])
+	assert.Equal(t, 50.0, coords[2])
 	assert.Equal(t, uint16(270), pos[1])
 	assert.Equal(t, uint8(1), pos[2])
 	assert.Equal(t, 1, pos[5])
@@ -327,13 +331,19 @@ func TestVehiclePositionFormat(t *testing.T) {
 	require.Len(t, entity.Positions, 1)
 
 	pos := entity.Positions[0]
-	require.Len(t, pos, 4) // [[x, y], bearing, isAlive, crew]
+	require.Len(t, pos, 5) // [[x, y, z], bearing, isAlive, crew, [frameStart, frameEnd]]
 
 	coords, ok := pos[0].([]float64)
 	require.True(t, ok, "position[0] should be []float64")
+	require.Len(t, coords, 3)
 	assert.Equal(t, 5000.0, coords[0])
 	assert.Equal(t, 6000.0, coords[1])
+	assert.Equal(t, 25.0, coords[2])
 	assert.Equal(t, 1, pos[2])
+
+	// Frame range
+	frameRange := pos[4].([]uint)
+	assert.Equal(t, []uint{3, 3}, frameRange)
 }
 
 func TestFiredEventFormat(t *testing.T) {
@@ -384,12 +394,14 @@ func TestMarkerPositionFormat(t *testing.T) {
 	positions := export.Markers[0][7].([][]any) // positions at index 7
 	require.Len(t, positions, 2)                // initial + 1 state
 
-	// Position format: [frameNum, [x, y], direction, alpha]
+	// Position format: [frameNum, [x, y, z], direction, alpha]
 	initialPos := positions[0]
 	assert.Equal(t, uint(0), initialPos[0])      // frameNum
 	coords := initialPos[1].([]float64)
+	require.Len(t, coords, 3)
 	assert.Equal(t, 1000.0, coords[0])           // posX
 	assert.Equal(t, 2000.0, coords[1])           // posY
+	assert.Equal(t, 0.0, coords[2])              // posZ
 
 	assert.Equal(t, uint(50), positions[1][0])   // second position frameNum
 }
@@ -751,11 +763,12 @@ func TestJSONFormatValidation(t *testing.T) {
 	assert.Equal(t, float64(10), vehicle["id"])
 	assert.Equal(t, "vehicle", vehicle["type"])
 
-	// Validate vehicle position format: [[x, y], bearing, alive, crew]
+	// Validate vehicle position format: [[x, y, z], bearing, alive, crew, [frameStart, frameEnd]]
 	vehiclePositions := vehicle["positions"].([]any)
 	require.Len(t, vehiclePositions, 1)
 	vehPos := vehiclePositions[0].([]any)
 	coords := vehPos[0].([]any)
+	require.Len(t, coords, 3)
 	assert.Equal(t, float64(3000), coords[0])
 	assert.Equal(t, float64(4000), coords[1])
 	// Crew should be parsed as array, not string
@@ -796,7 +809,7 @@ func TestJSONFormatValidation(t *testing.T) {
 	mCoords := mPos[1].([]any)
 	assert.Equal(t, float64(5000), mCoords[0])  // x
 	assert.Equal(t, float64(6000), mCoords[1])  // y
-	assert.Len(t, mCoords, 2)                   // should be [x, y], not [x, y, z]
+	assert.Len(t, mCoords, 3)                   // should be [x, y, z]
 }
 
 func ptrUint(v uint) *uint {


### PR DESCRIPTION
## Summary

- Add Z coordinate to all position arrays (soldier, vehicle, marker initial, marker state)
- Add `[frameStart, frameEnd]` frame range as 5th element in vehicle position arrays
- Add `role` field to unit entities, populated from `RoleDescription`

These changes make the v1 JSON export compatible with the OCAP2 web frontend which expects the format produced by the old C++ extension.

## Test plan

- [x] `go test ./internal/storage/memory/export/v1/ -v` — all pass
- [x] `go test ./internal/storage/memory/ -v` — all pass
- [x] `go test ./...` — all pass