### PR TITLE
feat: add WebSocket streaming storage backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ docker run --rm -v ${PWD}:/go/work -w /go/work golang:1.24-bullseye go build -bu
 /internal/dispatcher/        - Event routing with async buffering
 /internal/parser/            - Command parsing (args → core types)
 /internal/worker/            - Handler registration and DB writer loop
-/internal/storage/           - Storage backends (memory, postgres, sqlite)
+/internal/storage/           - Storage backends (memory, postgres, sqlite, websocket)
 /internal/model/             - GORM database models + converters
 /internal/queue/             - Thread-safe queue implementations
 /internal/cache/             - Entity caching layer
@@ -92,7 +92,7 @@ File: `ocap_recorder.cfg.json` (placed alongside DLL)
   "logsDir": "./ocaplogs",
   "defaultTag": "TvT",
   "api": {
-    "serverUrl": "http://127.0.0.1:5000",
+    "serverUrl": "http://127.0.0.1:5000/api",
     "apiKey": "secret"
   },
   "db": {
@@ -115,7 +115,7 @@ File: `ocap_recorder.cfg.json` (placed alongside DLL)
 }
 ```
 
-Storage types: `"memory"` (JSON export), `"postgres"` (PostgreSQL), `"sqlite"` (in-memory with periodic disk dump).
+Storage types: `"memory"` (JSON export), `"postgres"` (PostgreSQL), `"sqlite"` (in-memory with periodic disk dump), `"websocket"` (real-time streaming to OCAP2 web server).
 
 ## Key Dependencies
 
@@ -123,3 +123,4 @@ Storage types: `"memory"` (JSON export), `"postgres"` (PostgreSQL), `"sqlite"` (
 - **peterstace/simplefeatures** - Geometry/GIS support
 - **log/slog** - Structured logging (stdlib)
 - **spf13/viper** - Configuration management
+- **gorilla/websocket** - WebSocket client for streaming storage backend

--- a/cmd/ocap_recorder/storage.go
+++ b/cmd/ocap_recorder/storage.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/OCAP2/extension/v5/internal/config"
 	"github.com/OCAP2/extension/v5/internal/storage"
-	pgstorage "github.com/OCAP2/extension/v5/internal/storage/postgres"
 	"github.com/OCAP2/extension/v5/internal/storage/memory"
+	pgstorage "github.com/OCAP2/extension/v5/internal/storage/postgres"
 	sqlitestorage "github.com/OCAP2/extension/v5/internal/storage/sqlite"
+	wsstorage "github.com/OCAP2/extension/v5/internal/storage/websocket"
 	"github.com/OCAP2/extension/v5/internal/worker"
 	"github.com/OCAP2/extension/v5/pkg/a3interface"
 )
@@ -71,6 +72,13 @@ func createStorageBackend(storageCfg config.StorageConfig) (storage.Backend, err
 		}
 		Logger.Info("SQLite storage backend initialized")
 		return backend, nil
+
+	case "websocket":
+		Logger.Info("WebSocket storage backend initialized")
+		return wsstorage.New(wsstorage.Config{
+			URL:    storageCfg.WebSocket.URL,
+			Secret: storageCfg.WebSocket.Secret,
+		}), nil
 
 	default:
 		Logger.Info("Memory storage backend initialized")

--- a/cmd/ocap_recorder/storage.go
+++ b/cmd/ocap_recorder/storage.go
@@ -76,7 +76,7 @@ func createStorageBackend(storageCfg config.StorageConfig) (storage.Backend, err
 		return backend, nil
 
 	case "websocket":
-		wsURL := httpToWS(viper.GetString("api.serverUrl")) + "/api/v1/stream"
+		wsURL := httpToWS(viper.GetString("api.serverUrl")) + "/api"
 		secret := viper.GetString("api.apiKey")
 		Logger.Info("WebSocket storage backend initialized", "url", wsURL)
 		return wsstorage.New(wsstorage.Config{

--- a/cmd/ocap_recorder/storage.go
+++ b/cmd/ocap_recorder/storage.go
@@ -76,7 +76,7 @@ func createStorageBackend(storageCfg config.StorageConfig) (storage.Backend, err
 		return backend, nil
 
 	case "websocket":
-		wsURL := httpToWS(viper.GetString("api.serverUrl")) + "/api"
+		wsURL := httpToWS(viper.GetString("api.serverUrl")) + "/v1/stream"
 		secret := viper.GetString("api.apiKey")
 		Logger.Info("WebSocket storage backend initialized", "url", wsURL)
 		return wsstorage.New(wsstorage.Config{

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	github.com/glebarez/sqlite v1.11.0
+	github.com/gorilla/websocket v1.5.3
 	github.com/peterstace/simplefeatures v0.57.0
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26 h1:Xim43kblpZXfIBQsbu
 github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26/go.mod h1:dDKJzRmX4S37WGHujM7tX//fmj1uioxKzKxz3lo4HJo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 h1:X+2YciYSxvMQK0UZ7sg45ZVabVZBeBuvMkmuI2V3Fak=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7/go.mod h1:lW34nIZuQ8UDPdkon5fmfp2l3+ZkQ2me/+oecHYLOII=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -83,7 +83,7 @@ func (c *Client) Upload(filePath string, meta core.UploadMetadata) error {
 		errCh <- nil
 	}()
 
-	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/api/v1/operations/add", pr)
+	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/v1/operations/add", pr)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -62,7 +62,7 @@ func TestUpload_Success(t *testing.T) {
 	var receivedFileContent []byte
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/api/v1/operations/add", r.URL.Path)
+		assert.Equal(t, "/v1/operations/add", r.URL.Path)
 		assert.Equal(t, http.MethodPost, r.Method)
 
 		err := r.ParseMultipartForm(10 << 20)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,7 @@ func Load(configDir string) error {
 	viper.SetDefault("defaultTag", "Op")
 	viper.SetDefault("logsDir", "./ocaplogs")
 
-	viper.SetDefault("api.serverUrl", "http://localhost:5000")
+	viper.SetDefault("api.serverUrl", "http://localhost:5000/api")
 	viper.SetDefault("api.apiKey", "")
 
 	viper.SetDefault("db.host", "localhost")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,12 @@ type SQLiteConfig struct {
 	DumpInterval time.Duration `json:"dumpInterval" mapstructure:"dumpInterval"`
 }
 
+// WebSocketConfig holds WebSocket storage backend settings
+type WebSocketConfig struct {
+	URL    string `json:"url" mapstructure:"url"`
+	Secret string `json:"secret" mapstructure:"secret"`
+}
+
 // Load reads configuration from JSON file and sets default values.
 // configDir is the directory containing the config file.
 func Load(configDir string) error {
@@ -47,6 +53,8 @@ func Load(configDir string) error {
 	viper.SetDefault("storage.memory.outputDir", "./recordings")
 	viper.SetDefault("storage.memory.compressOutput", true)
 	viper.SetDefault("storage.sqlite.dumpInterval", "3m")
+	viper.SetDefault("storage.websocket.url", "ws://127.0.0.1:5000/api/v1/stream")
+	viper.SetDefault("storage.websocket.secret", "")
 
 	// OpenTelemetry defaults
 	viper.SetDefault("otel.enabled", false)
@@ -84,9 +92,10 @@ func GetBool(key string) bool {
 
 // StorageConfig holds storage backend configuration
 type StorageConfig struct {
-	Type   string       `json:"type" mapstructure:"type"`
-	Memory MemoryConfig `json:"memory" mapstructure:"memory"`
-	SQLite SQLiteConfig `json:"sqlite" mapstructure:"sqlite"`
+	Type      string          `json:"type" mapstructure:"type"`
+	Memory    MemoryConfig    `json:"memory" mapstructure:"memory"`
+	SQLite    SQLiteConfig    `json:"sqlite" mapstructure:"sqlite"`
+	WebSocket WebSocketConfig `json:"websocket" mapstructure:"websocket"`
 }
 
 // GetStorageConfig returns the storage backend configuration

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,12 +18,6 @@ type SQLiteConfig struct {
 	DumpInterval time.Duration `json:"dumpInterval" mapstructure:"dumpInterval"`
 }
 
-// WebSocketConfig holds WebSocket storage backend settings
-type WebSocketConfig struct {
-	URL    string `json:"url" mapstructure:"url"`
-	Secret string `json:"secret" mapstructure:"secret"`
-}
-
 // Load reads configuration from JSON file and sets default values.
 // configDir is the directory containing the config file.
 func Load(configDir string) error {
@@ -53,8 +47,6 @@ func Load(configDir string) error {
 	viper.SetDefault("storage.memory.outputDir", "./recordings")
 	viper.SetDefault("storage.memory.compressOutput", true)
 	viper.SetDefault("storage.sqlite.dumpInterval", "3m")
-	viper.SetDefault("storage.websocket.url", "ws://127.0.0.1:5000/api/v1/stream")
-	viper.SetDefault("storage.websocket.secret", "")
 
 	// OpenTelemetry defaults
 	viper.SetDefault("otel.enabled", false)
@@ -92,10 +84,9 @@ func GetBool(key string) bool {
 
 // StorageConfig holds storage backend configuration
 type StorageConfig struct {
-	Type      string          `json:"type" mapstructure:"type"`
-	Memory    MemoryConfig    `json:"memory" mapstructure:"memory"`
-	SQLite    SQLiteConfig    `json:"sqlite" mapstructure:"sqlite"`
-	WebSocket WebSocketConfig `json:"websocket" mapstructure:"websocket"`
+	Type   string       `json:"type" mapstructure:"type"`
+	Memory MemoryConfig `json:"memory" mapstructure:"memory"`
+	SQLite SQLiteConfig `json:"sqlite" mapstructure:"sqlite"`
 }
 
 // GetStorageConfig returns the storage backend configuration

--- a/internal/storage/websocket/connection.go
+++ b/internal/storage/websocket/connection.go
@@ -1,0 +1,273 @@
+package websocket
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"sync"
+	"time"
+
+	ws "github.com/gorilla/websocket"
+)
+
+const (
+	sendChSize   = 10_000
+	ackChSize    = 16
+	maxReconnect = 10
+	maxBackoff   = 30 * time.Second
+	writeWait    = 10 * time.Second
+	ackTimeout   = 10 * time.Second
+)
+
+// connection manages a WebSocket connection with a single write goroutine.
+type connection struct {
+	mu     sync.Mutex
+	conn   *ws.Conn
+	sendCh chan []byte
+	ackCh  chan AckMessage
+	done   chan struct{} // closed on shutdown
+	closed bool
+
+	wsURL  string
+	secret string
+
+	// Cached start_mission message for reconnect replay.
+	cachedStartMsg []byte
+
+	logger *slog.Logger
+}
+
+func newConnection(logger *slog.Logger) *connection {
+	return &connection{
+		sendCh: make(chan []byte, sendChSize),
+		ackCh:  make(chan AckMessage, ackChSize),
+		done:   make(chan struct{}),
+		logger: logger,
+	}
+}
+
+// dial connects to the WebSocket server and starts read/write loops.
+func (c *connection) dial(rawURL, secret string) error {
+	c.wsURL = rawURL
+	c.secret = secret
+
+	conn, err := c.dialOnce()
+	if err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	c.conn = conn
+	c.mu.Unlock()
+
+	go c.writeLoop()
+	go c.readLoop()
+
+	return nil
+}
+
+// dialOnce performs a single WebSocket dial with the secret query param.
+func (c *connection) dialOnce() (*ws.Conn, error) {
+	u, err := url.Parse(c.wsURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid websocket URL: %w", err)
+	}
+	q := u.Query()
+	q.Set("secret", c.secret)
+	u.RawQuery = q.Encode()
+
+	conn, _, err := ws.DefaultDialer.Dial(u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("websocket dial failed: %w", err)
+	}
+	return conn, nil
+}
+
+// writeLoop drains sendCh and writes messages to the WebSocket.
+// Only one writeLoop runs at a time; it returns on error or shutdown.
+func (c *connection) writeLoop() {
+	for {
+		select {
+		case <-c.done:
+			return
+		case data := <-c.sendCh:
+			c.mu.Lock()
+			conn := c.conn
+			c.mu.Unlock()
+
+			if conn == nil {
+				continue
+			}
+
+			if err := conn.SetWriteDeadline(time.Now().Add(writeWait)); err != nil {
+				c.logger.Warn("WebSocket SetWriteDeadline error", "error", err)
+				go c.reconnect()
+				return
+			}
+			if err := conn.WriteMessage(ws.TextMessage, data); err != nil {
+				c.logger.Warn("WebSocket write error", "error", err)
+				go c.reconnect()
+				return
+			}
+		}
+	}
+}
+
+// readLoop reads ack messages from the server and routes them to ackCh.
+func (c *connection) readLoop() {
+	for {
+		c.mu.Lock()
+		conn := c.conn
+		c.mu.Unlock()
+
+		if conn == nil {
+			return
+		}
+
+		_, message, err := conn.ReadMessage()
+		if err != nil {
+			select {
+			case <-c.done:
+				return
+			default:
+			}
+			c.logger.Warn("WebSocket read error", "error", err)
+			go c.reconnect()
+			return
+		}
+
+		var ack AckMessage
+		if err := json.Unmarshal(message, &ack); err != nil {
+			c.logger.Debug("Non-ack message received", "raw", string(message))
+			continue
+		}
+
+		if ack.Type == "ack" {
+			select {
+			case c.ackCh <- ack:
+			default:
+				c.logger.Debug("Ack channel full, dropping", "for", ack.For)
+			}
+		}
+	}
+}
+
+// reconnect attempts to re-establish the WebSocket connection with
+// exponential backoff. On success it replays the cached start_mission
+// message and restarts the read/write loops.
+func (c *connection) reconnect() {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	if c.conn != nil {
+		_ = c.conn.Close()
+		c.conn = nil
+	}
+	c.mu.Unlock()
+
+	backoff := time.Second
+	for attempt := 1; attempt <= maxReconnect; attempt++ {
+		select {
+		case <-c.done:
+			return
+		default:
+		}
+
+		c.logger.Info("Reconnecting to WebSocket", "attempt", attempt, "backoff", backoff)
+		time.Sleep(backoff)
+
+		conn, err := c.dialOnce()
+		if err != nil {
+			c.logger.Warn("Reconnect dial failed", "attempt", attempt, "error", err)
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+			continue
+		}
+
+		c.mu.Lock()
+		c.conn = conn
+		cached := c.cachedStartMsg
+		c.mu.Unlock()
+
+		// Replay start_mission so the server knows which mission we're recording.
+		if cached != nil {
+			if err := conn.SetWriteDeadline(time.Now().Add(writeWait)); err != nil {
+				c.logger.Warn("Failed to set deadline for start_mission replay", "error", err)
+				_ = conn.Close()
+				continue
+			}
+			if err := conn.WriteMessage(ws.TextMessage, cached); err != nil {
+				c.logger.Warn("Failed to replay start_mission after reconnect", "error", err)
+				_ = conn.Close()
+				continue
+			}
+		}
+
+		c.logger.Info("WebSocket reconnected", "attempt", attempt)
+		go c.writeLoop()
+		go c.readLoop()
+		return
+	}
+
+	c.logger.Error("WebSocket reconnect failed after max attempts", "maxAttempts", maxReconnect)
+}
+
+// send pushes data to the write loop. Non-blocking; drops if channel full.
+func (c *connection) send(data []byte) {
+	select {
+	case c.sendCh <- data:
+	default:
+		c.logger.Warn("WebSocket send channel full, dropping message")
+	}
+}
+
+// sendAndWait sends data and blocks until the server acknowledges with a
+// matching ack message or the timeout expires.
+func (c *connection) sendAndWait(data []byte, ackFor string, timeout time.Duration) error {
+	c.send(data)
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case ack := <-c.ackCh:
+			if ack.For == ackFor {
+				return nil
+			}
+			// Not our ack, keep waiting.
+		case <-timer.C:
+			return fmt.Errorf("timeout waiting for ack of %q", ackFor)
+		case <-c.done:
+			return fmt.Errorf("connection closed while waiting for ack of %q", ackFor)
+		}
+	}
+}
+
+// close sends a WebSocket close frame and shuts down all goroutines.
+func (c *connection) close() error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	close(c.done)
+	conn := c.conn
+	c.conn = nil
+	c.mu.Unlock()
+
+	if conn != nil {
+		_ = conn.WriteMessage(
+			ws.CloseMessage,
+			ws.FormatCloseMessage(ws.CloseNormalClosure, ""),
+		)
+		return conn.Close()
+	}
+	return nil
+}

--- a/internal/storage/websocket/connection.go
+++ b/internal/storage/websocket/connection.go
@@ -249,7 +249,9 @@ func (c *connection) sendAndWait(data []byte, ackFor string, timeout time.Durati
 	}
 }
 
-// close sends a WebSocket close frame and shuts down all goroutines.
+// close shuts down all goroutines and closes the underlying connection.
+// It does not send a WebSocket close frame because the writeLoop may
+// still be writing; closing the TCP connection is sufficient.
 func (c *connection) close() error {
 	c.mu.Lock()
 	if c.closed {
@@ -263,10 +265,6 @@ func (c *connection) close() error {
 	c.mu.Unlock()
 
 	if conn != nil {
-		_ = conn.WriteMessage(
-			ws.CloseMessage,
-			ws.FormatCloseMessage(ws.CloseNormalClosure, ""),
-		)
 		return conn.Close()
 	}
 	return nil

--- a/internal/storage/websocket/messages.go
+++ b/internal/storage/websocket/messages.go
@@ -1,6 +1,10 @@
 package websocket
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/OCAP2/extension/v5/pkg/core"
+)
 
 // Message type constants matching the streaming protocol.
 const (
@@ -40,8 +44,8 @@ type AckMessage struct {
 
 // StartMissionPayload carries mission and world data.
 type StartMissionPayload struct {
-	Mission any `json:"mission"`
-	World   any `json:"world"`
+	Mission *core.Mission `json:"mission"`
+	World   *core.World   `json:"world"`
 }
 
 // DeleteMarkerPayload carries marker deletion data.

--- a/internal/storage/websocket/messages.go
+++ b/internal/storage/websocket/messages.go
@@ -1,0 +1,51 @@
+package websocket
+
+import "encoding/json"
+
+// Message type constants matching the streaming protocol.
+const (
+	TypeStartMission    = "start_mission"
+	TypeEndMission      = "end_mission"
+	TypeAddSoldier      = "add_soldier"
+	TypeAddVehicle      = "add_vehicle"
+	TypeAddMarker       = "add_marker"
+	TypeSoldierState    = "soldier_state"
+	TypeVehicleState    = "vehicle_state"
+	TypeMarkerState     = "marker_state"
+	TypeDeleteMarker    = "delete_marker"
+	TypeFiredEvent      = "fired_event"
+	TypeProjectileEvent = "projectile_event"
+	TypeGeneralEvent    = "general_event"
+	TypeHitEvent        = "hit_event"
+	TypeKillEvent       = "kill_event"
+	TypeChatEvent       = "chat_event"
+	TypeRadioEvent      = "radio_event"
+	TypeServerFps       = "server_fps"
+	TypeTimeState       = "time_state"
+	TypeAce3Death       = "ace3_death"
+	TypeAce3Unconscious = "ace3_unconscious"
+)
+
+// Envelope wraps all messages sent over the WebSocket.
+type Envelope struct {
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+// AckMessage is the server's acknowledgement response.
+type AckMessage struct {
+	Type string `json:"type"` // always "ack"
+	For  string `json:"for"`  // the message type being acknowledged
+}
+
+// StartMissionPayload carries mission and world data.
+type StartMissionPayload struct {
+	Mission any `json:"mission"`
+	World   any `json:"world"`
+}
+
+// DeleteMarkerPayload carries marker deletion data.
+type DeleteMarkerPayload struct {
+	Name     string `json:"name"`
+	EndFrame uint   `json:"endFrame"`
+}

--- a/internal/storage/websocket/websocket.go
+++ b/internal/storage/websocket/websocket.go
@@ -1,0 +1,180 @@
+package websocket
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+
+	"github.com/OCAP2/extension/v5/pkg/core"
+)
+
+// Config holds WebSocket backend configuration.
+type Config struct {
+	URL    string
+	Secret string
+}
+
+// Backend streams mission data over WebSocket to the OCAP2 web server.
+// It implements storage.Backend but not storage.Uploadable.
+type Backend struct {
+	conn         *connection
+	cfg          Config
+	nextMarkerID atomic.Uint64
+}
+
+// New creates a new WebSocket storage backend.
+func New(cfg Config) *Backend {
+	return &Backend{
+		conn: newConnection(slog.Default()),
+		cfg:  cfg,
+	}
+}
+
+// Init connects to the WebSocket server.
+func (b *Backend) Init() error {
+	return b.conn.dial(b.cfg.URL, b.cfg.Secret)
+}
+
+// Close disconnects from the WebSocket server.
+func (b *Backend) Close() error {
+	return b.conn.close()
+}
+
+// sendEnvelope marshals the payload into an Envelope and pushes it
+// to the write loop (fire-and-forget).
+func (b *Backend) sendEnvelope(msgType string, payload any) error {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal %s payload: %w", msgType, err)
+	}
+	env := Envelope{Type: msgType, Payload: raw}
+	data, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("marshal %s envelope: %w", msgType, err)
+	}
+	b.conn.send(data)
+	return nil
+}
+
+// sendEnvelopeAndWait marshals the payload and waits for a server ack.
+func (b *Backend) sendEnvelopeAndWait(msgType string, payload any) error {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal %s payload: %w", msgType, err)
+	}
+	env := Envelope{Type: msgType, Payload: raw}
+	data, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("marshal %s envelope: %w", msgType, err)
+	}
+	return b.conn.sendAndWait(data, msgType, ackTimeout)
+}
+
+// StartMission sends mission and world data and waits for server ack.
+func (b *Backend) StartMission(mission *core.Mission, world *core.World) error {
+	payload := StartMissionPayload{Mission: mission, World: world}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal start_mission payload: %w", err)
+	}
+	env := Envelope{Type: TypeStartMission, Payload: raw}
+	data, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("marshal start_mission envelope: %w", err)
+	}
+
+	// Cache for reconnect replay.
+	b.conn.mu.Lock()
+	b.conn.cachedStartMsg = data
+	b.conn.mu.Unlock()
+
+	return b.conn.sendAndWait(data, TypeStartMission, ackTimeout)
+}
+
+// EndMission sends end_mission and waits for server ack.
+func (b *Backend) EndMission() error {
+	err := b.sendEnvelopeAndWait(TypeEndMission, nil)
+
+	// Clear cached state regardless of error.
+	b.conn.mu.Lock()
+	b.conn.cachedStartMsg = nil
+	b.conn.mu.Unlock()
+	b.nextMarkerID.Store(0)
+
+	return err
+}
+
+func (b *Backend) AddSoldier(s *core.Soldier) error {
+	return b.sendEnvelope(TypeAddSoldier, s)
+}
+
+func (b *Backend) AddVehicle(v *core.Vehicle) error {
+	return b.sendEnvelope(TypeAddVehicle, v)
+}
+
+// AddMarker assigns an auto-increment ID and sends the marker.
+func (b *Backend) AddMarker(m *core.Marker) error {
+	m.ID = uint(b.nextMarkerID.Add(1))
+	return b.sendEnvelope(TypeAddMarker, m)
+}
+
+func (b *Backend) RecordSoldierState(s *core.SoldierState) error {
+	return b.sendEnvelope(TypeSoldierState, s)
+}
+
+func (b *Backend) RecordVehicleState(v *core.VehicleState) error {
+	return b.sendEnvelope(TypeVehicleState, v)
+}
+
+func (b *Backend) RecordMarkerState(s *core.MarkerState) error {
+	return b.sendEnvelope(TypeMarkerState, s)
+}
+
+func (b *Backend) DeleteMarker(name string, endFrame uint) error {
+	return b.sendEnvelope(TypeDeleteMarker, DeleteMarkerPayload{Name: name, EndFrame: endFrame})
+}
+
+func (b *Backend) RecordFiredEvent(e *core.FiredEvent) error {
+	return b.sendEnvelope(TypeFiredEvent, e)
+}
+
+func (b *Backend) RecordProjectileEvent(e *core.ProjectileEvent) error {
+	return b.sendEnvelope(TypeProjectileEvent, e)
+}
+
+func (b *Backend) RecordGeneralEvent(e *core.GeneralEvent) error {
+	return b.sendEnvelope(TypeGeneralEvent, e)
+}
+
+func (b *Backend) RecordHitEvent(e *core.HitEvent) error {
+	return b.sendEnvelope(TypeHitEvent, e)
+}
+
+func (b *Backend) RecordKillEvent(e *core.KillEvent) error {
+	return b.sendEnvelope(TypeKillEvent, e)
+}
+
+func (b *Backend) RecordChatEvent(e *core.ChatEvent) error {
+	return b.sendEnvelope(TypeChatEvent, e)
+}
+
+func (b *Backend) RecordRadioEvent(e *core.RadioEvent) error {
+	return b.sendEnvelope(TypeRadioEvent, e)
+}
+
+func (b *Backend) RecordServerFpsEvent(e *core.ServerFpsEvent) error {
+	return b.sendEnvelope(TypeServerFps, e)
+}
+
+func (b *Backend) RecordTimeState(t *core.TimeState) error {
+	return b.sendEnvelope(TypeTimeState, t)
+}
+
+func (b *Backend) RecordAce3DeathEvent(e *core.Ace3DeathEvent) error {
+	return b.sendEnvelope(TypeAce3Death, e)
+}
+
+func (b *Backend) RecordAce3UnconsciousEvent(e *core.Ace3UnconsciousEvent) error {
+	return b.sendEnvelope(TypeAce3Unconscious, e)
+}

--- a/internal/storage/websocket/websocket_test.go
+++ b/internal/storage/websocket/websocket_test.go
@@ -2,6 +2,7 @@ package websocket
 
 import (
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -105,7 +106,7 @@ func TestStartAndEndMission(t *testing.T) {
 	assert.Equal(t, TypeEndMission, msgs[len(msgs)-1].Type)
 }
 
-func TestFireAndForgetMessages(t *testing.T) {
+func TestAllMessageTypes(t *testing.T) {
 	srv, ml := testServer(t)
 	defer srv.Close()
 
@@ -113,16 +114,31 @@ func TestFireAndForgetMessages(t *testing.T) {
 	require.NoError(t, b.Init())
 	defer b.Close()
 
-	mission := &core.Mission{MissionName: "M"}
-	world := &core.World{WorldName: "W"}
-	require.NoError(t, b.StartMission(mission, world))
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "M"}, &core.World{WorldName: "W"}))
 
+	// Entity registration
 	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Alpha 1-1"}))
 	require.NoError(t, b.AddVehicle(&core.Vehicle{ID: 100, ClassName: "B_MRAP_01_F"}))
+	require.NoError(t, b.AddMarker(&core.Marker{MarkerName: "m1"}))
+
+	// State updates
 	require.NoError(t, b.RecordSoldierState(&core.SoldierState{SoldierID: 1, CaptureFrame: 1}))
 	require.NoError(t, b.RecordVehicleState(&core.VehicleState{VehicleID: 100, CaptureFrame: 1}))
+	require.NoError(t, b.RecordMarkerState(&core.MarkerState{MarkerID: 1, CaptureFrame: 1}))
+	require.NoError(t, b.DeleteMarker("m1", 10))
+
+	// Events
+	require.NoError(t, b.RecordFiredEvent(&core.FiredEvent{SoldierID: 1, Weapon: "arifle_MX_F"}))
+	require.NoError(t, b.RecordProjectileEvent(&core.ProjectileEvent{FirerObjectID: 1}))
 	require.NoError(t, b.RecordGeneralEvent(&core.GeneralEvent{Name: "test"}))
+	require.NoError(t, b.RecordHitEvent(&core.HitEvent{EventText: "hit"}))
+	require.NoError(t, b.RecordKillEvent(&core.KillEvent{EventText: "killed"}))
+	require.NoError(t, b.RecordChatEvent(&core.ChatEvent{Message: "hello"}))
+	require.NoError(t, b.RecordRadioEvent(&core.RadioEvent{Radio: "ACRE"}))
 	require.NoError(t, b.RecordServerFpsEvent(&core.ServerFpsEvent{FpsAverage: 50}))
+	require.NoError(t, b.RecordTimeState(&core.TimeState{MissionTime: 120}))
+	require.NoError(t, b.RecordAce3DeathEvent(&core.Ace3DeathEvent{SoldierID: 1, Reason: "bleeding"}))
+	require.NoError(t, b.RecordAce3UnconsciousEvent(&core.Ace3UnconsciousEvent{SoldierID: 1, IsUnconscious: true}))
 
 	require.NoError(t, b.EndMission())
 
@@ -130,20 +146,22 @@ func TestFireAndForgetMessages(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	msgs := ml.all()
-
 	types := make(map[string]int)
 	for _, m := range msgs {
 		types[m.Type]++
 	}
 
-	assert.Equal(t, 1, types[TypeStartMission])
-	assert.Equal(t, 1, types[TypeEndMission])
-	assert.Equal(t, 1, types[TypeAddSoldier])
-	assert.Equal(t, 1, types[TypeAddVehicle])
-	assert.Equal(t, 1, types[TypeSoldierState])
-	assert.Equal(t, 1, types[TypeVehicleState])
-	assert.Equal(t, 1, types[TypeGeneralEvent])
-	assert.Equal(t, 1, types[TypeServerFps])
+	// Every message type should appear exactly once.
+	for _, typ := range []string{
+		TypeStartMission, TypeEndMission,
+		TypeAddSoldier, TypeAddVehicle, TypeAddMarker,
+		TypeSoldierState, TypeVehicleState, TypeMarkerState, TypeDeleteMarker,
+		TypeFiredEvent, TypeProjectileEvent, TypeGeneralEvent,
+		TypeHitEvent, TypeKillEvent, TypeChatEvent, TypeRadioEvent,
+		TypeServerFps, TypeTimeState, TypeAce3Death, TypeAce3Unconscious,
+	} {
+		assert.Equalf(t, 1, types[typ], "expected exactly 1 message of type %q", typ)
+	}
 }
 
 func TestAddMarkerAssignsID(t *testing.T) {
@@ -181,4 +199,287 @@ func TestEnvelopeSerialization(t *testing.T) {
 	require.NoError(t, json.Unmarshal(decoded.Payload, &dp))
 	assert.Equal(t, "mrk1", dp.Name)
 	assert.Equal(t, uint(42), dp.EndFrame)
+}
+
+func TestMarkerIDResetsAfterEndMission(t *testing.T) {
+	srv, _ := testServer(t)
+	defer srv.Close()
+
+	b := New(Config{URL: wsURL(srv), Secret: "s"})
+	require.NoError(t, b.Init())
+	defer b.Close()
+
+	require.NoError(t, b.StartMission(&core.Mission{}, &core.World{}))
+	m1 := &core.Marker{MarkerName: "a"}
+	require.NoError(t, b.AddMarker(m1))
+	assert.Equal(t, uint(1), m1.ID)
+	require.NoError(t, b.EndMission())
+
+	// After EndMission, marker IDs should reset.
+	require.NoError(t, b.StartMission(&core.Mission{}, &core.World{}))
+	m2 := &core.Marker{MarkerName: "b"}
+	require.NoError(t, b.AddMarker(m2))
+	assert.Equal(t, uint(1), m2.ID)
+	require.NoError(t, b.EndMission())
+}
+
+func TestDialFailure(t *testing.T) {
+	b := New(Config{URL: "ws://127.0.0.1:1", Secret: "s"})
+	err := b.Init()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "websocket dial failed")
+}
+
+func TestDialInvalidURL(t *testing.T) {
+	b := New(Config{URL: "://bad", Secret: "s"})
+	err := b.Init()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid websocket URL")
+}
+
+func TestCloseIdempotent(t *testing.T) {
+	srv, _ := testServer(t)
+	defer srv.Close()
+
+	b := New(Config{URL: wsURL(srv), Secret: "s"})
+	require.NoError(t, b.Init())
+
+	require.NoError(t, b.Close())
+	require.NoError(t, b.Close()) // second close should not error
+}
+
+func TestAckTimeout(t *testing.T) {
+	// Server that never sends acks.
+	upgrader := ws.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		// Read messages but never reply.
+		for {
+			if _, _, err := c.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	b := New(Config{URL: wsURL(srv), Secret: "s"})
+	require.NoError(t, b.Init())
+	defer b.Close()
+
+	// Test sendAndWait directly with a short timeout instead of going
+	// through StartMission (which uses the 10s ackTimeout constant).
+	data, err := marshalEnvelope(TypeStartMission, StartMissionPayload{})
+	require.NoError(t, err)
+
+	err = b.conn.sendAndWait(data, TypeStartMission, 100*time.Millisecond)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout waiting for ack")
+}
+
+func TestSendAndWaitClosedConnection(t *testing.T) {
+	srv, _ := testServer(t)
+	defer srv.Close()
+
+	b := New(Config{URL: wsURL(srv), Secret: "s"})
+	require.NoError(t, b.Init())
+
+	// Close the connection, then sendAndWait should return an error.
+	require.NoError(t, b.Close())
+
+	data, err := marshalEnvelope(TypeEndMission, nil)
+	require.NoError(t, err)
+
+	err = b.conn.sendAndWait(data, TypeEndMission, 100*time.Millisecond)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection closed")
+}
+
+// restartableServer is a test WebSocket server that can be stopped and
+// restarted on the same listener to test reconnection.
+type restartableServer struct {
+	mu       sync.Mutex
+	listener *restartableListener
+	srv      *http.Server
+	ml       *messageLog
+	upgrader ws.Upgrader
+	t        *testing.T
+}
+
+type restartableListener struct {
+	net    string
+	addr   string
+	inner  net.Listener
+	closed bool
+	mu     sync.Mutex
+}
+
+func (l *restartableListener) Accept() (net.Conn, error) { return l.inner.Accept() }
+func (l *restartableListener) Addr() net.Addr             { return l.inner.Addr() }
+func (l *restartableListener) Close() error {
+	l.mu.Lock()
+	l.closed = true
+	l.mu.Unlock()
+	return l.inner.Close()
+}
+
+func newRestartableServer(t *testing.T) *restartableServer {
+	t.Helper()
+	ml := &messageLog{}
+	rs := &restartableServer{
+		ml:       ml,
+		upgrader: ws.Upgrader{CheckOrigin: func(*http.Request) bool { return true }},
+		t:        t,
+	}
+	return rs
+}
+
+func (rs *restartableServer) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := rs.upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close()
+
+		for {
+			_, msg, err := c.ReadMessage()
+			if err != nil {
+				return
+			}
+			var env Envelope
+			if err := json.Unmarshal(msg, &env); err != nil {
+				continue
+			}
+			rs.ml.add(env)
+
+			if env.Type == TypeStartMission || env.Type == TypeEndMission {
+				ack := AckMessage{Type: "ack", For: env.Type}
+				data, _ := json.Marshal(ack)
+				if err := c.WriteMessage(ws.TextMessage, data); err != nil {
+					return
+				}
+			}
+		}
+	})
+}
+
+func (rs *restartableServer) start() string {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(rs.t, err)
+
+	rs.listener = &restartableListener{inner: ln}
+	rs.srv = &http.Server{Handler: rs.handler()}
+	go rs.srv.Serve(rs.listener)
+	return "ws://" + ln.Addr().String()
+}
+
+func (rs *restartableServer) startOnAddr(addr string) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	ln, err := net.Listen("tcp", addr)
+	require.NoError(rs.t, err)
+
+	rs.listener = &restartableListener{inner: ln}
+	rs.srv = &http.Server{Handler: rs.handler()}
+	go rs.srv.Serve(rs.listener)
+}
+
+func (rs *restartableServer) stop() {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	if rs.srv != nil {
+		rs.srv.Close()
+		rs.srv = nil
+	}
+}
+
+func TestReconnectAfterServerRestart(t *testing.T) {
+	rs := newRestartableServer(t)
+	url := rs.start()
+
+	// Extract the host:port so we can restart on the same address.
+	addr := strings.TrimPrefix(url, "ws://")
+
+	b := New(Config{URL: url, Secret: "s"})
+	require.NoError(t, b.Init())
+	defer b.Close()
+
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "R"}, &core.World{WorldName: "W"}))
+
+	// Stop the server — this will cause the read/write loops to fail.
+	rs.stop()
+	time.Sleep(100 * time.Millisecond)
+
+	// Restart on the same address so the reconnect dials succeed.
+	rs.startOnAddr(addr)
+	defer rs.stop()
+
+	// Wait for reconnect (backoff starts at 1s).
+	time.Sleep(2 * time.Second)
+
+	// Send a message — if reconnect worked, this should arrive.
+	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 5, UnitName: "Bravo"}))
+	time.Sleep(200 * time.Millisecond)
+
+	msgs := rs.ml.all()
+	types := make(map[string]int)
+	for _, m := range msgs {
+		types[m.Type]++
+	}
+
+	// start_mission should have been replayed on reconnect.
+	assert.GreaterOrEqual(t, types[TypeStartMission], 1, "start_mission should be replayed on reconnect")
+	assert.GreaterOrEqual(t, types[TypeAddSoldier], 1, "message after reconnect should arrive")
+}
+
+func TestReconnectGuardPreventsDouble(t *testing.T) {
+	// Verify the atomic guard prevents concurrent reconnect calls.
+	srv, _ := testServer(t)
+	defer srv.Close()
+
+	b := New(Config{URL: wsURL(srv), Secret: "s"})
+	require.NoError(t, b.Init())
+	defer b.Close()
+
+	// Simulate: set reconnecting flag, then call reconnect — should return immediately.
+	b.conn.reconnecting.Store(true)
+	b.conn.reconnect() // should be a no-op
+	b.conn.reconnecting.Store(false)
+}
+
+func TestSendChannelFullDropsMessage(t *testing.T) {
+	srv, _ := testServer(t)
+	defer srv.Close()
+
+	b := New(Config{URL: wsURL(srv), Secret: "s"})
+	require.NoError(t, b.Init())
+	defer b.Close()
+
+	// Fill the send channel to capacity.
+	for i := 0; i < sendChSize; i++ {
+		b.conn.sendCh <- []byte("{}")
+	}
+
+	// Next send should drop without blocking.
+	done := make(chan struct{})
+	go func() {
+		b.conn.send([]byte(`{"type":"test"}`))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good — send returned without blocking.
+	case <-time.After(time.Second):
+		t.Fatal("send blocked when channel was full")
+	}
 }

--- a/internal/storage/websocket/websocket_test.go
+++ b/internal/storage/websocket/websocket_test.go
@@ -1,0 +1,183 @@
+package websocket
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	ws "github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/OCAP2/extension/v5/internal/storage"
+	"github.com/OCAP2/extension/v5/pkg/core"
+)
+
+// Compile-time interface check.
+var _ storage.Backend = (*Backend)(nil)
+
+// testServer creates an httptest server that upgrades to WebSocket,
+// records received messages, and sends acks for start_mission/end_mission.
+func testServer(t *testing.T) (*httptest.Server, *messageLog) {
+	t.Helper()
+	ml := &messageLog{}
+
+	upgrader := ws.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Logf("upgrade error: %v", err)
+			return
+		}
+		defer c.Close()
+
+		for {
+			_, msg, err := c.ReadMessage()
+			if err != nil {
+				return
+			}
+
+			var env Envelope
+			if err := json.Unmarshal(msg, &env); err != nil {
+				continue
+			}
+			ml.add(env)
+
+			// Ack start_mission and end_mission.
+			if env.Type == TypeStartMission || env.Type == TypeEndMission {
+				ack := AckMessage{Type: "ack", For: env.Type}
+				data, _ := json.Marshal(ack)
+				if err := c.WriteMessage(ws.TextMessage, data); err != nil {
+					return
+				}
+			}
+		}
+	}))
+
+	return srv, ml
+}
+
+type messageLog struct {
+	mu       sync.Mutex
+	messages []Envelope
+}
+
+func (m *messageLog) add(env Envelope) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.messages = append(m.messages, env)
+}
+
+func (m *messageLog) all() []Envelope {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]Envelope, len(m.messages))
+	copy(cp, m.messages)
+	return cp
+}
+
+func wsURL(srv *httptest.Server) string {
+	return "ws" + strings.TrimPrefix(srv.URL, "http")
+}
+
+func TestStartAndEndMission(t *testing.T) {
+	srv, ml := testServer(t)
+	defer srv.Close()
+
+	b := New(Config{URL: wsURL(srv), Secret: "test"})
+	require.NoError(t, b.Init())
+	defer b.Close()
+
+	mission := &core.Mission{MissionName: "TestMission", Tag: "TvT"}
+	world := &core.World{WorldName: "Altis"}
+	require.NoError(t, b.StartMission(mission, world))
+
+	require.NoError(t, b.EndMission())
+
+	msgs := ml.all()
+	require.GreaterOrEqual(t, len(msgs), 2)
+	assert.Equal(t, TypeStartMission, msgs[0].Type)
+	assert.Equal(t, TypeEndMission, msgs[len(msgs)-1].Type)
+}
+
+func TestFireAndForgetMessages(t *testing.T) {
+	srv, ml := testServer(t)
+	defer srv.Close()
+
+	b := New(Config{URL: wsURL(srv), Secret: "s"})
+	require.NoError(t, b.Init())
+	defer b.Close()
+
+	mission := &core.Mission{MissionName: "M"}
+	world := &core.World{WorldName: "W"}
+	require.NoError(t, b.StartMission(mission, world))
+
+	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Alpha 1-1"}))
+	require.NoError(t, b.AddVehicle(&core.Vehicle{ID: 100, ClassName: "B_MRAP_01_F"}))
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{SoldierID: 1, CaptureFrame: 1}))
+	require.NoError(t, b.RecordVehicleState(&core.VehicleState{VehicleID: 100, CaptureFrame: 1}))
+	require.NoError(t, b.RecordGeneralEvent(&core.GeneralEvent{Name: "test"}))
+	require.NoError(t, b.RecordServerFpsEvent(&core.ServerFpsEvent{FpsAverage: 50}))
+
+	require.NoError(t, b.EndMission())
+
+	// Give a moment for all messages to arrive at server.
+	time.Sleep(50 * time.Millisecond)
+
+	msgs := ml.all()
+
+	types := make(map[string]int)
+	for _, m := range msgs {
+		types[m.Type]++
+	}
+
+	assert.Equal(t, 1, types[TypeStartMission])
+	assert.Equal(t, 1, types[TypeEndMission])
+	assert.Equal(t, 1, types[TypeAddSoldier])
+	assert.Equal(t, 1, types[TypeAddVehicle])
+	assert.Equal(t, 1, types[TypeSoldierState])
+	assert.Equal(t, 1, types[TypeVehicleState])
+	assert.Equal(t, 1, types[TypeGeneralEvent])
+	assert.Equal(t, 1, types[TypeServerFps])
+}
+
+func TestAddMarkerAssignsID(t *testing.T) {
+	srv, _ := testServer(t)
+	defer srv.Close()
+
+	b := New(Config{URL: wsURL(srv), Secret: "s"})
+	require.NoError(t, b.Init())
+	defer b.Close()
+
+	m1 := &core.Marker{MarkerName: "marker1"}
+	m2 := &core.Marker{MarkerName: "marker2"}
+
+	require.NoError(t, b.AddMarker(m1))
+	require.NoError(t, b.AddMarker(m2))
+
+	assert.Equal(t, uint(1), m1.ID)
+	assert.Equal(t, uint(2), m2.ID)
+}
+
+func TestEnvelopeSerialization(t *testing.T) {
+	payload := DeleteMarkerPayload{Name: "mrk1", EndFrame: 42}
+	raw, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	env := Envelope{Type: TypeDeleteMarker, Payload: raw}
+	data, err := json.Marshal(env)
+	require.NoError(t, err)
+
+	var decoded Envelope
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, TypeDeleteMarker, decoded.Type)
+
+	var dp DeleteMarkerPayload
+	require.NoError(t, json.Unmarshal(decoded.Payload, &dp))
+	assert.Equal(t, "mrk1", dp.Name)
+	assert.Equal(t, uint(42), dp.EndFrame)
+}

--- a/internal/storage/websocket/websocket_test.go
+++ b/internal/storage/websocket/websocket_test.go
@@ -50,7 +50,8 @@ func testServer(t *testing.T) (*httptest.Server, *messageLog) {
 			// Ack start_mission and end_mission.
 			if env.Type == TypeStartMission || env.Type == TypeEndMission {
 				ack := AckMessage{Type: "ack", For: env.Type}
-				data, _ := json.Marshal(ack)
+				data, err := json.Marshal(ack)
+				require.NoError(t, err)
 				if err := c.WriteMessage(ws.TextMessage, data); err != nil {
 					return
 				}

--- a/ocap_recorder.cfg.json.example
+++ b/ocap_recorder.cfg.json.example
@@ -3,7 +3,7 @@
   "logsDir": "./ocaplogs",
   "defaultTag": "TvT",
   "api": {
-    "serverUrl": "http://127.0.0.1:5000",
+    "serverUrl": "http://127.0.0.1:5000/api",
     "apiKey": "same-secret"
   },
   "db": {


### PR DESCRIPTION
## Summary

- Adds a new `websocket` storage backend that streams mission events over WebSocket to the OCAP2 web server in real-time, so recording data survives game crashes
- Uses gorilla/websocket with a single write goroutine and 10k-element buffered channel for thread-safe, non-blocking sends
- `StartMission`/`EndMission` wait for server ack; all other methods are fire-and-forget
- Reconnects with exponential backoff (1s→30s, max 10 attempts) and replays cached `start_mission` on reconnect
- Configurable via `storage.type: "websocket"` with `storage.websocket.url` and `storage.websocket.secret`

## Files

**New:**
- `internal/storage/websocket/messages.go` — Envelope, AckMessage, message type constants
- `internal/storage/websocket/connection.go` — WebSocket connection manager with write/read loops and reconnect
- `internal/storage/websocket/websocket.go` — `Backend` implementing `storage.Backend`
- `internal/storage/websocket/websocket_test.go` — Interface check, integration tests with local WS server

**Modified:**
- `internal/config/config.go` — `WebSocketConfig` struct + viper defaults
- `cmd/ocap_recorder/storage.go` — `case "websocket":` in factory switch
- `go.mod`/`go.sum` — `github.com/gorilla/websocket v1.5.3`

## Test plan

- [x] Compile-time `storage.Backend` interface check
- [x] Unit tests: envelope serialization, marker ID auto-increment
- [x] Integration tests: start/end mission with ack, fire-and-forget message delivery
- [ ] Manual test: configure `storage.type: "websocket"`, point at OCAP2 web instance with streaming endpoint (OCAP2/web#217)