### PR TITLE
refactor: move streaming message types to pkg/streaming

### DIFF
--- a/internal/storage/websocket/connection.go
+++ b/internal/storage/websocket/connection.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	ws "github.com/gorilla/websocket"
+
+	"github.com/OCAP2/extension/v5/pkg/streaming"
 )
 
 const (
@@ -26,7 +28,7 @@ type connection struct {
 	mu     sync.Mutex
 	conn   *ws.Conn
 	sendCh chan []byte
-	ackCh  chan AckMessage
+	ackCh  chan streaming.AckMessage
 	done         chan struct{} // closed on shutdown
 	closed       bool
 	reconnecting atomic.Bool
@@ -43,7 +45,7 @@ type connection struct {
 func newConnection(logger *slog.Logger) *connection {
 	return &connection{
 		sendCh: make(chan []byte, sendChSize),
-		ackCh:  make(chan AckMessage, ackChSize),
+		ackCh:  make(chan streaming.AckMessage, ackChSize),
 		done:   make(chan struct{}),
 		logger: logger,
 	}
@@ -139,7 +141,7 @@ func (c *connection) readLoop() {
 			return
 		}
 
-		var ack AckMessage
+		var ack streaming.AckMessage
 		if err := json.Unmarshal(message, &ack); err != nil {
 			c.logger.Debug("Non-ack message received", "raw", string(message))
 			continue

--- a/internal/storage/websocket/websocket.go
+++ b/internal/storage/websocket/websocket.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 
 	"github.com/OCAP2/extension/v5/pkg/core"
+	"github.com/OCAP2/extension/v5/pkg/streaming"
 )
 
 // Config holds WebSocket backend configuration.
@@ -47,7 +48,7 @@ func marshalEnvelope(msgType string, payload any) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("marshal %s payload: %w", msgType, err)
 	}
-	env := Envelope{Type: msgType, Payload: raw}
+	env := streaming.Envelope{Type: msgType, Payload: raw}
 	data, err := json.Marshal(env)
 	if err != nil {
 		return nil, fmt.Errorf("marshal %s envelope: %w", msgType, err)
@@ -77,7 +78,7 @@ func (b *Backend) sendEnvelopeAndWait(msgType string, payload any) error {
 
 // StartMission sends mission and world data and waits for server ack.
 func (b *Backend) StartMission(mission *core.Mission, world *core.World) error {
-	data, err := marshalEnvelope(TypeStartMission, StartMissionPayload{Mission: mission, World: world})
+	data, err := marshalEnvelope(streaming.TypeStartMission, streaming.StartMissionPayload{Mission: mission, World: world})
 	if err != nil {
 		return err
 	}
@@ -87,12 +88,12 @@ func (b *Backend) StartMission(mission *core.Mission, world *core.World) error {
 	b.conn.cachedStartMsg = data
 	b.conn.mu.Unlock()
 
-	return b.conn.sendAndWait(data, TypeStartMission, ackTimeout)
+	return b.conn.sendAndWait(data, streaming.TypeStartMission, ackTimeout)
 }
 
 // EndMission sends end_mission and waits for server ack.
 func (b *Backend) EndMission() error {
-	err := b.sendEnvelopeAndWait(TypeEndMission, nil)
+	err := b.sendEnvelopeAndWait(streaming.TypeEndMission, nil)
 
 	// Clear cached state regardless of error.
 	b.conn.mu.Lock()
@@ -104,75 +105,75 @@ func (b *Backend) EndMission() error {
 }
 
 func (b *Backend) AddSoldier(s *core.Soldier) error {
-	return b.sendEnvelope(TypeAddSoldier, s)
+	return b.sendEnvelope(streaming.TypeAddSoldier, s)
 }
 
 func (b *Backend) AddVehicle(v *core.Vehicle) error {
-	return b.sendEnvelope(TypeAddVehicle, v)
+	return b.sendEnvelope(streaming.TypeAddVehicle, v)
 }
 
 // AddMarker assigns an auto-increment ID and sends the marker.
 func (b *Backend) AddMarker(m *core.Marker) error {
 	m.ID = uint(b.nextMarkerID.Add(1))
-	return b.sendEnvelope(TypeAddMarker, m)
+	return b.sendEnvelope(streaming.TypeAddMarker, m)
 }
 
 func (b *Backend) RecordSoldierState(s *core.SoldierState) error {
-	return b.sendEnvelope(TypeSoldierState, s)
+	return b.sendEnvelope(streaming.TypeSoldierState, s)
 }
 
 func (b *Backend) RecordVehicleState(v *core.VehicleState) error {
-	return b.sendEnvelope(TypeVehicleState, v)
+	return b.sendEnvelope(streaming.TypeVehicleState, v)
 }
 
 func (b *Backend) RecordMarkerState(s *core.MarkerState) error {
-	return b.sendEnvelope(TypeMarkerState, s)
+	return b.sendEnvelope(streaming.TypeMarkerState, s)
 }
 
 func (b *Backend) DeleteMarker(dm *core.DeleteMarker) error {
-	return b.sendEnvelope(TypeDeleteMarker, dm)
+	return b.sendEnvelope(streaming.TypeDeleteMarker, dm)
 }
 
 func (b *Backend) RecordFiredEvent(e *core.FiredEvent) error {
-	return b.sendEnvelope(TypeFiredEvent, e)
+	return b.sendEnvelope(streaming.TypeFiredEvent, e)
 }
 
 func (b *Backend) RecordProjectileEvent(e *core.ProjectileEvent) error {
-	return b.sendEnvelope(TypeProjectileEvent, e)
+	return b.sendEnvelope(streaming.TypeProjectileEvent, e)
 }
 
 func (b *Backend) RecordGeneralEvent(e *core.GeneralEvent) error {
-	return b.sendEnvelope(TypeGeneralEvent, e)
+	return b.sendEnvelope(streaming.TypeGeneralEvent, e)
 }
 
 func (b *Backend) RecordHitEvent(e *core.HitEvent) error {
-	return b.sendEnvelope(TypeHitEvent, e)
+	return b.sendEnvelope(streaming.TypeHitEvent, e)
 }
 
 func (b *Backend) RecordKillEvent(e *core.KillEvent) error {
-	return b.sendEnvelope(TypeKillEvent, e)
+	return b.sendEnvelope(streaming.TypeKillEvent, e)
 }
 
 func (b *Backend) RecordChatEvent(e *core.ChatEvent) error {
-	return b.sendEnvelope(TypeChatEvent, e)
+	return b.sendEnvelope(streaming.TypeChatEvent, e)
 }
 
 func (b *Backend) RecordRadioEvent(e *core.RadioEvent) error {
-	return b.sendEnvelope(TypeRadioEvent, e)
+	return b.sendEnvelope(streaming.TypeRadioEvent, e)
 }
 
 func (b *Backend) RecordServerFpsEvent(e *core.ServerFpsEvent) error {
-	return b.sendEnvelope(TypeServerFps, e)
+	return b.sendEnvelope(streaming.TypeServerFps, e)
 }
 
 func (b *Backend) RecordTimeState(t *core.TimeState) error {
-	return b.sendEnvelope(TypeTimeState, t)
+	return b.sendEnvelope(streaming.TypeTimeState, t)
 }
 
 func (b *Backend) RecordAce3DeathEvent(e *core.Ace3DeathEvent) error {
-	return b.sendEnvelope(TypeAce3Death, e)
+	return b.sendEnvelope(streaming.TypeAce3Death, e)
 }
 
 func (b *Backend) RecordAce3UnconsciousEvent(e *core.Ace3UnconsciousEvent) error {
-	return b.sendEnvelope(TypeAce3Unconscious, e)
+	return b.sendEnvelope(streaming.TypeAce3Unconscious, e)
 }

--- a/internal/storage/websocket/websocket_test.go
+++ b/internal/storage/websocket/websocket_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/OCAP2/extension/v5/internal/storage"
 	"github.com/OCAP2/extension/v5/pkg/core"
+	"github.com/OCAP2/extension/v5/pkg/streaming"
 )
 
 // Compile-time interface check.
@@ -43,15 +44,15 @@ func testServer(t *testing.T) (*httptest.Server, *messageLog) {
 				return
 			}
 
-			var env Envelope
+			var env streaming.Envelope
 			if err := json.Unmarshal(msg, &env); err != nil {
 				continue
 			}
 			ml.add(env)
 
 			// Ack start_mission and end_mission.
-			if env.Type == TypeStartMission || env.Type == TypeEndMission {
-				ack := AckMessage{Type: "ack", For: env.Type}
+			if env.Type == streaming.TypeStartMission || env.Type == streaming.TypeEndMission {
+				ack := streaming.AckMessage{Type: "ack", For: env.Type}
 				data, err := json.Marshal(ack)
 				require.NoError(t, err)
 				if err := c.WriteMessage(ws.TextMessage, data); err != nil {
@@ -66,19 +67,19 @@ func testServer(t *testing.T) (*httptest.Server, *messageLog) {
 
 type messageLog struct {
 	mu       sync.Mutex
-	messages []Envelope
+	messages []streaming.Envelope
 }
 
-func (m *messageLog) add(env Envelope) {
+func (m *messageLog) add(env streaming.Envelope) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.messages = append(m.messages, env)
 }
 
-func (m *messageLog) all() []Envelope {
+func (m *messageLog) all() []streaming.Envelope {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	cp := make([]Envelope, len(m.messages))
+	cp := make([]streaming.Envelope, len(m.messages))
 	copy(cp, m.messages)
 	return cp
 }
@@ -123,8 +124,8 @@ func TestStartAndEndMission(t *testing.T) {
 
 	msgs := ml.all()
 	require.GreaterOrEqual(t, len(msgs), 2)
-	assert.Equal(t, TypeStartMission, msgs[0].Type)
-	assert.Equal(t, TypeEndMission, msgs[len(msgs)-1].Type)
+	assert.Equal(t, streaming.TypeStartMission, msgs[0].Type)
+	assert.Equal(t, streaming.TypeEndMission, msgs[len(msgs)-1].Type)
 }
 
 func TestAllMessageTypes(t *testing.T) {
@@ -174,12 +175,12 @@ func TestAllMessageTypes(t *testing.T) {
 
 	// Every message type should appear exactly once.
 	for _, typ := range []string{
-		TypeStartMission, TypeEndMission,
-		TypeAddSoldier, TypeAddVehicle, TypeAddMarker,
-		TypeSoldierState, TypeVehicleState, TypeMarkerState, TypeDeleteMarker,
-		TypeFiredEvent, TypeProjectileEvent, TypeGeneralEvent,
-		TypeHitEvent, TypeKillEvent, TypeChatEvent, TypeRadioEvent,
-		TypeServerFps, TypeTimeState, TypeAce3Death, TypeAce3Unconscious,
+		streaming.TypeStartMission, streaming.TypeEndMission,
+		streaming.TypeAddSoldier, streaming.TypeAddVehicle, streaming.TypeAddMarker,
+		streaming.TypeSoldierState, streaming.TypeVehicleState, streaming.TypeMarkerState, streaming.TypeDeleteMarker,
+		streaming.TypeFiredEvent, streaming.TypeProjectileEvent, streaming.TypeGeneralEvent,
+		streaming.TypeHitEvent, streaming.TypeKillEvent, streaming.TypeChatEvent, streaming.TypeRadioEvent,
+		streaming.TypeServerFps, streaming.TypeTimeState, streaming.TypeAce3Death, streaming.TypeAce3Unconscious,
 	} {
 		assert.Equalf(t, 1, types[typ], "expected exactly 1 message of type %q", typ)
 	}
@@ -208,13 +209,13 @@ func TestEnvelopeSerialization(t *testing.T) {
 	raw, err := json.Marshal(payload)
 	require.NoError(t, err)
 
-	env := Envelope{Type: TypeDeleteMarker, Payload: raw}
+	env := streaming.Envelope{Type: streaming.TypeDeleteMarker, Payload: raw}
 	data, err := json.Marshal(env)
 	require.NoError(t, err)
 
-	var decoded Envelope
+	var decoded streaming.Envelope
 	require.NoError(t, json.Unmarshal(data, &decoded))
-	assert.Equal(t, TypeDeleteMarker, decoded.Type)
+	assert.Equal(t, streaming.TypeDeleteMarker, decoded.Type)
 
 	var dp core.DeleteMarker
 	require.NoError(t, json.Unmarshal(decoded.Payload, &dp))
@@ -299,10 +300,10 @@ func TestAckTimeout(t *testing.T) {
 	require.NoError(t, b.Init())
 	defer b.Close()
 
-	data, err := marshalEnvelope(TypeStartMission, StartMissionPayload{})
+	data, err := marshalEnvelope(streaming.TypeStartMission, streaming.StartMissionPayload{})
 	require.NoError(t, err)
 
-	err = b.conn.sendAndWait(data, TypeStartMission, 100*time.Millisecond)
+	err = b.conn.sendAndWait(data, streaming.TypeStartMission, 100*time.Millisecond)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "timeout waiting for ack")
 }
@@ -316,10 +317,10 @@ func TestSendAndWaitClosedConnection(t *testing.T) {
 
 	require.NoError(t, b.Close())
 
-	data, err := marshalEnvelope(TypeEndMission, nil)
+	data, err := marshalEnvelope(streaming.TypeEndMission, nil)
 	require.NoError(t, err)
 
-	err = b.conn.sendAndWait(data, TypeEndMission, 100*time.Millisecond)
+	err = b.conn.sendAndWait(data, streaming.TypeEndMission, 100*time.Millisecond)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "connection closed")
 }
@@ -431,9 +432,9 @@ func TestReadLoopNonJsonMessage(t *testing.T) {
 			// Send garbage first (covers json.Unmarshal error in readLoop).
 			_ = c.WriteMessage(ws.TextMessage, []byte("not json"))
 
-			var env Envelope
-			if json.Unmarshal(msg, &env) == nil && env.Type == TypeStartMission {
-				ack, _ := json.Marshal(AckMessage{Type: "ack", For: env.Type})
+			var env streaming.Envelope
+			if json.Unmarshal(msg, &env) == nil && env.Type == streaming.TypeStartMission {
+				ack, _ := json.Marshal(streaming.AckMessage{Type: "ack", For: env.Type})
 				_ = c.WriteMessage(ws.TextMessage, ack)
 			}
 		}
@@ -445,11 +446,11 @@ func TestReadLoopNonJsonMessage(t *testing.T) {
 	defer b.Close()
 
 	// StartMission will get garbage first, then a valid ack.
-	data, err := marshalEnvelope(TypeStartMission, StartMissionPayload{
+	data, err := marshalEnvelope(streaming.TypeStartMission, streaming.StartMissionPayload{
 		Mission: &core.Mission{}, World: &core.World{},
 	})
 	require.NoError(t, err)
-	require.NoError(t, b.conn.sendAndWait(data, TypeStartMission, 2*time.Second))
+	require.NoError(t, b.conn.sendAndWait(data, streaming.TypeStartMission, 2*time.Second))
 }
 
 func TestReadLoopNonAckMessage(t *testing.T) {
@@ -470,9 +471,9 @@ func TestReadLoopNonAckMessage(t *testing.T) {
 			// Send a non-ack JSON message (valid JSON, but type != "ack").
 			_ = c.WriteMessage(ws.TextMessage, []byte(`{"type":"info","data":"hello"}`))
 
-			var env Envelope
-			if json.Unmarshal(msg, &env) == nil && env.Type == TypeStartMission {
-				ack, _ := json.Marshal(AckMessage{Type: "ack", For: env.Type})
+			var env streaming.Envelope
+			if json.Unmarshal(msg, &env) == nil && env.Type == streaming.TypeStartMission {
+				ack, _ := json.Marshal(streaming.AckMessage{Type: "ack", For: env.Type})
 				_ = c.WriteMessage(ws.TextMessage, ack)
 			}
 		}
@@ -483,11 +484,11 @@ func TestReadLoopNonAckMessage(t *testing.T) {
 	require.NoError(t, b.Init())
 	defer b.Close()
 
-	data, err := marshalEnvelope(TypeStartMission, StartMissionPayload{
+	data, err := marshalEnvelope(streaming.TypeStartMission, streaming.StartMissionPayload{
 		Mission: &core.Mission{}, World: &core.World{},
 	})
 	require.NoError(t, err)
-	require.NoError(t, b.conn.sendAndWait(data, TypeStartMission, 2*time.Second))
+	require.NoError(t, b.conn.sendAndWait(data, streaming.TypeStartMission, 2*time.Second))
 }
 
 // --- reconnect tests (called directly for reliable coverage) ---
@@ -515,7 +516,7 @@ func TestReconnectDirectSuccess(t *testing.T) {
 	c.mu.Unlock()
 
 	// Send a message to verify the connection works.
-	data, err := marshalEnvelope(TypeAddSoldier, &core.Soldier{ID: 1})
+	data, err := marshalEnvelope(streaming.TypeAddSoldier, &core.Soldier{ID: 1})
 	require.NoError(t, err)
 	c.send(data)
 	time.Sleep(200 * time.Millisecond)
@@ -532,7 +533,7 @@ func TestReconnectDirectWithCachedMessage(t *testing.T) {
 	defer c.close()
 
 	// Set a cached start_mission message for replay.
-	startData, err := marshalEnvelope(TypeStartMission, StartMissionPayload{
+	startData, err := marshalEnvelope(streaming.TypeStartMission, streaming.StartMissionPayload{
 		Mission: &core.Mission{MissionName: "Reconnect"},
 		World:   &core.World{WorldName: "Altis"},
 	})
@@ -551,7 +552,7 @@ func TestReconnectDirectWithCachedMessage(t *testing.T) {
 
 	msgs := ml.all()
 	require.GreaterOrEqual(t, len(msgs), 1)
-	assert.Equal(t, TypeStartMission, msgs[0].Type, "start_mission should be replayed")
+	assert.Equal(t, streaming.TypeStartMission, msgs[0].Type, "start_mission should be replayed")
 }
 
 func TestReconnectWhenClosed(t *testing.T) {
@@ -747,14 +748,14 @@ func (rs *restartableServer) handler() http.Handler {
 			if err != nil {
 				return
 			}
-			var env Envelope
+			var env streaming.Envelope
 			if err := json.Unmarshal(msg, &env); err != nil {
 				continue
 			}
 			rs.ml.add(env)
 
-			if env.Type == TypeStartMission || env.Type == TypeEndMission {
-				ack := AckMessage{Type: "ack", For: env.Type}
+			if env.Type == streaming.TypeStartMission || env.Type == streaming.TypeEndMission {
+				ack := streaming.AckMessage{Type: "ack", For: env.Type}
 				data, _ := json.Marshal(ack)
 				if err := c.WriteMessage(ws.TextMessage, data); err != nil {
 					return
@@ -826,6 +827,6 @@ func TestReconnectAfterServerRestart(t *testing.T) {
 		types[m.Type]++
 	}
 
-	assert.GreaterOrEqual(t, types[TypeStartMission], 1, "start_mission should be replayed on reconnect")
-	assert.GreaterOrEqual(t, types[TypeAddSoldier], 1, "message after reconnect should arrive")
+	assert.GreaterOrEqual(t, types[streaming.TypeStartMission], 1, "start_mission should be replayed on reconnect")
+	assert.GreaterOrEqual(t, types[streaming.TypeAddSoldier], 1, "message after reconnect should arrive")
 }

--- a/internal/storage/websocket/websocket_test.go
+++ b/internal/storage/websocket/websocket_test.go
@@ -174,14 +174,7 @@ func TestAllMessageTypes(t *testing.T) {
 	}
 
 	// Every message type should appear exactly once.
-	for _, typ := range []string{
-		streaming.TypeStartMission, streaming.TypeEndMission,
-		streaming.TypeAddSoldier, streaming.TypeAddVehicle, streaming.TypeAddMarker,
-		streaming.TypeSoldierState, streaming.TypeVehicleState, streaming.TypeMarkerState, streaming.TypeDeleteMarker,
-		streaming.TypeFiredEvent, streaming.TypeProjectileEvent, streaming.TypeGeneralEvent,
-		streaming.TypeHitEvent, streaming.TypeKillEvent, streaming.TypeChatEvent, streaming.TypeRadioEvent,
-		streaming.TypeServerFps, streaming.TypeTimeState, streaming.TypeAce3Death, streaming.TypeAce3Unconscious,
-	} {
+	for _, typ := range streaming.AllMessageTypes {
 		assert.Equalf(t, 1, types[typ], "expected exactly 1 message of type %q", typ)
 	}
 }

--- a/pkg/streaming/messages.go
+++ b/pkg/streaming/messages.go
@@ -30,6 +30,16 @@ const (
 	TypeAce3Unconscious = "ace3_unconscious"
 )
 
+// AllMessageTypes lists every streaming message type.
+var AllMessageTypes = []string{
+	TypeStartMission, TypeEndMission,
+	TypeAddSoldier, TypeAddVehicle, TypeAddMarker,
+	TypeSoldierState, TypeVehicleState, TypeMarkerState, TypeDeleteMarker,
+	TypeFiredEvent, TypeProjectileEvent, TypeGeneralEvent,
+	TypeHitEvent, TypeKillEvent, TypeChatEvent, TypeRadioEvent,
+	TypeServerFps, TypeTimeState, TypeAce3Death, TypeAce3Unconscious,
+}
+
 // Envelope wraps all messages sent over the WebSocket.
 type Envelope struct {
 	Type    string          `json:"type"`

--- a/pkg/streaming/messages.go
+++ b/pkg/streaming/messages.go
@@ -1,4 +1,4 @@
-package websocket
+package streaming
 
 import (
 	"encoding/json"


### PR DESCRIPTION
## Summary
- Moves `Envelope`, `AckMessage`, type constants, and `StartMissionPayload` from `internal/storage/websocket/` to `pkg/streaming/` so the OCAP2 web server can import them
- Removes unused `DeleteMarkerPayload` (replaced by `core.DeleteMarker`)

## Test plan
- [x] All existing websocket storage tests pass
- [x] Full project builds (`go build ./...`)