### PR TITLE
refactor: introduce core.DeleteMarker struct

### DIFF
--- a/internal/parser/parse_marker.go
+++ b/internal/parser/parse_marker.go
@@ -151,19 +151,20 @@ func (p *Parser) ParseMarkerMove(data []string) (MarkerMove, error) {
 	return result, nil
 }
 
-// ParseMarkerDelete parses marker delete data and returns the marker name and frame number
-func (p *Parser) ParseMarkerDelete(data []string) (string, uint, error) {
+// ParseMarkerDelete parses marker delete data and returns a DeleteMarker
+func (p *Parser) ParseMarkerDelete(data []string) (*core.DeleteMarker, error) {
 	// fix received data
 	for i, v := range data {
 		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
 	}
 
-	markerName := data[0]
-
 	capframe, err := strconv.ParseFloat(data[1], 64)
 	if err != nil {
-		return markerName, 0, fmt.Errorf("error parsing capture frame: %w", err)
+		return nil, fmt.Errorf("error parsing capture frame: %w", err)
 	}
 
-	return markerName, uint(capframe), nil
+	return &core.DeleteMarker{
+		Name:     data[0],
+		EndFrame: uint(capframe),
+	}, nil
 }

--- a/internal/parser/parse_marker_test.go
+++ b/internal/parser/parse_marker_test.go
@@ -291,14 +291,14 @@ func TestParseMarkerDelete(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			name, frame, err := p.ParseMarkerDelete(tt.input)
+			dm, err := p.ParseMarkerDelete(tt.input)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantName, name)
-			assert.Equal(t, tt.wantFrame, frame)
+			assert.Equal(t, tt.wantName, dm.Name)
+			assert.Equal(t, tt.wantFrame, dm.EndFrame)
 		})
 	}
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -69,7 +69,7 @@ type Service interface {
 	ParseAce3UnconsciousEvent(args []string) (core.Ace3UnconsciousEvent, error)
 	ParseMarkerCreate(args []string) (core.Marker, error)
 	ParseMarkerMove(args []string) (MarkerMove, error)
-	ParseMarkerDelete(args []string) (string, uint, error)
+	ParseMarkerDelete(args []string) (*core.DeleteMarker, error)
 }
 
 var _ Service = (*Parser)(nil)

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -221,12 +221,12 @@ func (b *Backend) RecordMarkerState(s *core.MarkerState) error {
 }
 
 // DeleteMarker sets the end frame for a marker, marking it as deleted at that frame
-func (b *Backend) DeleteMarker(name string, endFrame uint) error {
+func (b *Backend) DeleteMarker(dm *core.DeleteMarker) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if record, ok := b.markers[name]; ok {
-		record.Marker.EndFrame = int(endFrame)
+	if record, ok := b.markers[dm.Name]; ok {
+		record.Marker.EndFrame = int(dm.EndFrame)
 	}
 	return nil
 }

--- a/internal/storage/memory/memory_test.go
+++ b/internal/storage/memory/memory_test.go
@@ -234,13 +234,13 @@ func TestDeleteMarker(t *testing.T) {
 	require.NoError(t, b.AddMarker(m))
 
 	// Delete marker at frame 100
-	require.NoError(t, b.DeleteMarker("grenade_1", 100))
+	require.NoError(t, b.DeleteMarker(&core.DeleteMarker{Name: "grenade_1", EndFrame: 100}))
 
 	record := b.markers["grenade_1"]
 	assert.Equal(t, 100, record.Marker.EndFrame)
 
 	// Deleting non-existent marker should not panic
-	require.NoError(t, b.DeleteMarker("nonexistent", 50))
+	require.NoError(t, b.DeleteMarker(&core.DeleteMarker{Name: "nonexistent", EndFrame: 50}))
 }
 
 func TestRecordFiredEvent(t *testing.T) {

--- a/internal/storage/postgres/postgres.go
+++ b/internal/storage/postgres/postgres.go
@@ -262,15 +262,15 @@ func (b *Backend) RecordMarkerState(s *core.MarkerState) error {
 }
 
 // DeleteMarker pushes an alpha=0 MarkerState to the queue and marks the marker as deleted in DB.
-func (b *Backend) DeleteMarker(name string, endFrame uint) error {
-	markerID, ok := b.deps.MarkerCache.Get(name)
+func (b *Backend) DeleteMarker(dm *core.DeleteMarker) error {
+	markerID, ok := b.deps.MarkerCache.Get(dm.Name)
 	if !ok {
 		return nil
 	}
 
 	deleteState := model.MarkerState{
 		MarkerID:     markerID,
-		CaptureFrame: endFrame,
+		CaptureFrame: dm.EndFrame,
 		Time:         time.Now(),
 		Alpha:        0,
 	}

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -436,7 +436,7 @@ func TestDeleteMarker_PushesAlphaZeroState(t *testing.T) {
 	// Pre-populate marker cache
 	b.deps.MarkerCache.Set("TestMarker", 42)
 
-	require.NoError(t, b.DeleteMarker("TestMarker", 500))
+	require.NoError(t, b.DeleteMarker(&core.DeleteMarker{Name: "TestMarker", EndFrame: 500}))
 
 	assert.Equal(t, 1, b.queues.MarkerStates.Len())
 	items := b.queues.MarkerStates.GetAndEmpty()
@@ -451,7 +451,7 @@ func TestDeleteMarker_UnknownMarker_NoOp(t *testing.T) {
 	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
 	defer func() { require.NoError(t, b.Close()) }()
 
-	require.NoError(t, b.DeleteMarker("NonExistent", 500))
+	require.NoError(t, b.DeleteMarker(&core.DeleteMarker{Name: "NonExistent", EndFrame: 500}))
 
 	assert.Equal(t, 0, b.queues.MarkerStates.Len())
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -22,7 +22,7 @@ type Backend interface {
 	RecordSoldierState(s *core.SoldierState) error
 	RecordVehicleState(v *core.VehicleState) error
 	RecordMarkerState(s *core.MarkerState) error
-	DeleteMarker(name string, endFrame uint) error
+	DeleteMarker(dm *core.DeleteMarker) error
 
 	// Event recording
 	RecordFiredEvent(e *core.FiredEvent) error

--- a/internal/storage/websocket/messages.go
+++ b/internal/storage/websocket/messages.go
@@ -47,9 +47,3 @@ type StartMissionPayload struct {
 	Mission *core.Mission `json:"mission"`
 	World   *core.World   `json:"world"`
 }
-
-// DeleteMarkerPayload carries marker deletion data.
-type DeleteMarkerPayload struct {
-	Name     string `json:"name"`
-	EndFrame uint   `json:"endFrame"`
-}

--- a/internal/storage/websocket/websocket.go
+++ b/internal/storage/websocket/websocket.go
@@ -129,8 +129,8 @@ func (b *Backend) RecordMarkerState(s *core.MarkerState) error {
 	return b.sendEnvelope(TypeMarkerState, s)
 }
 
-func (b *Backend) DeleteMarker(name string, endFrame uint) error {
-	return b.sendEnvelope(TypeDeleteMarker, DeleteMarkerPayload{Name: name, EndFrame: endFrame})
+func (b *Backend) DeleteMarker(dm *core.DeleteMarker) error {
+	return b.sendEnvelope(TypeDeleteMarker, dm)
 }
 
 func (b *Backend) RecordFiredEvent(e *core.FiredEvent) error {

--- a/internal/storage/websocket/websocket_test.go
+++ b/internal/storage/websocket/websocket_test.go
@@ -146,7 +146,7 @@ func TestAllMessageTypes(t *testing.T) {
 	require.NoError(t, b.RecordSoldierState(&core.SoldierState{SoldierID: 1, CaptureFrame: 1}))
 	require.NoError(t, b.RecordVehicleState(&core.VehicleState{VehicleID: 100, CaptureFrame: 1}))
 	require.NoError(t, b.RecordMarkerState(&core.MarkerState{MarkerID: 1, CaptureFrame: 1}))
-	require.NoError(t, b.DeleteMarker("m1", 10))
+	require.NoError(t, b.DeleteMarker(&core.DeleteMarker{Name: "m1", EndFrame: 10}))
 
 	// Events
 	require.NoError(t, b.RecordFiredEvent(&core.FiredEvent{SoldierID: 1, Weapon: "arifle_MX_F"}))
@@ -204,7 +204,7 @@ func TestAddMarkerAssignsID(t *testing.T) {
 }
 
 func TestEnvelopeSerialization(t *testing.T) {
-	payload := DeleteMarkerPayload{Name: "mrk1", EndFrame: 42}
+	payload := core.DeleteMarker{Name: "mrk1", EndFrame: 42}
 	raw, err := json.Marshal(payload)
 	require.NoError(t, err)
 
@@ -216,7 +216,7 @@ func TestEnvelopeSerialization(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &decoded))
 	assert.Equal(t, TypeDeleteMarker, decoded.Type)
 
-	var dp DeleteMarkerPayload
+	var dp core.DeleteMarker
 	require.NoError(t, json.Unmarshal(decoded.Payload, &dp))
 	assert.Equal(t, "mrk1", dp.Name)
 	assert.Equal(t, uint(42), dp.EndFrame)

--- a/internal/worker/dispatch.go
+++ b/internal/worker/dispatch.go
@@ -365,12 +365,12 @@ func (m *Manager) handleMarkerMove(e dispatcher.Event) (any, error) {
 }
 
 func (m *Manager) handleMarkerDelete(e dispatcher.Event) (any, error) {
-	markerName, frameNo, err := m.deps.ParserService.ParseMarkerDelete(e.Args)
+	dm, err := m.deps.ParserService.ParseMarkerDelete(e.Args)
 	if err != nil {
 		return nil, fmt.Errorf("failed to delete marker: %w", err)
 	}
 
-	if err := m.backend.DeleteMarker(markerName, frameNo); err != nil {
+	if err := m.backend.DeleteMarker(dm); err != nil {
 		return nil, fmt.Errorf("delete marker: %w", err)
 	}
 	return nil, nil

--- a/pkg/core/marker.go
+++ b/pkg/core/marker.go
@@ -25,6 +25,12 @@ type Marker struct {
 	IsDeleted    bool
 }
 
+// DeleteMarker represents a marker deletion at a specific frame
+type DeleteMarker struct {
+	Name     string
+	EndFrame uint
+}
+
 // MarkerState tracks marker position changes over time
 type MarkerState struct {
 	ID           uint

--- a/pkg/core/marker.go
+++ b/pkg/core/marker.go
@@ -27,8 +27,8 @@ type Marker struct {
 
 // DeleteMarker represents a marker deletion at a specific frame
 type DeleteMarker struct {
-	Name     string `json:"name"`
-	EndFrame uint   `json:"endFrame"`
+	Name     string
+	EndFrame uint
 }
 
 // MarkerState tracks marker position changes over time

--- a/pkg/core/marker.go
+++ b/pkg/core/marker.go
@@ -27,8 +27,8 @@ type Marker struct {
 
 // DeleteMarker represents a marker deletion at a specific frame
 type DeleteMarker struct {
-	Name     string
-	EndFrame uint
+	Name     string `json:"name"`
+	EndFrame uint   `json:"endFrame"`
 }
 
 // MarkerState tracks marker position changes over time


### PR DESCRIPTION
## Summary
- Add `core.DeleteMarker` struct with `Name` and `EndFrame` fields, replacing loose parameters `(name string, endFrame uint)` on the `storage.Backend` interface
- Thread the new type through parser → worker → all storage backends (memory, postgres, websocket)
- Remove `websocket.DeleteMarkerPayload` since `core.DeleteMarker` now serves that purpose directly

## Test plan
- [x] `go test ./pkg/core/ ./internal/parser/ ./internal/worker/ ./internal/storage/... -count=1` — all pass
- [x] `go build ./...` — compiles cleanly