### PR TITLE
fix: resolve remaining errcheck and staticcheck lint issues

### DIFF
--- a/cmd/ocap_recorder/cli.go
+++ b/cmd/ocap_recorder/cli.go
@@ -163,7 +163,7 @@ func getOcapRecording(missionIDs []string) (err error) {
 			for _, state := range soldierStatesByID[soldier.ObjectID] {
 				coord, _ := state.Position.Coordinates()
 				position := []any{
-					[]float64{coord.XY.X, coord.XY.Y},
+					[]float64{coord.X, coord.Y},
 					state.Bearing,
 					state.Lifestate,
 					state.InVehicleObjectID,
@@ -241,7 +241,7 @@ func getOcapRecording(missionIDs []string) (err error) {
 					crew = []any{}
 				}
 				position := []any{
-					[]float64{coord.XY.X, coord.XY.Y},
+					[]float64{coord.X, coord.Y},
 					state.Bearing,
 					state.IsAlive,
 					crew,

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -77,7 +77,7 @@ func TestUpload_Success(t *testing.T) {
 
 		file, _, err := r.FormFile("file")
 		require.NoError(t, err)
-		defer func() { _ = file.Close() }()
+		defer func() { assert.NoError(t, file.Close()) }()
 
 		receivedFileContent = make([]byte, 1024)
 		n, _ := file.Read(receivedFileContent)
@@ -126,7 +126,7 @@ func TestUpload_ServerError(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	testFile := tmpDir + "/test.json.gz"
-	_ = writeTestFile(testFile, []byte("content"))
+	require.NoError(t, writeTestFile(testFile, []byte("content")))
 
 	c := New(server.URL, "wrong-secret")
 	err := c.Upload(testFile, core.UploadMetadata{})
@@ -136,7 +136,7 @@ func TestUpload_ServerError(t *testing.T) {
 func TestUpload_ServerDown(t *testing.T) {
 	tmpDir := t.TempDir()
 	testFile := tmpDir + "/test.json.gz"
-	_ = writeTestFile(testFile, []byte("content"))
+	require.NoError(t, writeTestFile(testFile, []byte("content")))
 
 	// Server URL that is unreachable
 	c := New("http://localhost:59999", "secret")

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -77,7 +77,7 @@ func TestUpload_Success(t *testing.T) {
 
 		file, _, err := r.FormFile("file")
 		require.NoError(t, err)
-		defer file.Close()
+		defer func() { _ = file.Close() }()
 
 		receivedFileContent = make([]byte, 1024)
 		n, _ := file.Read(receivedFileContent)

--- a/internal/dispatcher/dispatcher_test.go
+++ b/internal/dispatcher/dispatcher_test.go
@@ -106,9 +106,9 @@ func TestDispatcher_BufferedDropsWhenFull(t *testing.T) {
 	}, Buffered(2))
 
 	// Fill the queue (2 items) + 1 being processed
-	d.Dispatch(Event{Command: ":FULL:"}) // being processed
-	d.Dispatch(Event{Command: ":FULL:"}) // queued
-	d.Dispatch(Event{Command: ":FULL:"}) // queued
+	_, _ = d.Dispatch(Event{Command: ":FULL:"}) // being processed
+	_, _ = d.Dispatch(Event{Command: ":FULL:"}) // queued
+	_, _ = d.Dispatch(Event{Command: ":FULL:"}) // queued
 
 	// This should be dropped
 	_, err := d.Dispatch(Event{Command: ":FULL:"})
@@ -128,14 +128,14 @@ func TestDispatcher_BufferedBlocking(t *testing.T) {
 	}, Buffered(1), Blocking())
 
 	// First event starts processing
-	d.Dispatch(Event{Command: ":BLOCKING:"})
+	_, _ = d.Dispatch(Event{Command: ":BLOCKING:"})
 	// Second event fills the queue
-	d.Dispatch(Event{Command: ":BLOCKING:"})
+	_, _ = d.Dispatch(Event{Command: ":BLOCKING:"})
 
 	// Third event should block (test with timeout)
 	done := make(chan struct{})
 	go func() {
-		d.Dispatch(Event{Command: ":BLOCKING:"})
+		_, _ = d.Dispatch(Event{Command: ":BLOCKING:"})
 		close(done)
 	}()
 
@@ -156,7 +156,7 @@ func TestDispatcher_LoggedHandler(t *testing.T) {
 		return nil, nil
 	}, Logged())
 
-	d.Dispatch(Event{Command: ":LOGGED:", Args: []string{"a", "b"}})
+	_, _ = d.Dispatch(Event{Command: ":LOGGED:", Args: []string{"a", "b"}})
 
 	// Give time for logging
 	time.Sleep(10 * time.Millisecond)
@@ -174,7 +174,7 @@ func TestDispatcher_LoggedHandlerError(t *testing.T) {
 		return nil, fmt.Errorf("test error")
 	}, Logged())
 
-	d.Dispatch(Event{Command: ":ERROR:"})
+	_, _ = d.Dispatch(Event{Command: ":ERROR:"})
 
 	logger.mu.Lock()
 	defer logger.mu.Unlock()
@@ -284,7 +284,7 @@ func TestDispatcher_LoggedArgPreview(t *testing.T) {
 		return nil, nil
 	}, Logged())
 
-	d.Dispatch(Event{Command: ":ARGS:", Args: []string{"620", "350.811", "1", "extra1", "extra2"}})
+	_, _ = d.Dispatch(Event{Command: ":ARGS:", Args: []string{"620", "350.811", "1", "extra1", "extra2"}})
 
 	logger.mu.Lock()
 	defer logger.mu.Unlock()
@@ -353,9 +353,9 @@ func TestDispatcher_GatedHandlerProcessesInOrder(t *testing.T) {
 	}, Buffered(10), Gated(ready))
 
 	// Dispatch in order
-	d.Dispatch(Event{Command: ":ORDERED:", Args: []string{"first"}})
-	d.Dispatch(Event{Command: ":ORDERED:", Args: []string{"second"}})
-	d.Dispatch(Event{Command: ":ORDERED:", Args: []string{"third"}})
+	_, _ = d.Dispatch(Event{Command: ":ORDERED:", Args: []string{"first"}})
+	_, _ = d.Dispatch(Event{Command: ":ORDERED:", Args: []string{"second"}})
+	_, _ = d.Dispatch(Event{Command: ":ORDERED:", Args: []string{"third"}})
 
 	// Open gate
 	close(ready)
@@ -383,12 +383,12 @@ func TestDispatcher_GatedWithBlocking(t *testing.T) {
 	}, Buffered(1), Blocking(), Gated(ready))
 
 	// First event fills buffer
-	d.Dispatch(Event{Command: ":GATED_BLOCKING:"})
+	_, _ = d.Dispatch(Event{Command: ":GATED_BLOCKING:"})
 
 	// Second event should block since buffer is full and gate closed
 	dispatched := make(chan struct{})
 	go func() {
-		d.Dispatch(Event{Command: ":GATED_BLOCKING:"})
+		_, _ = d.Dispatch(Event{Command: ":GATED_BLOCKING:"})
 		close(dispatched)
 	}()
 
@@ -478,7 +478,7 @@ func TestDispatcher_ConcurrentRegisterAndDispatch(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < 200; i++ {
 			d.HasHandler(":EXISTING:")
-			d.Dispatch(Event{Command: ":EXISTING:"})
+			_, _ = d.Dispatch(Event{Command: ":EXISTING:"})
 		}
 	}()
 
@@ -535,7 +535,7 @@ func TestDispatcher_GatedLogsWhenOpened(t *testing.T) {
 		return nil, nil
 	}, Buffered(10), Gated(ready))
 
-	d.Dispatch(Event{Command: ":GATED_LOG:"})
+	_, _ = d.Dispatch(Event{Command: ":GATED_LOG:"})
 	close(ready)
 	wg.Wait()
 

--- a/internal/dispatcher/dispatcher_test.go
+++ b/internal/dispatcher/dispatcher_test.go
@@ -106,12 +106,16 @@ func TestDispatcher_BufferedDropsWhenFull(t *testing.T) {
 	}, Buffered(2))
 
 	// Fill the queue (2 items) + 1 being processed
-	_, _ = d.Dispatch(Event{Command: ":FULL:"}) // being processed
-	_, _ = d.Dispatch(Event{Command: ":FULL:"}) // queued
-	_, _ = d.Dispatch(Event{Command: ":FULL:"}) // queued
+	_, err := d.Dispatch(Event{Command: ":FULL:"}) // being processed
+	require.NoError(t, err)
+	time.Sleep(10 * time.Millisecond) // let goroutine pick up the first event
+	_, err = d.Dispatch(Event{Command: ":FULL:"})  // queued
+	require.NoError(t, err)
+	_, err = d.Dispatch(Event{Command: ":FULL:"}) // queued
+	require.NoError(t, err)
 
 	// This should be dropped
-	_, err := d.Dispatch(Event{Command: ":FULL:"})
+	_, err = d.Dispatch(Event{Command: ":FULL:"})
 
 	assert.Error(t, err)
 
@@ -128,14 +132,17 @@ func TestDispatcher_BufferedBlocking(t *testing.T) {
 	}, Buffered(1), Blocking())
 
 	// First event starts processing
-	_, _ = d.Dispatch(Event{Command: ":BLOCKING:"})
+	_, err := d.Dispatch(Event{Command: ":BLOCKING:"})
+	require.NoError(t, err)
 	// Second event fills the queue
-	_, _ = d.Dispatch(Event{Command: ":BLOCKING:"})
+	_, err = d.Dispatch(Event{Command: ":BLOCKING:"})
+	require.NoError(t, err)
 
 	// Third event should block (test with timeout)
 	done := make(chan struct{})
 	go func() {
-		_, _ = d.Dispatch(Event{Command: ":BLOCKING:"})
+		_, err := d.Dispatch(Event{Command: ":BLOCKING:"})
+		assert.NoError(t, err)
 		close(done)
 	}()
 
@@ -156,7 +163,8 @@ func TestDispatcher_LoggedHandler(t *testing.T) {
 		return nil, nil
 	}, Logged())
 
-	_, _ = d.Dispatch(Event{Command: ":LOGGED:", Args: []string{"a", "b"}})
+	_, err := d.Dispatch(Event{Command: ":LOGGED:", Args: []string{"a", "b"}})
+	require.NoError(t, err)
 
 	// Give time for logging
 	time.Sleep(10 * time.Millisecond)
@@ -174,7 +182,8 @@ func TestDispatcher_LoggedHandlerError(t *testing.T) {
 		return nil, fmt.Errorf("test error")
 	}, Logged())
 
-	_, _ = d.Dispatch(Event{Command: ":ERROR:"})
+	_, err := d.Dispatch(Event{Command: ":ERROR:"})
+	assert.Error(t, err)
 
 	logger.mu.Lock()
 	defer logger.mu.Unlock()
@@ -284,7 +293,8 @@ func TestDispatcher_LoggedArgPreview(t *testing.T) {
 		return nil, nil
 	}, Logged())
 
-	_, _ = d.Dispatch(Event{Command: ":ARGS:", Args: []string{"620", "350.811", "1", "extra1", "extra2"}})
+	_, err := d.Dispatch(Event{Command: ":ARGS:", Args: []string{"620", "350.811", "1", "extra1", "extra2"}})
+	require.NoError(t, err)
 
 	logger.mu.Lock()
 	defer logger.mu.Unlock()
@@ -353,9 +363,12 @@ func TestDispatcher_GatedHandlerProcessesInOrder(t *testing.T) {
 	}, Buffered(10), Gated(ready))
 
 	// Dispatch in order
-	_, _ = d.Dispatch(Event{Command: ":ORDERED:", Args: []string{"first"}})
-	_, _ = d.Dispatch(Event{Command: ":ORDERED:", Args: []string{"second"}})
-	_, _ = d.Dispatch(Event{Command: ":ORDERED:", Args: []string{"third"}})
+	_, err := d.Dispatch(Event{Command: ":ORDERED:", Args: []string{"first"}})
+	require.NoError(t, err)
+	_, err = d.Dispatch(Event{Command: ":ORDERED:", Args: []string{"second"}})
+	require.NoError(t, err)
+	_, err = d.Dispatch(Event{Command: ":ORDERED:", Args: []string{"third"}})
+	require.NoError(t, err)
 
 	// Open gate
 	close(ready)
@@ -383,12 +396,14 @@ func TestDispatcher_GatedWithBlocking(t *testing.T) {
 	}, Buffered(1), Blocking(), Gated(ready))
 
 	// First event fills buffer
-	_, _ = d.Dispatch(Event{Command: ":GATED_BLOCKING:"})
+	_, err := d.Dispatch(Event{Command: ":GATED_BLOCKING:"})
+	require.NoError(t, err)
 
 	// Second event should block since buffer is full and gate closed
 	dispatched := make(chan struct{})
 	go func() {
-		_, _ = d.Dispatch(Event{Command: ":GATED_BLOCKING:"})
+		_, err := d.Dispatch(Event{Command: ":GATED_BLOCKING:"})
+		assert.NoError(t, err)
 		close(dispatched)
 	}()
 
@@ -478,7 +493,8 @@ func TestDispatcher_ConcurrentRegisterAndDispatch(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < 200; i++ {
 			d.HasHandler(":EXISTING:")
-			_, _ = d.Dispatch(Event{Command: ":EXISTING:"})
+			_, err := d.Dispatch(Event{Command: ":EXISTING:"})
+			assert.NoError(t, err)
 		}
 	}()
 
@@ -535,7 +551,8 @@ func TestDispatcher_GatedLogsWhenOpened(t *testing.T) {
 		return nil, nil
 	}, Buffered(10), Gated(ready))
 
-	_, _ = d.Dispatch(Event{Command: ":GATED_LOG:"})
+	_, err := d.Dispatch(Event{Command: ":GATED_LOG:"})
+	require.NoError(t, err)
 	close(ready)
 	wg.Wait()
 

--- a/internal/model/convert/to_gorm_test.go
+++ b/internal/model/convert/to_gorm_test.go
@@ -18,8 +18,8 @@ func TestPosition3DToPoint(t *testing.T) {
 
 	coord, ok := pt.Coordinates()
 	require.True(t, ok)
-	assert.Equal(t, 100.5, coord.XY.X)
-	assert.Equal(t, 200.5, coord.XY.Y)
+	assert.Equal(t, 100.5, coord.X)
+	assert.Equal(t, 200.5, coord.Y)
 	assert.Equal(t, 50.0, coord.Z)
 }
 
@@ -79,7 +79,7 @@ func TestCoreToSoldier(t *testing.T) {
 	assert.Equal(t, "12345678", result.PlayerUID)
 
 	var params []any
-	json.Unmarshal(result.SquadParams, &params)
+	require.NoError(t, json.Unmarshal(result.SquadParams, &params))
 	assert.Equal(t, []any{"test", "params"}, params)
 }
 
@@ -162,8 +162,8 @@ func TestCoreToSoldierState(t *testing.T) {
 
 	coord, ok := result.Position.Coordinates()
 	require.True(t, ok)
-	assert.Equal(t, 1000.0, coord.XY.X)
-	assert.Equal(t, 2000.0, coord.XY.Y)
+	assert.Equal(t, 1000.0, coord.X)
+	assert.Equal(t, 2000.0, coord.Y)
 	assert.Equal(t, 10.0, coord.Z)
 }
 
@@ -296,7 +296,7 @@ func TestCoreToGeneralEvent(t *testing.T) {
 	assert.Equal(t, "Test message", result.Message)
 
 	var extra map[string]any
-	json.Unmarshal(result.ExtraData, &extra)
+	require.NoError(t, json.Unmarshal(result.ExtraData, &extra))
 	assert.Equal(t, "value", extra["key"])
 }
 
@@ -631,8 +631,8 @@ func TestCoreToWorld(t *testing.T) {
 
 	coord, ok := result.Location.Coordinates()
 	require.True(t, ok)
-	assert.Equal(t, 100.0, coord.XY.X)
-	assert.Equal(t, 200.0, coord.XY.Y)
+	assert.Equal(t, 100.0, coord.X)
+	assert.Equal(t, 200.0, coord.Y)
 }
 
 // Compile-time interface checks for CoreToX functions

--- a/internal/storage/memory/export_test.go
+++ b/internal/storage/memory/export_test.go
@@ -211,11 +211,11 @@ func TestExportGzipJSON(t *testing.T) {
 
 	f, err := os.Open(matches[0])
 	require.NoError(t, err)
-	defer func() { _ = f.Close() }()
+	defer func() { require.NoError(t, f.Close()) }()
 
 	gzReader, err := gzip.NewReader(f)
 	require.NoError(t, err)
-	defer func() { _ = gzReader.Close() }()
+	defer func() { require.NoError(t, gzReader.Close()) }()
 
 	var export v1.Export
 	require.NoError(t, json.NewDecoder(gzReader).Decode(&export))

--- a/internal/storage/memory/export_test.go
+++ b/internal/storage/memory/export_test.go
@@ -211,11 +211,11 @@ func TestExportGzipJSON(t *testing.T) {
 
 	f, err := os.Open(matches[0])
 	require.NoError(t, err)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	gzReader, err := gzip.NewReader(f)
 	require.NoError(t, err)
-	defer gzReader.Close()
+	defer func() { _ = gzReader.Close() }()
 
 	var export v1.Export
 	require.NoError(t, json.NewDecoder(gzReader).Decode(&export))
@@ -843,10 +843,10 @@ func TestMarkerColorHashPrefixIsStripped(t *testing.T) {
 	// Find markers and verify color format
 	var hexMarker, namedMarker []any
 	for _, m := range export.Markers {
-		text := m[1].(string)
-		if text == "Hex Color" {
+		switch m[1].(string) {
+		case "Hex Color":
 			hexMarker = m
-		} else if text == "Named Color" {
+		case "Named Color":
 			namedMarker = m
 		}
 	}
@@ -887,10 +887,10 @@ func TestMarkerOwnerIDExport(t *testing.T) {
 	// Find and verify each marker's playerId (index 4 in the array)
 	var systemMarker, playerMarker []any
 	for _, m := range export.Markers {
-		text := m[1].(string)
-		if text == "System" {
+		switch m[1].(string) {
+		case "System":
 			systemMarker = m
-		} else if text == "Player Drawn" {
+		case "Player Drawn":
 			playerMarker = m
 		}
 	}
@@ -930,10 +930,10 @@ func TestMarkerSizeAndBrushExport(t *testing.T) {
 
 	var customMarker, defaultMarker []any
 	for _, m := range export.Markers {
-		text := m[1].(string)
-		if text == "Custom" {
+		switch m[1].(string) {
+		case "Custom":
 			customMarker = m
-		} else if text == "Default" {
+		case "Default":
 			defaultMarker = m
 		}
 	}

--- a/internal/storage/memory/memory_test.go
+++ b/internal/storage/memory/memory_test.go
@@ -234,13 +234,13 @@ func TestDeleteMarker(t *testing.T) {
 	_ = b.AddMarker(m)
 
 	// Delete marker at frame 100
-	b.DeleteMarker("grenade_1", 100)
+	require.NoError(t, b.DeleteMarker("grenade_1", 100))
 
 	record := b.markers["grenade_1"]
 	assert.Equal(t, 100, record.Marker.EndFrame)
 
 	// Deleting non-existent marker should not panic
-	b.DeleteMarker("nonexistent", 50)
+	require.NoError(t, b.DeleteMarker("nonexistent", 50))
 }
 
 func TestRecordFiredEvent(t *testing.T) {

--- a/internal/storage/postgres/postgres.go
+++ b/internal/storage/postgres/postgres.go
@@ -130,7 +130,7 @@ func (b *Backend) setupDB() error {
 		}
 	}
 
-	if db.Dialector.Name() == "postgres" {
+	if db.Name() == "postgres" {
 		if err := db.Exec(`CREATE Extension IF NOT EXISTS postgis;`).Error; err != nil {
 			return fmt.Errorf("failed to create PostGIS Extension: %w", err)
 		}

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -62,8 +62,8 @@ func TestInitClose(t *testing.T) {
 
 func TestAddSoldier_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
 	soldier := &core.Soldier{
 		ID:       42,
@@ -78,8 +78,8 @@ func TestAddSoldier_QueuesToInternalQueue(t *testing.T) {
 
 func TestAddVehicle_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
 	vehicle := &core.Vehicle{
 		ID:          10,
@@ -94,8 +94,8 @@ func TestAddVehicle_QueuesToInternalQueue(t *testing.T) {
 
 func TestAddMarker_NoDB_NoError(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
 	marker := &core.Marker{
 		MarkerName: "TestMarker",
@@ -109,8 +109,8 @@ func TestAddMarker_NoDB_NoError(t *testing.T) {
 
 func TestRecordSoldierState_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
 	state := &core.SoldierState{
 		SoldierID:    42,
@@ -125,8 +125,8 @@ func TestRecordSoldierState_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordVehicleState_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
 	state := &core.VehicleState{
 		VehicleID:    10,
@@ -140,8 +140,8 @@ func TestRecordVehicleState_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordMarkerState_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
 	state := &core.MarkerState{
 		MarkerID:     5,
@@ -155,8 +155,8 @@ func TestRecordMarkerState_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordProjectileEvent_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
 	event := &core.ProjectileEvent{
 		FirerObjectID: 1,
@@ -174,8 +174,8 @@ func TestRecordProjectileEvent_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordGeneralEvent_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
 	event := &core.GeneralEvent{
 		Name:    "connected",
@@ -189,8 +189,8 @@ func TestRecordGeneralEvent_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordKillEvent_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
 	victimID := uint(5)
 	event := &core.KillEvent{
@@ -205,8 +205,8 @@ func TestRecordKillEvent_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordChatEvent_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
 	event := &core.ChatEvent{
 		Channel: "Global",
@@ -220,8 +220,8 @@ func TestRecordChatEvent_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordRadioEvent_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
 	event := &core.RadioEvent{
 		Radio:     "AN/PRC-152",
@@ -235,8 +235,8 @@ func TestRecordRadioEvent_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordServerFpsEvent_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
 	event := &core.ServerFpsEvent{
 		FpsAverage: 50.0,
@@ -250,8 +250,8 @@ func TestRecordServerFpsEvent_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordAce3DeathEvent_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
 	event := &core.Ace3DeathEvent{
 		SoldierID: 5,
@@ -265,8 +265,8 @@ func TestRecordAce3DeathEvent_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordAce3UnconsciousEvent_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
 	event := &core.Ace3UnconsciousEvent{
 		SoldierID:     5,
@@ -280,8 +280,8 @@ func TestRecordAce3UnconsciousEvent_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordTimeState_IsNoOp(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
 	ts := &core.TimeState{
 		CaptureFrame: 100,
@@ -294,8 +294,8 @@ func TestRecordTimeState_IsNoOp(t *testing.T) {
 
 func TestRecordFiredEvent_IsNoOp(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
 	err := b.RecordFiredEvent(&core.FiredEvent{})
 	require.NoError(t, err)
@@ -303,8 +303,8 @@ func TestRecordFiredEvent_IsNoOp(t *testing.T) {
 
 func TestRecordHitEvent_IsNoOp(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
 	err := b.RecordHitEvent(&core.HitEvent{})
 	require.NoError(t, err)
@@ -312,8 +312,8 @@ func TestRecordHitEvent_IsNoOp(t *testing.T) {
 
 func TestStartMission_NoDB_NoOp(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
 	err := b.StartMission(&core.Mission{}, &core.World{})
 	require.NoError(t, err)
@@ -328,8 +328,8 @@ func TestStartMission_WithDB(t *testing.T) {
 		MarkerCache: cache.NewMarkerCache(),
 		LogManager:  logging.NewSlogManager(),
 	})
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	require.NoError(t, b.Init())
+	defer func() { require.NoError(t, b.Close()) }()
 
 	mission := &core.Mission{
 		MissionName: "Test Mission",
@@ -381,8 +381,8 @@ func TestStartMission_WithDB(t *testing.T) {
 
 func TestSetMissionID(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
 	assert.Equal(t, uint64(0), b.missionID.Load())
 	b.SetMissionID(42)
@@ -409,7 +409,7 @@ func TestSetupDB_CreatesOcapInfo(t *testing.T) {
 	// Init calls setupDB
 	err = b.Init()
 	require.NoError(t, err)
-	defer func() { _ = b.Close() }()
+	defer func() { require.NoError(t, b.Close()) }()
 
 	var info model.OcapInfo
 	require.NoError(t, rawDB.First(&info).Error)
@@ -421,8 +421,8 @@ func TestSetupDB_CreatesOcapInfo(t *testing.T) {
 
 func TestEndMission_IsNoOp(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
 	err := b.EndMission()
 	require.NoError(t, err)
@@ -430,13 +430,13 @@ func TestEndMission_IsNoOp(t *testing.T) {
 
 func TestDeleteMarker_PushesAlphaZeroState(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
 	// Pre-populate marker cache
 	b.deps.MarkerCache.Set("TestMarker", 42)
 
-	_ = b.DeleteMarker("TestMarker", 500)
+	require.NoError(t, b.DeleteMarker("TestMarker", 500))
 
 	assert.Equal(t, 1, b.queues.MarkerStates.Len())
 	items := b.queues.MarkerStates.GetAndEmpty()
@@ -448,10 +448,10 @@ func TestDeleteMarker_PushesAlphaZeroState(t *testing.T) {
 
 func TestDeleteMarker_UnknownMarker_NoOp(t *testing.T) {
 	b := newTestBackend()
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
 
-	_ = b.DeleteMarker("NonExistent", 500)
+	require.NoError(t, b.DeleteMarker("NonExistent", 500))
 
 	assert.Equal(t, 0, b.queues.MarkerStates.Len())
 }
@@ -543,7 +543,7 @@ func TestWriteQueue_OnSuccessCallback(t *testing.T) {
 func TestWriteQueue_FailureRequeues(t *testing.T) {
 	db := newTestDB(t)
 	// Drop the table so the insert fails
-	_ = db.Migrator().DropTable(&model.Soldier{})
+	require.NoError(t, db.Migrator().DropTable(&model.Soldier{}))
 
 	q := queue.New[model.Soldier]()
 	q.Push(model.Soldier{ObjectID: 1, MissionID: 1, UnitName: "Alpha", JoinTime: time.Now()})
@@ -570,8 +570,8 @@ func TestAddMarker_WithDB(t *testing.T) {
 		LogManager:  logging.NewSlogManager(),
 	})
 	b.missionID.Store(1)
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	require.NoError(t, b.Init())
+	defer func() { require.NoError(t, b.Close()) }()
 
 	marker := &core.Marker{
 		MarkerName: "TestMarker",
@@ -601,22 +601,22 @@ func TestStartDBWriters_DrainsQueues(t *testing.T) {
 		LogManager:  logging.NewSlogManager(),
 	})
 	b.missionID.Store(1)
-	_ = b.Init()
-	defer func() { _ = b.Close() }()
+	require.NoError(t, b.Init())
+	defer func() { require.NoError(t, b.Close()) }()
 
 	// Push items via the public API (which queues GORM models internally)
-	_ = b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Alpha", Side: "WEST"})
-	_ = b.AddVehicle(&core.Vehicle{ID: 2, ClassName: "Humvee"})
-	_ = b.RecordSoldierState(&core.SoldierState{SoldierID: 1})
-	_ = b.RecordVehicleState(&core.VehicleState{VehicleID: 2})
-	_ = b.RecordProjectileEvent(&core.ProjectileEvent{FirerObjectID: 1, CaptureFrame: 1})
-	_ = b.RecordGeneralEvent(&core.GeneralEvent{Name: "connected", Message: "Player1"})
-	_ = b.RecordKillEvent(&core.KillEvent{CaptureFrame: 1})
-	_ = b.RecordChatEvent(&core.ChatEvent{Message: "hello", CaptureFrame: 1})
-	_ = b.RecordRadioEvent(&core.RadioEvent{CaptureFrame: 1})
-	_ = b.RecordServerFpsEvent(&core.ServerFpsEvent{FpsAverage: 50, FpsMin: 30, CaptureFrame: 1})
-	_ = b.RecordAce3DeathEvent(&core.Ace3DeathEvent{SoldierID: 1, CaptureFrame: 1})
-	_ = b.RecordAce3UnconsciousEvent(&core.Ace3UnconsciousEvent{SoldierID: 1, CaptureFrame: 1})
+	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Alpha", Side: "WEST"}))
+	require.NoError(t, b.AddVehicle(&core.Vehicle{ID: 2, ClassName: "Humvee"}))
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{SoldierID: 1}))
+	require.NoError(t, b.RecordVehicleState(&core.VehicleState{VehicleID: 2}))
+	require.NoError(t, b.RecordProjectileEvent(&core.ProjectileEvent{FirerObjectID: 1, CaptureFrame: 1}))
+	require.NoError(t, b.RecordGeneralEvent(&core.GeneralEvent{Name: "connected", Message: "Player1"}))
+	require.NoError(t, b.RecordKillEvent(&core.KillEvent{CaptureFrame: 1}))
+	require.NoError(t, b.RecordChatEvent(&core.ChatEvent{Message: "hello", CaptureFrame: 1}))
+	require.NoError(t, b.RecordRadioEvent(&core.RadioEvent{CaptureFrame: 1}))
+	require.NoError(t, b.RecordServerFpsEvent(&core.ServerFpsEvent{FpsAverage: 50, FpsMin: 30, CaptureFrame: 1}))
+	require.NoError(t, b.RecordAce3DeathEvent(&core.Ace3DeathEvent{SoldierID: 1, CaptureFrame: 1}))
+	require.NoError(t, b.RecordAce3UnconsciousEvent(&core.Ace3UnconsciousEvent{SoldierID: 1, CaptureFrame: 1}))
 
 	// Wait for the background writer to drain (it runs on a 2s loop, so wait up to 5s)
 	require.Eventually(t, func() bool {

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -62,8 +62,8 @@ func TestInitClose(t *testing.T) {
 
 func TestAddSoldier_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	soldier := &core.Soldier{
 		ID:       42,
@@ -78,8 +78,8 @@ func TestAddSoldier_QueuesToInternalQueue(t *testing.T) {
 
 func TestAddVehicle_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	vehicle := &core.Vehicle{
 		ID:          10,
@@ -94,8 +94,8 @@ func TestAddVehicle_QueuesToInternalQueue(t *testing.T) {
 
 func TestAddMarker_NoDB_NoError(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	marker := &core.Marker{
 		MarkerName: "TestMarker",
@@ -109,8 +109,8 @@ func TestAddMarker_NoDB_NoError(t *testing.T) {
 
 func TestRecordSoldierState_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	state := &core.SoldierState{
 		SoldierID:    42,
@@ -125,8 +125,8 @@ func TestRecordSoldierState_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordVehicleState_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	state := &core.VehicleState{
 		VehicleID:    10,
@@ -140,8 +140,8 @@ func TestRecordVehicleState_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordMarkerState_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	state := &core.MarkerState{
 		MarkerID:     5,
@@ -155,8 +155,8 @@ func TestRecordMarkerState_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordProjectileEvent_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	event := &core.ProjectileEvent{
 		FirerObjectID: 1,
@@ -174,8 +174,8 @@ func TestRecordProjectileEvent_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordGeneralEvent_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	event := &core.GeneralEvent{
 		Name:    "connected",
@@ -189,8 +189,8 @@ func TestRecordGeneralEvent_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordKillEvent_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	victimID := uint(5)
 	event := &core.KillEvent{
@@ -205,8 +205,8 @@ func TestRecordKillEvent_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordChatEvent_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	event := &core.ChatEvent{
 		Channel: "Global",
@@ -220,8 +220,8 @@ func TestRecordChatEvent_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordRadioEvent_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	event := &core.RadioEvent{
 		Radio:     "AN/PRC-152",
@@ -235,8 +235,8 @@ func TestRecordRadioEvent_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordServerFpsEvent_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	event := &core.ServerFpsEvent{
 		FpsAverage: 50.0,
@@ -250,8 +250,8 @@ func TestRecordServerFpsEvent_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordAce3DeathEvent_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	event := &core.Ace3DeathEvent{
 		SoldierID: 5,
@@ -265,8 +265,8 @@ func TestRecordAce3DeathEvent_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordAce3UnconsciousEvent_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	event := &core.Ace3UnconsciousEvent{
 		SoldierID:     5,
@@ -280,8 +280,8 @@ func TestRecordAce3UnconsciousEvent_QueuesToInternalQueue(t *testing.T) {
 
 func TestRecordTimeState_IsNoOp(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	ts := &core.TimeState{
 		CaptureFrame: 100,
@@ -294,8 +294,8 @@ func TestRecordTimeState_IsNoOp(t *testing.T) {
 
 func TestRecordFiredEvent_IsNoOp(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	err := b.RecordFiredEvent(&core.FiredEvent{})
 	require.NoError(t, err)
@@ -303,8 +303,8 @@ func TestRecordFiredEvent_IsNoOp(t *testing.T) {
 
 func TestRecordHitEvent_IsNoOp(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	err := b.RecordHitEvent(&core.HitEvent{})
 	require.NoError(t, err)
@@ -312,8 +312,8 @@ func TestRecordHitEvent_IsNoOp(t *testing.T) {
 
 func TestStartMission_NoDB_NoOp(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	err := b.StartMission(&core.Mission{}, &core.World{})
 	require.NoError(t, err)
@@ -328,8 +328,8 @@ func TestStartMission_WithDB(t *testing.T) {
 		MarkerCache: cache.NewMarkerCache(),
 		LogManager:  logging.NewSlogManager(),
 	})
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	mission := &core.Mission{
 		MissionName: "Test Mission",
@@ -381,8 +381,8 @@ func TestStartMission_WithDB(t *testing.T) {
 
 func TestSetMissionID(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	assert.Equal(t, uint64(0), b.missionID.Load())
 	b.SetMissionID(42)
@@ -409,7 +409,7 @@ func TestSetupDB_CreatesOcapInfo(t *testing.T) {
 	// Init calls setupDB
 	err = b.Init()
 	require.NoError(t, err)
-	defer b.Close()
+	defer func() { _ = b.Close() }()
 
 	var info model.OcapInfo
 	require.NoError(t, rawDB.First(&info).Error)
@@ -421,8 +421,8 @@ func TestSetupDB_CreatesOcapInfo(t *testing.T) {
 
 func TestEndMission_IsNoOp(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	err := b.EndMission()
 	require.NoError(t, err)
@@ -430,13 +430,13 @@ func TestEndMission_IsNoOp(t *testing.T) {
 
 func TestDeleteMarker_PushesAlphaZeroState(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	// Pre-populate marker cache
 	b.deps.MarkerCache.Set("TestMarker", 42)
 
-	b.DeleteMarker("TestMarker", 500)
+	_ = b.DeleteMarker("TestMarker", 500)
 
 	assert.Equal(t, 1, b.queues.MarkerStates.Len())
 	items := b.queues.MarkerStates.GetAndEmpty()
@@ -448,10 +448,10 @@ func TestDeleteMarker_PushesAlphaZeroState(t *testing.T) {
 
 func TestDeleteMarker_UnknownMarker_NoOp(t *testing.T) {
 	b := newTestBackend()
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
-	b.DeleteMarker("NonExistent", 500)
+	_ = b.DeleteMarker("NonExistent", 500)
 
 	assert.Equal(t, 0, b.queues.MarkerStates.Len())
 }
@@ -543,7 +543,7 @@ func TestWriteQueue_OnSuccessCallback(t *testing.T) {
 func TestWriteQueue_FailureRequeues(t *testing.T) {
 	db := newTestDB(t)
 	// Drop the table so the insert fails
-	db.Migrator().DropTable(&model.Soldier{})
+	_ = db.Migrator().DropTable(&model.Soldier{})
 
 	q := queue.New[model.Soldier]()
 	q.Push(model.Soldier{ObjectID: 1, MissionID: 1, UnitName: "Alpha", JoinTime: time.Now()})
@@ -570,8 +570,8 @@ func TestAddMarker_WithDB(t *testing.T) {
 		LogManager:  logging.NewSlogManager(),
 	})
 	b.missionID.Store(1)
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	marker := &core.Marker{
 		MarkerName: "TestMarker",
@@ -601,22 +601,22 @@ func TestStartDBWriters_DrainsQueues(t *testing.T) {
 		LogManager:  logging.NewSlogManager(),
 	})
 	b.missionID.Store(1)
-	b.Init()
-	defer b.Close()
+	_ = b.Init()
+	defer func() { _ = b.Close() }()
 
 	// Push items via the public API (which queues GORM models internally)
-	b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Alpha", Side: "WEST"})
-	b.AddVehicle(&core.Vehicle{ID: 2, ClassName: "Humvee"})
-	b.RecordSoldierState(&core.SoldierState{SoldierID: 1})
-	b.RecordVehicleState(&core.VehicleState{VehicleID: 2})
-	b.RecordProjectileEvent(&core.ProjectileEvent{FirerObjectID: 1, CaptureFrame: 1})
-	b.RecordGeneralEvent(&core.GeneralEvent{Name: "connected", Message: "Player1"})
-	b.RecordKillEvent(&core.KillEvent{CaptureFrame: 1})
-	b.RecordChatEvent(&core.ChatEvent{Message: "hello", CaptureFrame: 1})
-	b.RecordRadioEvent(&core.RadioEvent{CaptureFrame: 1})
-	b.RecordServerFpsEvent(&core.ServerFpsEvent{FpsAverage: 50, FpsMin: 30, CaptureFrame: 1})
-	b.RecordAce3DeathEvent(&core.Ace3DeathEvent{SoldierID: 1, CaptureFrame: 1})
-	b.RecordAce3UnconsciousEvent(&core.Ace3UnconsciousEvent{SoldierID: 1, CaptureFrame: 1})
+	_ = b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Alpha", Side: "WEST"})
+	_ = b.AddVehicle(&core.Vehicle{ID: 2, ClassName: "Humvee"})
+	_ = b.RecordSoldierState(&core.SoldierState{SoldierID: 1})
+	_ = b.RecordVehicleState(&core.VehicleState{VehicleID: 2})
+	_ = b.RecordProjectileEvent(&core.ProjectileEvent{FirerObjectID: 1, CaptureFrame: 1})
+	_ = b.RecordGeneralEvent(&core.GeneralEvent{Name: "connected", Message: "Player1"})
+	_ = b.RecordKillEvent(&core.KillEvent{CaptureFrame: 1})
+	_ = b.RecordChatEvent(&core.ChatEvent{Message: "hello", CaptureFrame: 1})
+	_ = b.RecordRadioEvent(&core.RadioEvent{CaptureFrame: 1})
+	_ = b.RecordServerFpsEvent(&core.ServerFpsEvent{FpsAverage: 50, FpsMin: 30, CaptureFrame: 1})
+	_ = b.RecordAce3DeathEvent(&core.Ace3DeathEvent{SoldierID: 1, CaptureFrame: 1})
+	_ = b.RecordAce3UnconsciousEvent(&core.Ace3UnconsciousEvent{SoldierID: 1, CaptureFrame: 1})
 
 	// Wait for the background writer to drain (it runs on a 2s loop, so wait up to 5s)
 	require.Eventually(t, func() bool {

--- a/pkg/a3interface/extensioncallback.go
+++ b/pkg/a3interface/extensioncallback.go
@@ -45,12 +45,12 @@ func WriteArmaCallback(
 	// preprocess data with escape characters
 	for i, v := range data {
 		// replace double quotes with 2 double quotes
-		escapedData := strings.Replace(v, `"`, `""`, -1)
+		escapedData := strings.ReplaceAll(v, `"`, `""`)
 		// do the same for single quotes
-		escapedData = strings.Replace(escapedData, `'`, `''`, -1)
+		escapedData = strings.ReplaceAll(escapedData, `'`, `''`)
 		// replace brackets w parentheses
-		escapedData = strings.Replace(escapedData, `[`, `(`, -1)
-		escapedData = strings.Replace(escapedData, `]`, `)`, -1)
+		escapedData = strings.ReplaceAll(escapedData, `[`, `(`)
+		escapedData = strings.ReplaceAll(escapedData, `]`, `)`)
 
 		data[i] = fmt.Sprintf(`"%s"`, escapedData)
 	}


### PR DESCRIPTION
## Summary

- Resolves all 40 remaining `golangci-lint` findings (30 errcheck + 10 staticcheck)
- `golangci-lint run ./...` now reports **0 issues**

**errcheck (30 — all in test files):**
- Explicitly discard or check error returns from `Init`, `Close`, `Dispatch`, `DeleteMarker`, `json.Unmarshal`, `DropTable`, and `Add*`/`Record*` methods

**staticcheck (10 — production + test code):**
- **QF1008**: Remove redundant embedded field selectors (`coord.XY.X` → `coord.X`, `db.Dialector.Name()` → `db.Name()`)
- **QF1004**: `strings.Replace(..., -1)` → `strings.ReplaceAll(...)` in `extensioncallback.go`
- **QF1003**: if-else chains → tagged switch in `export_test.go`

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` — all 22 packages pass
- [x] `golangci-lint run ./...` — 0 issues