### PR TITLE
fix: handle float-formatted IDs from ArmA 3 extension API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor/
 dist/
 docs/plans/
 cover.out
+.worktrees/

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -32,7 +32,10 @@ func parseUintFromFloat(s string) (uint64, error) {
 	}
 	f, err := strconv.ParseFloat(s, 64)
 	if err != nil {
-		return 0, fmt.Errorf("strconv.ParseUint/Float: parsing %q: invalid syntax", s)
+		return 0, err
+	}
+	if f < 0 || f != float64(uint64(f)) {
+		return 0, fmt.Errorf("parseUintFromFloat: %q is not a valid uint64", s)
 	}
 	return uint64(f), nil
 }
@@ -44,7 +47,10 @@ func parseIntFromFloat(s string) (int64, error) {
 	}
 	f, err := strconv.ParseFloat(s, 64)
 	if err != nil {
-		return 0, fmt.Errorf("strconv.ParseInt/Float: parsing %q: invalid syntax", s)
+		return 0, err
+	}
+	if f != float64(int64(f)) {
+		return 0, fmt.Errorf("parseIntFromFloat: %q is not a valid int64", s)
 	}
 	return int64(f), nil
 }

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -340,12 +340,12 @@ func TestParseUintFromFloat(t *testing.T) {
 		{"zero", "0", 0, false},
 		{"float with decimals", "32.00", 32, false},
 		{"float with trailing zero", "30.0", 30, false},
-		{"float truncates", "10.99", 10, false},
 		{"large integer", "65535", 65535, false},
 		{"large float", "65535.00", 65535, false},
+		{"fractional rejects", "10.99", 0, true},
 		{"empty string", "", 0, true},
 		{"non-numeric", "abc", 0, true},
-		{"negative wraps", "-1", ^uint64(0), false}, // float-to-uint wraps; callers use parseIntFromFloat for signed IDs
+		{"negative", "-1", 0, true},
 	}
 
 	for _, tt := range tests {
@@ -373,8 +373,8 @@ func TestParseIntFromFloat(t *testing.T) {
 		{"negative integer", "-1", -1, false},
 		{"float with decimals", "32.00", 32, false},
 		{"negative float", "-1.00", -1, false},
-		{"float truncates", "10.99", 10, false},
 		{"large integer", "65535", 65535, false},
+		{"fractional rejects", "10.99", 0, true},
 		{"empty string", "", 0, true},
 		{"non-numeric", "abc", 0, true},
 	}


### PR DESCRIPTION
## Summary
- ArmA 3's SQF has no integer type, so the extension API may serialize IDs as floats (e.g. `"32.00"` instead of `"32"`), causing `strconv.ParseUint` failures in `:NEW:VEHICLE:STATE:` and other handlers
- Added `parseUintFromFloat` / `parseIntFromFloat` helpers that try integer parsing first (fast path), then fall back to `ParseFloat`
- Replaced all 17 ID parsing call sites across soldier, vehicle, projectile, hit, kill, chat, radio, and ACE3 event handlers

## Test plan
- [x] Unit tests for `parseUintFromFloat` (10 cases: integers, floats, edge cases)
- [x] Unit tests for `parseIntFromFloat` (9 cases: integers, negatives, floats, edge cases)
- [x] End-to-end test for `LogVehicleState` with float ocapId `"32.00"`
- [x] End-to-end test for `LogSoldierState` with float ocapId `"30.00"`
- [x] Full test suite passes