### PR TITLE
refactor: return assigned ID from AddMarker instead of mutating input

### DIFF
--- a/internal/storage/memory/export_test.go
+++ b/internal/storage/memory/export_test.go
@@ -596,19 +596,19 @@ func TestMultipleMarkersExport(t *testing.T) {
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 	// Each marker needs a unique ID so RecordMarkerState can find the correct one
-	_, err := b.AddMarker(&core.Marker{
-		ID: 1, MarkerName: "obj_alpha", Text: "Alpha", MarkerType: "mil_objective", Color: "ColorBLUFOR", Side: "WEST", Shape: "ICON",
+	alphaID, err := b.AddMarker(&core.Marker{
+		MarkerName: "obj_alpha", Text: "Alpha", MarkerType: "mil_objective", Color: "ColorBLUFOR", Side: "WEST", Shape: "ICON",
 		CaptureFrame: 0, Position: core.Position3D{X: 1000, Y: 1000}, Direction: 0, Alpha: 1.0,
 	})
 	require.NoError(t, err)
 	_, err = b.AddMarker(&core.Marker{
-		ID: 2, MarkerName: "obj_bravo", Text: "Bravo", MarkerType: "mil_objective", Color: "ColorOPFOR", Side: "EAST", Shape: "ICON",
+		MarkerName: "obj_bravo", Text: "Bravo", MarkerType: "mil_objective", Color: "ColorOPFOR", Side: "EAST", Shape: "ICON",
 		CaptureFrame: 0, Position: core.Position3D{X: 2000, Y: 2000}, Direction: 45, Alpha: 1.0,
 	})
 	require.NoError(t, err)
-	// States for marker 1 (Alpha)
-	require.NoError(t, b.RecordMarkerState(&core.MarkerState{MarkerID: 1, CaptureFrame: 10, Position: core.Position3D{X: 1100, Y: 1100}, Direction: 90, Alpha: 0.8}))
-	require.NoError(t, b.RecordMarkerState(&core.MarkerState{MarkerID: 1, CaptureFrame: 20, Position: core.Position3D{X: 1200, Y: 1200}, Direction: 180, Alpha: 0.6}))
+	// States for marker Alpha
+	require.NoError(t, b.RecordMarkerState(&core.MarkerState{MarkerID: alphaID, CaptureFrame: 10, Position: core.Position3D{X: 1100, Y: 1100}, Direction: 90, Alpha: 0.8}))
+	require.NoError(t, b.RecordMarkerState(&core.MarkerState{MarkerID: alphaID, CaptureFrame: 20, Position: core.Position3D{X: 1200, Y: 1200}, Direction: 180, Alpha: 0.6}))
 
 	export := b.BuildExport()
 

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -167,20 +167,24 @@ func (b *Backend) AddVehicle(v *core.Vehicle) error {
 
 // AddMarker registers a new marker.
 // Assigns an auto-increment ID so marker state updates can reference it.
-func (b *Backend) AddMarker(m *core.Marker) error {
+// Returns the assigned ID.
+func (b *Backend) AddMarker(m *core.Marker) (uint, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	b.nextMarkerID++
-	m.ID = b.nextMarkerID
+	id := b.nextMarkerID
+
+	markerCopy := *m
+	markerCopy.ID = id
 
 	record := &MarkerRecord{
-		Marker: *m,
+		Marker: markerCopy,
 		States: make([]core.MarkerState, 0),
 	}
 	b.markers[m.MarkerName] = record
-	b.markersByID[m.ID] = record
-	return nil
+	b.markersByID[id] = record
+	return id, nil
 }
 
 // RecordSoldierState records a soldier state update.

--- a/internal/storage/postgres/postgres.go
+++ b/internal/storage/postgres/postgres.go
@@ -228,16 +228,17 @@ func (b *Backend) AddVehicle(v *core.Vehicle) error {
 
 // AddMarker inserts a marker synchronously (not queued) because markers are low-volume
 // and need immediate ID assignment for the MarkerCache.
-func (b *Backend) AddMarker(m *core.Marker) error {
+// Returns the DB-assigned ID (0 if no DB is configured).
+func (b *Backend) AddMarker(m *core.Marker) (uint, error) {
 	gormObj := convert.CoreToMarker(*m)
 	if b.deps.DB != nil {
 		gormObj.MissionID = uint(b.missionID.Load())
 		if err := b.deps.DB.Create(&gormObj).Error; err != nil {
-			return fmt.Errorf("failed to insert marker: %w", err)
+			return 0, fmt.Errorf("failed to insert marker: %w", err)
 		}
-		m.ID = gormObj.ID
+		return gormObj.ID, nil
 	}
-	return nil
+	return 0, nil
 }
 
 // RecordSoldierState converts and queues a soldier state.

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -102,9 +102,9 @@ func TestAddMarker_NoDB_NoError(t *testing.T) {
 		MarkerType: "mil_dot",
 	}
 
-	err := b.AddMarker(marker)
+	id, err := b.AddMarker(marker)
 	require.NoError(t, err)
-	// No DB → marker not inserted, but no error
+	assert.Equal(t, uint(0), id, "no DB → ID should be 0")
 }
 
 func TestRecordSoldierState_QueuesToInternalQueue(t *testing.T) {
@@ -579,9 +579,9 @@ func TestAddMarker_WithDB(t *testing.T) {
 		Text:       "HQ",
 	}
 
-	err := b.AddMarker(marker)
+	id, err := b.AddMarker(marker)
 	require.NoError(t, err)
-	assert.NotZero(t, marker.ID, "marker ID should be assigned by DB")
+	assert.NotZero(t, id, "returned ID should be assigned by DB")
 
 	var count int64
 	db.Model(&model.Marker{}).Count(&count)

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -16,7 +16,7 @@ type Backend interface {
 	// Entity registration (assigns ID to the passed pointer)
 	AddSoldier(s *core.Soldier) error
 	AddVehicle(v *core.Vehicle) error
-	AddMarker(m *core.Marker) error
+	AddMarker(m *core.Marker) (uint, error)
 
 	// State recording
 	RecordSoldierState(s *core.SoldierState) error

--- a/internal/storage/websocket/websocket.go
+++ b/internal/storage/websocket/websocket.go
@@ -113,9 +113,12 @@ func (b *Backend) AddVehicle(v *core.Vehicle) error {
 }
 
 // AddMarker assigns an auto-increment ID and sends the marker.
-func (b *Backend) AddMarker(m *core.Marker) error {
-	m.ID = uint(b.nextMarkerID.Add(1))
-	return b.sendEnvelope(streaming.TypeAddMarker, m)
+// Returns the assigned ID.
+func (b *Backend) AddMarker(m *core.Marker) (uint, error) {
+	id := uint(b.nextMarkerID.Add(1))
+	markerCopy := *m
+	markerCopy.ID = id
+	return id, b.sendEnvelope(streaming.TypeAddMarker, &markerCopy)
 }
 
 func (b *Backend) RecordSoldierState(s *core.SoldierState) error {

--- a/internal/storage/websocket/websocket_test.go
+++ b/internal/storage/websocket/websocket_test.go
@@ -141,7 +141,8 @@ func TestAllMessageTypes(t *testing.T) {
 	// Entity registration
 	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Alpha 1-1"}))
 	require.NoError(t, b.AddVehicle(&core.Vehicle{ID: 100, ClassName: "B_MRAP_01_F"}))
-	require.NoError(t, b.AddMarker(&core.Marker{MarkerName: "m1"}))
+	_, err := b.AddMarker(&core.Marker{MarkerName: "m1"})
+	require.NoError(t, err)
 
 	// State updates
 	require.NoError(t, b.RecordSoldierState(&core.SoldierState{SoldierID: 1, CaptureFrame: 1}))
@@ -190,11 +191,13 @@ func TestAddMarkerAssignsID(t *testing.T) {
 	m1 := &core.Marker{MarkerName: "marker1"}
 	m2 := &core.Marker{MarkerName: "marker2"}
 
-	require.NoError(t, b.AddMarker(m1))
-	require.NoError(t, b.AddMarker(m2))
+	id1, err := b.AddMarker(m1)
+	require.NoError(t, err)
+	id2, err := b.AddMarker(m2)
+	require.NoError(t, err)
 
-	assert.Equal(t, uint(1), m1.ID)
-	assert.Equal(t, uint(2), m2.ID)
+	assert.Equal(t, uint(1), id1)
+	assert.Equal(t, uint(2), id2)
 }
 
 func TestEnvelopeSerialization(t *testing.T) {
@@ -226,15 +229,17 @@ func TestMarkerIDResetsAfterEndMission(t *testing.T) {
 
 	require.NoError(t, b.StartMission(&core.Mission{}, &core.World{}))
 	m1 := &core.Marker{MarkerName: "a"}
-	require.NoError(t, b.AddMarker(m1))
-	assert.Equal(t, uint(1), m1.ID)
+	id1, err := b.AddMarker(m1)
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), id1)
 	require.NoError(t, b.EndMission())
 
 	// After EndMission, marker IDs should reset.
 	require.NoError(t, b.StartMission(&core.Mission{}, &core.World{}))
 	m2 := &core.Marker{MarkerName: "b"}
-	require.NoError(t, b.AddMarker(m2))
-	assert.Equal(t, uint(1), m2.ID)
+	id2, err := b.AddMarker(m2)
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), id2)
 	require.NoError(t, b.EndMission())
 }
 

--- a/internal/worker/dispatch.go
+++ b/internal/worker/dispatch.go
@@ -328,11 +328,12 @@ func (m *Manager) handleMarkerCreate(e dispatcher.Event) (any, error) {
 		return nil, fmt.Errorf("failed to create marker: %w", err)
 	}
 
-	if err := m.backend.AddMarker(&marker); err != nil {
+	id, err := m.backend.AddMarker(&marker)
+	if err != nil {
 		return nil, fmt.Errorf("add marker: %w", err)
 	}
 	// Cache the assigned ID so state updates can find this marker
-	m.deps.MarkerCache.Set(marker.MarkerName, marker.ID)
+	m.deps.MarkerCache.Set(marker.MarkerName, id)
 
 	return nil, nil
 }

--- a/internal/worker/dispatch_test.go
+++ b/internal/worker/dispatch_test.go
@@ -109,12 +109,12 @@ func (b *mockBackend) AddVehicle(v *core.Vehicle) error {
 	return nil
 }
 
-func (b *mockBackend) AddMarker(m *core.Marker) error {
+func (b *mockBackend) AddMarker(m *core.Marker) (uint, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	m.ID = uint(len(b.markers) + 1)
+	id := uint(len(b.markers) + 1)
 	b.markers = append(b.markers, m)
-	return nil
+	return id, nil
 }
 
 func (b *mockBackend) RecordSoldierState(s *core.SoldierState) error {
@@ -228,8 +228,8 @@ type errorBackend struct {
 	err error
 }
 
-func (b *errorBackend) AddMarker(_ *core.Marker) error {
-	return b.err
+func (b *errorBackend) AddMarker(_ *core.Marker) (uint, error) {
+	return 0, b.err
 }
 
 // mockParserService provides a minimal implementation for testing


### PR DESCRIPTION
## Summary
- Change `AddMarker(m *core.Marker) error` → `AddMarker(m *core.Marker) (uint, error)` across the `storage.Backend` interface and all implementations (memory, postgres, websocket)
- Each backend now returns the assigned marker ID explicitly instead of mutating `m.ID` via pointer side effect
- The caller in `dispatch.go` uses the returned ID directly for the `MarkerCache`, removing the implicit contract where the input struct had to be read back after the call

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)