### PR TITLE
feat: track groupID and side dynamically in SoldierState

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor/
 dist/
 docs/plans/
 cover.out
+.worktrees/

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -450,6 +450,16 @@ func (s *Service) LogSoldierState(data []string) (model.SoldierState, error) {
 	// stance
 	soldierState.Stance = data[14]
 
+	// groupID and side (added by addon PR#55, backward compatible)
+	if len(data) >= 17 {
+		soldierState.GroupID = data[15]
+		soldierState.Side = data[16]
+	} else {
+		// Fall back to initial registration data
+		soldierState.GroupID = soldier.GroupID
+		soldierState.Side = soldier.Side
+	}
+
 	return soldierState, nil
 }
 

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -329,6 +329,53 @@ func TestLogSoldierState_ScoresParsingPanic(t *testing.T) {
 	}
 }
 
+func TestLogSoldierState_GroupAndSide(t *testing.T) {
+	svc := newTestService()
+	svc.SetBackend(&mockBackend{})
+
+	mission := &model.Mission{}
+	mission.ID = 1
+	svc.ctx.SetMission(mission, &model.World{})
+
+	svc.deps.EntityCache.AddSoldier(model.Soldier{
+		ObjectID: 42, MissionID: 1,
+		GroupID: "InitGroup", Side: "WEST",
+	})
+
+	baseData := []string{
+		"42",                  // 0: ocapId
+		"[100.0,200.0,50.0]", // 1: position
+		"90",                  // 2: bearing
+		"1",                   // 3: lifestate
+		"false",               // 4: inVehicle
+		"TestUnit",            // 5: name
+		"false",               // 6: isPlayer
+		"rifleman",            // 7: currentRole
+		"10",                  // 8: frame
+		"true",                // 9: hasStableVitals
+		"false",               // 10: isDraggedCarried
+		"",                    // 11: scores
+		"",                    // 12: vehicleRole
+		"-1",                  // 13: inVehicleID
+		"STAND",               // 14: stance
+	}
+
+	t.Run("17 fields parses group and side", func(t *testing.T) {
+		data := append(append([]string{}, baseData...), "Alpha 1-1", "EAST")
+		state, err := svc.LogSoldierState(data)
+		require.NoError(t, err)
+		assert.Equal(t, "Alpha 1-1", state.GroupID)
+		assert.Equal(t, "EAST", state.Side)
+	})
+
+	t.Run("15 fields falls back to initial soldier data", func(t *testing.T) {
+		state, err := svc.LogSoldierState(append([]string{}, baseData...))
+		require.NoError(t, err)
+		assert.Equal(t, "InitGroup", state.GroupID)
+		assert.Equal(t, "WEST", state.Side)
+	})
+}
+
 func TestMissionContext_ThreadSafe(t *testing.T) {
 	ctx := NewMissionContext()
 

--- a/internal/model/convert/convert.go
+++ b/internal/model/convert/convert.go
@@ -85,6 +85,8 @@ func SoldierStateToCore(s model.SoldierState) core.SoldierState {
 		HasStableVitals:   s.HasStableVitals,
 		IsDraggedCarried:  s.IsDraggedCarried,
 		Stance:            s.Stance,
+		GroupID:           s.GroupID,
+		Side:              s.Side,
 		Scores: core.SoldierScores{
 			InfantryKills: s.Scores.InfantryKills,
 			VehicleKills:  s.Scores.VehicleKills,

--- a/internal/model/convert/convert_test.go
+++ b/internal/model/convert/convert_test.go
@@ -84,6 +84,8 @@ func TestSoldierStateToCore(t *testing.T) {
 		HasStableVitals: true,
 		IsDraggedCarried: false,
 		Stance:          "Up",
+		GroupID:         "Alpha 1-1",
+		Side:            "WEST",
 		Scores: model.SoldierScores{
 			InfantryKills: 5,
 			VehicleKills:  2,
@@ -104,6 +106,8 @@ func TestSoldierStateToCore(t *testing.T) {
 	require.NotNil(t, coreState.InVehicleObjectID)
 	assert.Equal(t, uint16(5), *coreState.InVehicleObjectID)
 	assert.Equal(t, uint8(5), coreState.Scores.InfantryKills)
+	assert.Equal(t, "Alpha 1-1", coreState.GroupID)
+	assert.Equal(t, "WEST", coreState.Side)
 }
 
 func TestVehicleToCore(t *testing.T) {

--- a/internal/model/core/soldier.go
+++ b/internal/model/core/soldier.go
@@ -41,5 +41,7 @@ type SoldierState struct {
 	HasStableVitals   bool
 	IsDraggedCarried  bool
 	Stance            string
+	GroupID           string
+	Side              string
 	Scores            SoldierScores
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -334,7 +334,7 @@ func (s *Soldier) Get(db *gorm.DB) (err error) {
 // References Soldier by (MissionID, SoldierObjectID) composite FK
 //
 // SQF Command: :NEW:SOLDIER:STATE:
-// Args: [ocapId, pos, dir, lifeState, inVehicle, name, isPlayer, role, frameNo, hasStableVitals, isDragged, scores, vehicleRole, vehicleOcapId, stance]
+// Args: [ocapId, pos, dir, lifeState, inVehicle, name, isPlayer, role, frameNo, hasStableVitals, isDragged, scores, vehicleRole, vehicleOcapId, stance, groupID, side]
 type SoldierState struct {
 	ID              uint      `json:"id" gorm:"primarykey;autoIncrement;"`
 	Time            time.Time `json:"time" gorm:"type:timestamptz;"`                                // Server time when state was recorded
@@ -357,6 +357,8 @@ type SoldierState struct {
 	HasStableVitals  bool          `json:"hasStableVitals" gorm:"default:true"`         // ACE Medical: has stable vitals (true if ACE not present)
 	IsDraggedCarried bool          `json:"isDraggedCarried" gorm:"default:false"`       // ACE Medical: is being dragged or carried
 	Stance           string        `json:"stance" gorm:"size:64"`                       // Stance: STAND, CROUCH, PRONE, etc.
+	GroupID          string        `json:"groupId" gorm:"size:64"`                      // Group name (dynamic, may change mid-mission)
+	Side             string        `json:"side" gorm:"size:16"`                         // Side (dynamic, may change mid-mission)
 	Scores           SoldierScores `json:"scores" gorm:"embedded;embeddedPrefix:scores_"` // Player score data (only for players)
 }
 

--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -121,6 +121,8 @@ func Build(data *MissionData) Export {
 				state.UnitName,
 				boolToInt(state.IsPlayer),
 				state.CurrentRole,
+				state.GroupID,
+				state.Side,
 			}
 			entity.Positions = append(entity.Positions, pos)
 			if state.CaptureFrame > maxFrame {

--- a/internal/storage/memory/export/v1/builder_test.go
+++ b/internal/storage/memory/export/v1/builder_test.go
@@ -157,8 +157,8 @@ func TestBuildWithSoldier(t *testing.T) {
 					ID: 5, UnitName: "Player1", GroupID: "Alpha", Side: "WEST", IsPlayer: true, JoinFrame: 10, RoleDescription: "Rifleman",
 				},
 				States: []core.SoldierState{
-					{SoldierID: 5, CaptureFrame: 10, Position: core.Position3D{X: 1000, Y: 2000}, Bearing: 90, Lifestate: 1, UnitName: "Player1", IsPlayer: true, CurrentRole: "Rifleman"},
-					{SoldierID: 5, CaptureFrame: 20, Position: core.Position3D{X: 1100, Y: 2100}, Bearing: 95, Lifestate: 1, UnitName: "Player1", IsPlayer: true, CurrentRole: "Rifleman"},
+					{SoldierID: 5, CaptureFrame: 10, Position: core.Position3D{X: 1000, Y: 2000}, Bearing: 90, Lifestate: 1, UnitName: "Player1", IsPlayer: true, CurrentRole: "Rifleman", GroupID: "Alpha", Side: "WEST"},
+					{SoldierID: 5, CaptureFrame: 20, Position: core.Position3D{X: 1100, Y: 2100}, Bearing: 95, Lifestate: 1, UnitName: "Player1", IsPlayer: true, CurrentRole: "Rifleman", GroupID: "Bravo", Side: "WEST"},
 				},
 				FiredEvents: []core.FiredEvent{
 					{SoldierID: 5, CaptureFrame: 15, Weapon: "arifle_MX_F", Magazine: "30Rnd_65x39", FiringMode: "Single", StartPos: core.Position3D{X: 1050, Y: 2050}, EndPos: core.Position3D{X: 1200, Y: 2200}},
@@ -198,6 +198,12 @@ func TestBuildWithSoldier(t *testing.T) {
 	assert.Equal(t, "Player1", pos[4])   // unitName
 	assert.Equal(t, 1, pos[5])           // isPlayer
 	assert.Equal(t, "Rifleman", pos[6])  // currentRole
+	assert.Equal(t, "Alpha", pos[7])    // groupID
+	assert.Equal(t, "WEST", pos[8])     // side
+
+	// Second position has different group
+	pos2 := entity.Positions[1]
+	assert.Equal(t, "Bravo", pos2[7])   // groupID changed mid-mission
 
 	// Check fired events - v1 format: [frameNum, [x, y, z]]
 	require.Len(t, entity.FramesFired, 1)

--- a/internal/storage/memory/export_test.go
+++ b/internal/storage/memory/export_test.go
@@ -300,7 +300,7 @@ func TestSoldierPositionFormat(t *testing.T) {
 	require.Len(t, entity.Positions, 1)
 
 	pos := entity.Positions[0]
-	require.Len(t, pos, 7) // [[x, y], bearing, lifestate, inVehicleObjectID, unitName, isPlayer, currentRole]
+	require.Len(t, pos, 9) // [[x, y, z], bearing, lifestate, inVehicleObjectID, unitName, isPlayer, currentRole, groupID, side]
 
 	coords, ok := pos[0].([]float64)
 	require.True(t, ok, "position[0] should be []float64")


### PR DESCRIPTION
## Summary

- Adds per-frame `groupID` and `side` fields to soldier state tracking, enabling the web player to detect mid-mission group/side changes (e.g., JIP players joining different groups, Zeus reassignments, side switches)
- Parses the two new fields (`data[15]`, `data[16]`) appended by [OCAP2/addon#55](https://github.com/OCAP2/addon/pull/55) with backward compatibility — falls back to the soldier's initial registration data when receiving 15-element arrays from older addon versions
- Propagates through the full pipeline: core model → GORM model → handler parser → converter → v1 JSON export

## Changes

| File | Change |
|------|--------|
| `internal/model/core/soldier.go` | Add `GroupID`, `Side` to `SoldierState` struct |
| `internal/model/model.go` | Add `GroupID`, `Side` to GORM `SoldierState` with tags |
| `internal/model/convert/convert.go` | Map new fields in `SoldierStateToCore` |
| `internal/handlers/handlers.go` | Parse `data[15]`/`data[16]` with backward compat fallback |
| `internal/storage/memory/export/v1/builder.go` | Append `groupID`, `side` to position arrays |
| Tests updated in all layers |

## v1 JSON Export — Position Array Format (for web implementation)

The soldier position array in the v1 JSON export now has **9 elements** (was 7):

```
Index  Type      Field          Description
─────  ────      ─────          ───────────
[0]    float[]   position       [x, y, z] coordinates
[1]    uint16    bearing        Direction facing (0-360)
[2]    uint8     lifestate      0=dead, 1=alive, 2=unconscious
[3]    any       inVehicleID    Vehicle OCAP ID (0 if not in vehicle)
[4]    string    unitName       Current unit name
[5]    int       isPlayer       1=player, 0=AI
[6]    string    currentRole    Role/unit type
[7]    string    groupID        ← NEW: Group name (e.g., "Alpha 1-1")
[8]    string    side           ← NEW: Side (e.g., "WEST", "EAST", "INDEPENDENT", "CIVILIAN")
```

These values are **per-frame** — they can change mid-mission. The entity-level `group` and `side` fields still reflect the soldier's initial values at registration time.

### Example position entry

```json
[
  [5432.1, 7890.3, 25.0],
  180,
  1,
  0,
  "Player1",
  1,
  "Rifleman",
  "Bravo 1-2",
  "WEST"
]
```

### Backward compatibility

When the addon doesn't send `groupID`/`side` per frame (older versions), the extension falls back to the soldier's initial registration values. The web player will always receive these two fields in positions — no conditional logic needed on the frontend.

## DB Migration

GORM AutoMigrate adds two columns (`group_id`, `side`) to `soldier_states` automatically. No manual migration needed.

## Test Plan

- [x] All Go tests pass (`go test ./...`)
- [x] Windows DLL builds
- [x] Linux .so builds
- [x] Integration test with addon sending 17-field state arrays
- [x] Integration test with addon sending 15-field state arrays (backward compat)

Refs OCAP2/addon#55