### PR TITLE
ci: add release workflow with build metadata injection

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -93,7 +93,9 @@ jobs:
       - name: Build x64 DLL
         run: |
           docker run --rm -v "${{ github.workspace }}:/go/work" -w /go/work x1unix/go-mingw:1.24 \
-            go build -buildvcs=false -o dist/ocap_recorder_x64.dll -buildmode=c-shared ./cmd/ocap_recorder
+            go build -buildvcs=false \
+              -ldflags "-X main.BuildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -X main.BuildCommit=${{ github.sha }}" \
+              -o dist/ocap_recorder_x64.dll -buildmode=c-shared ./cmd/ocap_recorder
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,9 @@ jobs:
       - name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
         run: |
           docker run --rm -v "${{ github.workspace }}:/go/work" -w /go/work ${{ matrix.docker_image }} \
-            go build -buildvcs=false -o dist/${{ matrix.binary }} -buildmode=c-shared ./cmd/ocap_recorder
+            go build -buildvcs=false \
+              -ldflags "-X main.BuildVersion=${{ github.ref_name }} -X main.BuildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -X main.BuildCommit=${{ github.sha }}" \
+              -o dist/${{ matrix.binary }} -buildmode=c-shared ./cmd/ocap_recorder
 
       - name: Create release archive
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    strategy:
+      matrix:
+        include:
+          - goos: windows
+            goarch: amd64
+            docker_image: x1unix/go-mingw:1.24
+            binary: ocap_recorder_x64.dll
+            archive: ocap_recorder-windows-amd64.zip
+            archiver: zip -r
+          - goos: linux
+            goarch: amd64
+            docker_image: golang:1.24-bullseye
+            binary: ocap_recorder_x64.so
+            archive: ocap_recorder-linux-amd64.tar.gz
+            archiver: tar -czvf
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/go/work" -w /go/work ${{ matrix.docker_image }} \
+            go build -buildvcs=false -o dist/${{ matrix.binary }} -buildmode=c-shared ./cmd/ocap_recorder
+
+      - name: Create release archive
+        run: |
+          mkdir -p release
+          cp dist/${{ matrix.binary }} release/
+          cp ocap_recorder.cfg.json.example release/
+          cp createViews.sql release/
+          cd release && ${{ matrix.archiver }} ../${{ matrix.archive }} .
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2
+        with:
+          files: ${{ matrix.archive }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,6 @@ jobs:
           mkdir -p release
           cp dist/${{ matrix.binary }} release/
           cp ocap_recorder.cfg.json.example release/
-          cp createViews.sql release/
           cd release && ${{ matrix.archiver }} ../${{ matrix.archive }} .
 
       - name: Upload release asset

--- a/cmd/ocap_recorder/main.go
+++ b/cmd/ocap_recorder/main.go
@@ -47,10 +47,11 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-// module defs - BuildDate can be set at build time via ldflags
+// module defs - can be set at build time via ldflags
 var (
-	CurrentExtensionVersion string = "0.0.1"
-	BuildDate               string = "unknown"
+	BuildVersion string = "dev"
+	BuildCommit  string = "unknown"
+	BuildDate    string = "unknown"
 
 	Addon         string = "ocap"
 	ExtensionName string = "ocap_recorder"
@@ -290,7 +291,7 @@ func initExtension() {
 	// send ready callback to Arma
 	a3interface.WriteArmaCallback(ExtensionName, ":EXT:READY:")
 	// send extension version
-	a3interface.WriteArmaCallback(ExtensionName, ":VERSION:", CurrentExtensionVersion)
+	a3interface.WriteArmaCallback(ExtensionName, ":VERSION:", BuildVersion)
 }
 
 func initStorage() error {
@@ -326,7 +327,7 @@ func initStorage() error {
 }
 
 func setupA3Interface() (err error) {
-	a3interface.SetVersion(CurrentExtensionVersion)
+	a3interface.SetVersion(BuildVersion)
 
 	// Create early dispatcher for commands that don't need DB/workers
 	// This ensures :VERSION:, :INIT:, etc. work immediately when the DLL loads
@@ -529,7 +530,7 @@ func startGoroutines() (err error) {
 		LogManager:       SlogManager,
 		ExtensionName:    ExtensionName,
 		AddonVersion:     addonVersion,
-		ExtensionVersion: CurrentExtensionVersion,
+		ExtensionVersion: BuildVersion,
 	}, missionCtx)
 
 	// Initialize worker manager
@@ -810,7 +811,7 @@ func registerLifecycleHandlers(d *dispatcher.Dispatcher) {
 
 	// Simple queries - sync return is sufficient, no callback needed
 	d.Register(":VERSION:", func(e dispatcher.Event) (any, error) {
-		return []string{CurrentExtensionVersion, BuildDate}, nil
+		return []string{BuildVersion, BuildCommit, BuildDate}, nil
 	})
 
 	d.Register(":GETDIR:ARMA:", func(e dispatcher.Event) (any, error) {


### PR DESCRIPTION
## Summary
- Add GitHub Actions release workflow that builds Windows DLL and Linux .so on tag push, attaches them to GitHub releases
- Inject build metadata (version, commit SHA, date) via `-ldflags` in both release and CI workflows, aligned with the ocap2-web pattern
- Rename `CurrentExtensionVersion` to `BuildVersion`, add `BuildCommit` variable, default to `"dev"` / `"unknown"`

## Test plan
- [x] CI build workflow passes with new ldflags
- [x] Push a test tag to verify release workflow builds and attaches binaries with correct version metadata