### PR TITLE
fix: prevent panic on malformed player scores in LogSoldierState

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -410,19 +410,23 @@ func (s *Service) LogSoldierState(data []string) (model.SoldierState, error) {
 	if isPlayer {
 		scoresStr := data[11]
 		scoresArr := strings.Split(scoresStr, ",")
-		scoresInt := make([]uint8, len(scoresArr))
-		for i, v := range scoresArr {
-			num, _ := strconv.Atoi(v)
-			scoresInt[i] = uint8(num)
-		}
+		if len(scoresArr) >= 6 {
+			scoresInt := make([]uint8, len(scoresArr))
+			for i, v := range scoresArr {
+				num, _ := strconv.Atoi(v)
+				scoresInt[i] = uint8(num)
+			}
 
-		soldierState.Scores = model.SoldierScores{
-			InfantryKills: scoresInt[0],
-			VehicleKills:  scoresInt[1],
-			ArmorKills:    scoresInt[2],
-			AirKills:      scoresInt[3],
-			Deaths:        scoresInt[4],
-			TotalScore:    scoresInt[5],
+			soldierState.Scores = model.SoldierScores{
+				InfantryKills: scoresInt[0],
+				VehicleKills:  scoresInt[1],
+				ArmorKills:    scoresInt[2],
+				AirKills:      scoresInt[3],
+				Deaths:        scoresInt[4],
+				TotalScore:    scoresInt[5],
+			}
+		} else {
+			s.writeLog(functionName, fmt.Sprintf("expected 6 score values, got %d: %q", len(scoresArr), scoresStr), "WARN")
 		}
 	}
 


### PR DESCRIPTION
## Summary
- ArmA 3's `getPlayerScores` can return an empty array `[]` during JIP or AI-to-player transitions. After `joinString ","` this becomes `""`, which `strings.Split` turns into a single-element slice — causing an index out of range panic at `handlers.go:421`.
- Added a length check (`len(scoresArr) >= 6`) before accessing score indices, with a warning log for malformed data.
- Added table-driven test covering valid scores, empty/partial scores, and non-player cases.

## Test plan
- [x] `go test ./...` passes
- [x] `TestLogSoldierState_ScoresParsingPanic` reproduces the original crash scenario and verifies the fix