### PR TITLE
fix: recover panics in dispatcher buffered handler goroutines

### DIFF
--- a/internal/dispatcher/dispatcher_test.go
+++ b/internal/dispatcher/dispatcher_test.go
@@ -366,12 +366,14 @@ func TestDispatcher_BufferedPanicRecovery(t *testing.T) {
 	defer logger.mu.Unlock()
 	hasPanicLog := false
 	for _, msg := range logger.messages {
-		if strings.HasPrefix(msg, "ERROR") && strings.Contains(msg, "panic") {
+		if strings.Contains(msg, "panic in buffered handler (recovered)") &&
+			strings.Contains(msg, ":PANIC:") &&
+			strings.Contains(msg, "test panic in handler") {
 			hasPanicLog = true
 			break
 		}
 	}
-	assert.True(t, hasPanicLog, "expected panic recovery to be logged")
+	assert.True(t, hasPanicLog, "expected panic recovery to be logged with command and panic details")
 }
 
 func TestDispatcher_ConcurrentRegisterAndDispatch(t *testing.T) {


### PR DESCRIPTION
## Summary
- `defer recover()` only catches panics in the **same goroutine**. The existing panic recovery at the CGo boundary (`RVExtension`/`RVExtensionArgs`) does not protect the separate goroutines spawned by `withBuffer` for async command processing. Any unrecovered panic there crashes the entire ArmA 3 server process.
- Extracted handler invocation into `safeHandle()` which wraps each event with its own `defer/recover`, so a single bad event is logged and skipped without killing the goroutine or the host process.
- Added `TestDispatcher_BufferedPanicRecovery` which sends 3 events where #2 panics, and verifies all 3 are processed and the panic is logged.

## Test plan
- [x] `go test ./...` passes
- [x] `TestDispatcher_BufferedPanicRecovery` confirms the goroutine survives a panic and continues processing