### PR TITLE
feat: unified :TELEMETRY: command replaces :FPS: and :METRIC:

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Copy `ocap_recorder.cfg.json.example` to `ocap_recorder.cfg.json` alongside the 
 | `:EVENT:` | 1,000 | General gameplay event |
 | `:CHAT:` | 1,000 | Chat message |
 | `:RADIO:` | 1,000 | Radio transmission |
-| `:FPS:` | 1,000 | Server FPS sample |
+| `:TELEMETRY:` | 1,000 | Server telemetry (FPS, entity counts, weather, player network stats) |
 | `:NEW:TIME:STATE:` | 100 | Mission time/date tracking |
 
 ### Marker Commands

--- a/cmd/ocap_recorder/main.go
+++ b/cmd/ocap_recorder/main.go
@@ -372,12 +372,6 @@ func registerLifecycleHandlers(d *dispatcher.Dispatcher) {
 		return nil, nil
 	})
 
-	// :METRIC: receives telemetry data from the addon (stub - metrics are logged but not stored)
-	d.Register(":METRIC:", func(e dispatcher.Event) (any, error) {
-		// Metrics are currently not stored, just acknowledged
-		return nil, nil
-	})
-
 	d.Register(":NEW:MISSION:", handleNewMission, dispatcher.Buffered(1), dispatcher.Blocking(), dispatcher.Gated(storageReady))
 
 	d.Register(":SAVE:MISSION:", func(e dispatcher.Event) (any, error) {

--- a/internal/model/convert/to_gorm.go
+++ b/internal/model/convert/to_gorm.go
@@ -266,16 +266,6 @@ func CoreToRadioEvent(e core.RadioEvent) model.RadioEvent {
 	return result
 }
 
-// CoreToServerFpsEvent converts a core.ServerFpsEvent to a GORM model.ServerFpsEvent.
-func CoreToServerFpsEvent(e core.ServerFpsEvent) model.ServerFpsEvent {
-	return model.ServerFpsEvent{
-		Time:         e.Time,
-		CaptureFrame: e.CaptureFrame,
-		FpsAverage:   e.FpsAverage,
-		FpsMin:       e.FpsMin,
-	}
-}
-
 // CoreToAce3DeathEvent converts a core.Ace3DeathEvent to a GORM model.Ace3DeathEvent.
 func CoreToAce3DeathEvent(e core.Ace3DeathEvent) model.Ace3DeathEvent {
 	result := model.Ace3DeathEvent{

--- a/internal/model/convert/to_gorm_test.go
+++ b/internal/model/convert/to_gorm_test.go
@@ -387,24 +387,6 @@ func TestCoreToRadioEvent(t *testing.T) {
 	assert.Equal(t, "ABC", result.Code)
 }
 
-func TestCoreToServerFpsEvent(t *testing.T) {
-	now := time.Now().Truncate(time.Millisecond)
-
-	input := core.ServerFpsEvent{
-		Time:         now,
-		CaptureFrame: 100,
-		FpsAverage:   50.5,
-		FpsMin:       30.0,
-	}
-
-	result := CoreToServerFpsEvent(input)
-
-	assert.Equal(t, now, result.Time)
-	assert.Equal(t, uint(100), result.CaptureFrame)
-	assert.Equal(t, float32(50.5), result.FpsAverage)
-	assert.Equal(t, float32(30.0), result.FpsMin)
-}
-
 func TestCoreToAce3DeathEvent(t *testing.T) {
 	now := time.Now().Truncate(time.Millisecond)
 	sourceID := uint(10)
@@ -647,7 +629,6 @@ var (
 	_ model.KillEvent            = CoreToKillEvent(core.KillEvent{})
 	_ model.ChatEvent            = CoreToChatEvent(core.ChatEvent{})
 	_ model.RadioEvent           = CoreToRadioEvent(core.RadioEvent{})
-	_ model.ServerFpsEvent       = CoreToServerFpsEvent(core.ServerFpsEvent{})
 	_ model.Ace3DeathEvent       = CoreToAce3DeathEvent(core.Ace3DeathEvent{})
 	_ model.Ace3UnconsciousEvent = CoreToAce3UnconsciousEvent(core.Ace3UnconsciousEvent{})
 	_ model.ProjectileEvent      = CoreToProjectileEvent(core.ProjectileEvent{})

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -535,10 +535,8 @@ func (r *RadioEvent) TableName() string {
 	return "radio_events"
 }
 
-// ServerFpsEvent records server performance metrics
-//
-// SQF Command: :FPS:
-// Args: [frameNo, currentFps, minFps]
+// ServerFpsEvent records server performance metrics.
+// Populated from :TELEMETRY: command data (FPS fields).
 type ServerFpsEvent struct {
 	Time         time.Time `json:"time" gorm:"type:timestamptz;"`                              // Server time when measurement taken
 	MissionID    uint      `json:"missionId" gorm:"index:idx_serverfpsevent_mission_id"`

--- a/internal/parser/parse_events.go
+++ b/internal/parser/parse_events.go
@@ -230,38 +230,6 @@ func (p *Parser) ParseKillEvent(data []string) (KillEvent, error) {
 	return result, nil
 }
 
-// ParseFpsEvent parses FPS event data and returns a core ServerFpsEvent
-func (p *Parser) ParseFpsEvent(data []string) (core.ServerFpsEvent, error) {
-	var fpsEvent core.ServerFpsEvent
-
-	// fix received data
-	for i, v := range data {
-		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
-	}
-
-	capframe, err := strconv.ParseFloat(data[0], 64)
-	if err != nil {
-		return fpsEvent, fmt.Errorf("error converting capture frame to int: %w", err)
-	}
-
-	fpsEvent.CaptureFrame = uint(capframe)
-	fpsEvent.Time = time.Now()
-
-	fps, err := strconv.ParseFloat(data[1], 64)
-	if err != nil {
-		return fpsEvent, fmt.Errorf("error converting fps to float: %w", err)
-	}
-	fpsEvent.FpsAverage = float32(fps)
-
-	fpsMin, err := strconv.ParseFloat(data[2], 64)
-	if err != nil {
-		return fpsEvent, fmt.Errorf("error converting fpsMin to float: %w", err)
-	}
-	fpsEvent.FpsMin = float32(fpsMin)
-
-	return fpsEvent, nil
-}
-
 // ParseTelemetryEvent parses a unified telemetry snapshot sent every ~10 seconds.
 // Replaces the old :FPS: and :METRIC: commands.
 //

--- a/internal/parser/parse_events.go
+++ b/internal/parser/parse_events.go
@@ -303,19 +303,25 @@ func (p *Parser) ParseTelemetryEvent(data []string) (core.TelemetryEvent, error)
 	if err := json.Unmarshal([]byte(data[2]), &sides); err != nil {
 		return result, fmt.Errorf("telemetry: parse side data: %w", err)
 	}
-	for i, side := range sides {
-		result.SideEntityCounts[i] = core.SideEntityCount{
+	parseSide := func(s [2][6]float64) core.SideEntityCount {
+		return core.SideEntityCount{
 			Local: core.EntityLocality{
-				UnitsTotal: uint(side[0][0]), UnitsAlive: uint(side[0][1]),
-				UnitsDead: uint(side[0][2]), Groups: uint(side[0][3]),
-				Vehicles: uint(side[0][4]), WeaponHolders: uint(side[0][5]),
+				UnitsTotal: uint(s[0][0]), UnitsAlive: uint(s[0][1]),
+				UnitsDead: uint(s[0][2]), Groups: uint(s[0][3]),
+				Vehicles: uint(s[0][4]), WeaponHolders: uint(s[0][5]),
 			},
 			Remote: core.EntityLocality{
-				UnitsTotal: uint(side[1][0]), UnitsAlive: uint(side[1][1]),
-				UnitsDead: uint(side[1][2]), Groups: uint(side[1][3]),
-				Vehicles: uint(side[1][4]), WeaponHolders: uint(side[1][5]),
+				UnitsTotal: uint(s[1][0]), UnitsAlive: uint(s[1][1]),
+				UnitsDead: uint(s[1][2]), Groups: uint(s[1][3]),
+				Vehicles: uint(s[1][4]), WeaponHolders: uint(s[1][5]),
 			},
 		}
+	}
+	result.SideEntityCounts = core.SideEntityCounts{
+		East:        parseSide(sides[0]),
+		West:        parseSide(sides[1]),
+		Independent: parseSide(sides[2]),
+		Civilian:    parseSide(sides[3]),
 	}
 
 	// [3] Global entity counts:

--- a/internal/parser/parse_events_test.go
+++ b/internal/parser/parse_events_test.go
@@ -525,63 +525,6 @@ func TestParseGeneralEvent(t *testing.T) {
 	}
 }
 
-func TestParseFpsEvent(t *testing.T) {
-	p := newTestParser()
-
-	tests := []struct {
-		name    string
-		input   []string
-		check   func(t *testing.T, e core.ServerFpsEvent)
-		wantErr bool
-	}{
-		{
-			name:  "normal FPS",
-			input: []string{"0", "35.4767", "3.55872"},
-			check: func(t *testing.T, e core.ServerFpsEvent) {
-				assert.Equal(t, uint(0), e.CaptureFrame)
-				assert.InDelta(t, float32(35.4767), e.FpsAverage, 0.01)
-				assert.InDelta(t, float32(3.55872), e.FpsMin, 0.01)
-			},
-		},
-		{
-			name:  "low FPS",
-			input: []string{"16", "18.9798", "14.4928"},
-			check: func(t *testing.T, e core.ServerFpsEvent) {
-				assert.Equal(t, uint(16), e.CaptureFrame)
-				assert.InDelta(t, float32(18.9798), e.FpsAverage, 0.01)
-				assert.InDelta(t, float32(14.4928), e.FpsMin, 0.01)
-			},
-		},
-		{
-			name:    "error: bad frame",
-			input:   []string{"abc", "35.0", "3.0"},
-			wantErr: true,
-		},
-		{
-			name:    "error: bad fpsAvg",
-			input:   []string{"0", "abc", "3.0"},
-			wantErr: true,
-		},
-		{
-			name:    "error: bad fpsMin",
-			input:   []string{"0", "35.0", "abc"},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := p.ParseFpsEvent(tt.input)
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			tt.check(t, result)
-		})
-	}
-}
-
 func TestParseTimeState(t *testing.T) {
 	p := newTestParser()
 

--- a/internal/parser/parse_events_test.go
+++ b/internal/parser/parse_events_test.go
@@ -894,3 +894,74 @@ func TestParseTelemetryEvent(t *testing.T) {
 		})
 	}
 }
+
+// Benchmarks using real RPT data
+
+func BenchmarkParseTelemetryEvent_1Player(b *testing.B) {
+	p := newTestParser()
+	// RPT frame 0: mission start, 1 player
+	args := []string{
+		"0",
+		"[43.3604,4.36681]",
+		`[[[1,1,0,1,0,0],[0,0,0,0,0,0]],[[10,10,0,8,0,0],[0,0,0,0,0,0]],[[6,6,0,6,0,0],[0,0,0,0,0,0]],[[5,5,12,0,24,0],[0,0,0,0,0,0]]]`,
+		"[22,12,15,28,0,1,0,1]",
+		"[28,4,0,4,2]",
+		"[0.2,0.25,0,0,0.1,0,0.25,0.315,0,0.423059,0.421672,1]",
+		`[["76561198000074241","info",100,28,0]]`,
+	}
+	b.ResetTimer()
+	for b.Loop() {
+		// Copy args to avoid mutation from TrimQuotes/FixEscapeQuotes
+		input := make([]string, len(args))
+		copy(input, args)
+		p.ParseTelemetryEvent(input) //nolint:errcheck
+	}
+}
+
+func BenchmarkParseTelemetryEvent_NoPlayers(b *testing.B) {
+	p := newTestParser()
+	args := []string{
+		"0",
+		"[50.0,40.0]",
+		`[[[0,0,0,0,0,0],[0,0,0,0,0,0]],[[0,0,0,0,0,0],[0,0,0,0,0,0]],[[0,0,0,0,0,0],[0,0,0,0,0,0]],[[0,0,0,0,0,0],[0,0,0,0,0,0]]]`,
+		"[0,0,0,0,0,0,0,0]",
+		"[0,0,0,0,0]",
+		"[0,0,0,0,0,0,0,0,0,0,0,0]",
+		"[]",
+	}
+	b.ResetTimer()
+	for b.Loop() {
+		input := make([]string, len(args))
+		copy(input, args)
+		p.ParseTelemetryEvent(input) //nolint:errcheck
+	}
+}
+
+func BenchmarkParseTelemetryEvent_20Players(b *testing.B) {
+	p := newTestParser()
+	// Simulate a populated server: 20 connected players
+	args := []string{
+		"114",
+		"[122.137,90.9091]",
+		`[[[32,32,0,10,0,0],[0,0,0,0,0,0]],[[6,6,0,8,1,0],[0,0,0,0,0,0]],[[6,6,0,6,0,0],[0,0,0,0,0,0]],[[4,4,19,0,23,22],[0,0,0,0,0,0]]]`,
+		"[48,19,24,28,22,1,0,1]",
+		"[17,3,0,4,3]",
+		"[0.2,0.25,0,0,0.1,160.864,0.25,0.175,0.003153,0.441581,0.421672,1]",
+		`[["76561198000000001","Alpha1",45,512,0.1],["76561198000000002","Alpha2",52,480,0.05],` +
+			`["76561198000000003","Alpha3",38,510,0],["76561198000000004","Alpha4",61,490,0.2],` +
+			`["76561198000000005","Bravo1",44,505,0],["76561198000000006","Bravo2",55,495,0.1],` +
+			`["76561198000000007","Bravo3",39,515,0],["76561198000000008","Bravo4",48,500,0.05],` +
+			`["76561198000000009","Charlie1",42,508,0],["76561198000000010","Charlie2",57,488,0.15],` +
+			`["76561198000000011","Charlie3",35,520,0],["76561198000000012","Charlie4",63,475,0.3],` +
+			`["76561198000000013","Delta1",41,512,0],["76561198000000014","Delta2",50,498,0.1],` +
+			`["76561198000000015","Delta3",37,516,0],["76561198000000016","Delta4",59,485,0.2],` +
+			`["76561198000000017","Echo1",43,507,0],["76561198000000018","Echo2",54,492,0.1],` +
+			`["76561198000000019","Echo3",36,518,0],["76561198000000020","Echo4",62,478,0.25]]`,
+	}
+	b.ResetTimer()
+	for b.Loop() {
+		input := make([]string, len(args))
+		copy(input, args)
+		p.ParseTelemetryEvent(input) //nolint:errcheck
+	}
+}

--- a/internal/parser/parse_events_test.go
+++ b/internal/parser/parse_events_test.go
@@ -643,7 +643,7 @@ func TestParseTelemetryEvent(t *testing.T) {
 				assert.InDelta(t, 4.36681, float64(e.FpsMin), 0.001)
 
 				// East: 1 local unit alive, 1 group, no vehicles
-				east := e.SideEntityCounts[0]
+				east := e.SideEntityCounts.East
 				assert.Equal(t, uint(1), east.Local.UnitsTotal)
 				assert.Equal(t, uint(1), east.Local.UnitsAlive)
 				assert.Equal(t, uint(0), east.Local.UnitsDead)
@@ -654,15 +654,15 @@ func TestParseTelemetryEvent(t *testing.T) {
 				assert.Equal(t, uint(0), east.Remote.UnitsTotal)
 
 				// West: 10 local units, 8 groups
-				assert.Equal(t, uint(10), e.SideEntityCounts[1].Local.UnitsTotal)
-				assert.Equal(t, uint(8), e.SideEntityCounts[1].Local.Groups)
+				assert.Equal(t, uint(10), e.SideEntityCounts.West.Local.UnitsTotal)
+				assert.Equal(t, uint(8), e.SideEntityCounts.West.Local.Groups)
 
 				// Independent: 6 local units, 6 groups
-				assert.Equal(t, uint(6), e.SideEntityCounts[2].Local.UnitsTotal)
-				assert.Equal(t, uint(6), e.SideEntityCounts[2].Local.Groups)
+				assert.Equal(t, uint(6), e.SideEntityCounts.Independent.Local.UnitsTotal)
+				assert.Equal(t, uint(6), e.SideEntityCounts.Independent.Local.Groups)
 
 				// Civilian: 5 alive, 12 dead, 24 vehicles, no weapon holders
-				civ := e.SideEntityCounts[3].Local
+				civ := e.SideEntityCounts.Civilian.Local
 				assert.Equal(t, uint(5), civ.UnitsTotal)
 				assert.Equal(t, uint(5), civ.UnitsAlive)
 				assert.Equal(t, uint(12), civ.UnitsDead)
@@ -719,13 +719,13 @@ func TestParseTelemetryEvent(t *testing.T) {
 				assert.InDelta(t, 90.9091, float64(e.FpsMin), 0.01)
 
 				// East lost 1 unit (33→32 in later frame, but at 114: 32 local)
-				assert.Equal(t, uint(32), e.SideEntityCounts[0].Local.UnitsTotal)
+				assert.Equal(t, uint(32), e.SideEntityCounts.East.Local.UnitsTotal)
 
 				// West: 1 vehicle now present
-				assert.Equal(t, uint(1), e.SideEntityCounts[1].Local.Vehicles)
+				assert.Equal(t, uint(1), e.SideEntityCounts.West.Local.Vehicles)
 
 				// Civilian: 19 dead (was 12 at start), 23 vehicles, 22 weapon holders on ground
-				civ := e.SideEntityCounts[3].Local
+				civ := e.SideEntityCounts.Civilian.Local
 				assert.Equal(t, uint(4), civ.UnitsTotal)
 				assert.Equal(t, uint(19), civ.UnitsDead)
 				assert.Equal(t, uint(23), civ.Vehicles)
@@ -753,18 +753,18 @@ func TestParseTelemetryEvent(t *testing.T) {
 				assert.InDelta(t, 76.9231, float64(e.FpsMin), 0.01)
 
 				// East: down to 30 local units
-				assert.Equal(t, uint(30), e.SideEntityCounts[0].Local.UnitsTotal)
+				assert.Equal(t, uint(30), e.SideEntityCounts.East.Local.UnitsTotal)
 
 				// West: down to 3 units, still 1 vehicle
-				west := e.SideEntityCounts[1].Local
+				west := e.SideEntityCounts.West.Local
 				assert.Equal(t, uint(3), west.UnitsTotal)
 				assert.Equal(t, uint(1), west.Vehicles)
 
 				// Independent: down to 2 units
-				assert.Equal(t, uint(2), e.SideEntityCounts[2].Local.UnitsTotal)
+				assert.Equal(t, uint(2), e.SideEntityCounts.Independent.Local.UnitsTotal)
 
 				// Civilian: 22 dead, 21 vehicles, 24 weapon holders
-				civ := e.SideEntityCounts[3].Local
+				civ := e.SideEntityCounts.Civilian.Local
 				assert.Equal(t, uint(22), civ.UnitsDead)
 				assert.Equal(t, uint(21), civ.Vehicles)
 				assert.Equal(t, uint(24), civ.WeaponHolders)

--- a/internal/parser/parse_events_test.go
+++ b/internal/parser/parse_events_test.go
@@ -880,6 +880,117 @@ func TestParseTelemetryEvent(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "error: bad sides JSON",
+			input: []string{
+				"0", "[50,40]", "not_json",
+				"[0,0,0,0,0,0,0,0]", "[0,0,0,0,0]",
+				"[0,0,0,0,0,0,0,0,0,0,0,0]", "[]",
+			},
+			wantErr: true,
+		},
+		{
+			name: "error: bad global JSON",
+			input: []string{
+				"0", "[50,40]", zeroSides,
+				"not_json", "[0,0,0,0,0]",
+				"[0,0,0,0,0,0,0,0,0,0,0,0]", "[]",
+			},
+			wantErr: true,
+		},
+		{
+			name: "error: bad scripts JSON",
+			input: []string{
+				"0", "[50,40]", zeroSides,
+				"[0,0,0,0,0,0,0,0]", "not_json",
+				"[0,0,0,0,0,0,0,0,0,0,0,0]", "[]",
+			},
+			wantErr: true,
+		},
+		{
+			name: "error: bad weather JSON",
+			input: []string{
+				"0", "[50,40]", zeroSides,
+				"[0,0,0,0,0,0,0,0]", "[0,0,0,0,0]",
+				"not_json", "[]",
+			},
+			wantErr: true,
+		},
+		{
+			name: "error: bad players JSON",
+			input: []string{
+				"0", "[50,40]", zeroSides,
+				"[0,0,0,0,0,0,0,0]", "[0,0,0,0,0]",
+				"[0,0,0,0,0,0,0,0,0,0,0,0]", "not_json",
+			},
+			wantErr: true,
+		},
+		{
+			name: "player with < 5 elements skipped",
+			input: []string{
+				"0", "[50,40]", zeroSides,
+				"[0,0,0,0,0,0,0,0]", "[0,0,0,0,0]",
+				"[0,0,0,0,0,0,0,0,0,0,0,0]", `[["uid","name",10]]`,
+			},
+			check: func(t *testing.T, e core.TelemetryEvent) {
+				assert.Empty(t, e.Players)
+			},
+		},
+		{
+			name: "player with bad uid type skipped",
+			input: []string{
+				"0", "[50,40]", zeroSides,
+				"[0,0,0,0,0,0,0,0]", "[0,0,0,0,0]",
+				"[0,0,0,0,0,0,0,0,0,0,0,0]", `[[123,"name",10,20,0]]`,
+			},
+			check: func(t *testing.T, e core.TelemetryEvent) {
+				assert.Empty(t, e.Players)
+			},
+		},
+		{
+			name: "player with bad name type skipped",
+			input: []string{
+				"0", "[50,40]", zeroSides,
+				"[0,0,0,0,0,0,0,0]", "[0,0,0,0,0]",
+				"[0,0,0,0,0,0,0,0,0,0,0,0]", `[["uid",123,10,20,0]]`,
+			},
+			check: func(t *testing.T, e core.TelemetryEvent) {
+				assert.Empty(t, e.Players)
+			},
+		},
+		{
+			name: "player with bad ping type skipped",
+			input: []string{
+				"0", "[50,40]", zeroSides,
+				"[0,0,0,0,0,0,0,0]", "[0,0,0,0,0]",
+				"[0,0,0,0,0,0,0,0,0,0,0,0]", `[["uid","name","bad",20,0]]`,
+			},
+			check: func(t *testing.T, e core.TelemetryEvent) {
+				assert.Empty(t, e.Players)
+			},
+		},
+		{
+			name: "player with bad bw type skipped",
+			input: []string{
+				"0", "[50,40]", zeroSides,
+				"[0,0,0,0,0,0,0,0]", "[0,0,0,0,0]",
+				"[0,0,0,0,0,0,0,0,0,0,0,0]", `[["uid","name",10,"bad",0]]`,
+			},
+			check: func(t *testing.T, e core.TelemetryEvent) {
+				assert.Empty(t, e.Players)
+			},
+		},
+		{
+			name: "player with bad desync type skipped",
+			input: []string{
+				"0", "[50,40]", zeroSides,
+				"[0,0,0,0,0,0,0,0]", "[0,0,0,0,0]",
+				"[0,0,0,0,0,0,0,0,0,0,0,0]", `[["uid","name",10,20,"bad"]]`,
+			},
+			check: func(t *testing.T, e core.TelemetryEvent) {
+				assert.Empty(t, e.Players)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -63,7 +63,6 @@ type Service interface {
 	ParseKillEvent(args []string) (KillEvent, error)
 	ParseChatEvent(args []string) (core.ChatEvent, error)
 	ParseRadioEvent(args []string) (core.RadioEvent, error)
-	ParseFpsEvent(args []string) (core.ServerFpsEvent, error)
 	ParseTimeState(args []string) (core.TimeState, error)
 	ParseAce3DeathEvent(args []string) (core.Ace3DeathEvent, error)
 	ParseAce3UnconsciousEvent(args []string) (core.Ace3UnconsciousEvent, error)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -70,6 +70,7 @@ type Service interface {
 	ParseMarkerCreate(args []string) (core.Marker, error)
 	ParseMarkerMove(args []string) (MarkerMove, error)
 	ParseMarkerDelete(args []string) (*core.DeleteMarker, error)
+	ParseTelemetryEvent(args []string) (core.TelemetryEvent, error)
 }
 
 var _ Service = (*Parser)(nil)

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -309,8 +309,8 @@ func (b *Backend) RecordServerFpsEvent(e *core.ServerFpsEvent) error {
 // RecordTelemetryEvent records a telemetry event.
 func (b *Backend) RecordTelemetryEvent(e *core.TelemetryEvent) error {
 	b.mu.Lock()
-	defer b.mu.Unlock()
 	b.telemetryEvents = append(b.telemetryEvents, *e)
+	b.mu.Unlock()
 	return nil
 }
 

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -49,7 +49,6 @@ type Backend struct {
 	killEvents            []core.KillEvent
 	chatEvents            []core.ChatEvent
 	radioEvents           []core.RadioEvent
-	serverFpsEvents       []core.ServerFpsEvent
 	telemetryEvents       []core.TelemetryEvent
 	timeStates            []core.TimeState
 	ace3DeathEvents       []core.Ace3DeathEvent
@@ -131,7 +130,6 @@ func (b *Backend) resetCollections() {
 	b.killEvents = nil
 	b.chatEvents = nil
 	b.radioEvents = nil
-	b.serverFpsEvents = nil
 	b.telemetryEvents = nil
 	b.timeStates = nil
 	b.ace3DeathEvents = nil
@@ -295,14 +293,6 @@ func (b *Backend) RecordRadioEvent(e *core.RadioEvent) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.radioEvents = append(b.radioEvents, *e)
-	return nil
-}
-
-// RecordServerFpsEvent records a server FPS event
-func (b *Backend) RecordServerFpsEvent(e *core.ServerFpsEvent) error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	b.serverFpsEvents = append(b.serverFpsEvents, *e)
 	return nil
 }
 

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -50,6 +50,7 @@ type Backend struct {
 	chatEvents            []core.ChatEvent
 	radioEvents           []core.RadioEvent
 	serverFpsEvents       []core.ServerFpsEvent
+	telemetryEvents       []core.TelemetryEvent
 	timeStates            []core.TimeState
 	ace3DeathEvents       []core.Ace3DeathEvent
 	ace3UnconsciousEvents []core.Ace3UnconsciousEvent
@@ -131,6 +132,7 @@ func (b *Backend) resetCollections() {
 	b.chatEvents = nil
 	b.radioEvents = nil
 	b.serverFpsEvents = nil
+	b.telemetryEvents = nil
 	b.timeStates = nil
 	b.ace3DeathEvents = nil
 	b.ace3UnconsciousEvents = nil
@@ -301,6 +303,20 @@ func (b *Backend) RecordServerFpsEvent(e *core.ServerFpsEvent) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.serverFpsEvents = append(b.serverFpsEvents, *e)
+	return nil
+}
+
+// RecordTelemetryEvent records a telemetry event and extracts FPS data.
+func (b *Backend) RecordTelemetryEvent(e *core.TelemetryEvent) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.telemetryEvents = append(b.telemetryEvents, *e)
+	b.serverFpsEvents = append(b.serverFpsEvents, core.ServerFpsEvent{
+		Time:         e.Time,
+		CaptureFrame: e.CaptureFrame,
+		FpsAverage:   e.FpsAverage,
+		FpsMin:       e.FpsMin,
+	})
 	return nil
 }
 

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -306,17 +306,11 @@ func (b *Backend) RecordServerFpsEvent(e *core.ServerFpsEvent) error {
 	return nil
 }
 
-// RecordTelemetryEvent records a telemetry event and extracts FPS data.
+// RecordTelemetryEvent records a telemetry event.
 func (b *Backend) RecordTelemetryEvent(e *core.TelemetryEvent) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.telemetryEvents = append(b.telemetryEvents, *e)
-	b.serverFpsEvents = append(b.serverFpsEvents, core.ServerFpsEvent{
-		Time:         e.Time,
-		CaptureFrame: e.CaptureFrame,
-		FpsAverage:   e.FpsAverage,
-		FpsMin:       e.FpsMin,
-	})
 	return nil
 }
 

--- a/internal/storage/memory/memory_test.go
+++ b/internal/storage/memory/memory_test.go
@@ -362,20 +362,6 @@ func TestRecordRadioEvent(t *testing.T) {
 	assert.Len(t, b.radioEvents, 1)
 }
 
-func TestRecordServerFpsEvent(t *testing.T) {
-	b := New(config.MemoryConfig{})
-
-	evt := &core.ServerFpsEvent{
-		CaptureFrame: 400,
-		FpsAverage:   45.5,
-		FpsMin:       30.0,
-	}
-
-	require.NoError(t, b.RecordServerFpsEvent(evt))
-
-	assert.Len(t, b.serverFpsEvents, 1)
-}
-
 func TestRecordTimeState(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
@@ -520,7 +506,6 @@ func TestStartMissionResetsEverything(t *testing.T) {
 	require.NoError(t, b.RecordKillEvent(&core.KillEvent{}))
 	require.NoError(t, b.RecordChatEvent(&core.ChatEvent{}))
 	require.NoError(t, b.RecordRadioEvent(&core.RadioEvent{}))
-	require.NoError(t, b.RecordServerFpsEvent(&core.ServerFpsEvent{}))
 	require.NoError(t, b.RecordTimeState(&core.TimeState{}))
 	require.NoError(t, b.RecordAce3DeathEvent(&core.Ace3DeathEvent{}))
 	require.NoError(t, b.RecordAce3UnconsciousEvent(&core.Ace3UnconsciousEvent{}))
@@ -539,7 +524,6 @@ func TestStartMissionResetsEverything(t *testing.T) {
 	assert.Len(t, b.killEvents, 0)
 	assert.Len(t, b.chatEvents, 0)
 	assert.Len(t, b.radioEvents, 0)
-	assert.Len(t, b.serverFpsEvents, 0)
 	assert.Len(t, b.timeStates, 0)
 	assert.Len(t, b.ace3DeathEvents, 0)
 	assert.Len(t, b.ace3UnconsciousEvents, 0)

--- a/internal/storage/memory/memory_test.go
+++ b/internal/storage/memory/memory_test.go
@@ -362,6 +362,21 @@ func TestRecordRadioEvent(t *testing.T) {
 	assert.Len(t, b.radioEvents, 1)
 }
 
+func TestRecordTelemetryEvent(t *testing.T) {
+	b := New(config.MemoryConfig{})
+
+	evt := &core.TelemetryEvent{
+		CaptureFrame: 100,
+		FpsAverage:   45.5,
+		FpsMin:       30.0,
+	}
+
+	require.NoError(t, b.RecordTelemetryEvent(evt))
+
+	assert.Len(t, b.telemetryEvents, 1)
+	assert.Equal(t, float32(45.5), b.telemetryEvents[0].FpsAverage)
+}
+
 func TestRecordTimeState(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
@@ -506,6 +521,7 @@ func TestStartMissionResetsEverything(t *testing.T) {
 	require.NoError(t, b.RecordKillEvent(&core.KillEvent{}))
 	require.NoError(t, b.RecordChatEvent(&core.ChatEvent{}))
 	require.NoError(t, b.RecordRadioEvent(&core.RadioEvent{}))
+	require.NoError(t, b.RecordTelemetryEvent(&core.TelemetryEvent{}))
 	require.NoError(t, b.RecordTimeState(&core.TimeState{}))
 	require.NoError(t, b.RecordAce3DeathEvent(&core.Ace3DeathEvent{}))
 	require.NoError(t, b.RecordAce3UnconsciousEvent(&core.Ace3UnconsciousEvent{}))
@@ -524,6 +540,7 @@ func TestStartMissionResetsEverything(t *testing.T) {
 	assert.Len(t, b.killEvents, 0)
 	assert.Len(t, b.chatEvents, 0)
 	assert.Len(t, b.radioEvents, 0)
+	assert.Len(t, b.telemetryEvents, 0)
 	assert.Len(t, b.timeStates, 0)
 	assert.Len(t, b.ace3DeathEvents, 0)
 	assert.Len(t, b.ace3UnconsciousEvents, 0)

--- a/internal/storage/postgres/postgres.go
+++ b/internal/storage/postgres/postgres.go
@@ -335,6 +335,19 @@ func (b *Backend) RecordServerFpsEvent(e *core.ServerFpsEvent) error {
 	return nil
 }
 
+// RecordTelemetryEvent extracts FPS data and queues it.
+// Full telemetry data is not stored in the database.
+func (b *Backend) RecordTelemetryEvent(e *core.TelemetryEvent) error {
+	fpsEvent := convert.CoreToServerFpsEvent(core.ServerFpsEvent{
+		Time:         e.Time,
+		CaptureFrame: e.CaptureFrame,
+		FpsAverage:   e.FpsAverage,
+		FpsMin:       e.FpsMin,
+	})
+	b.queues.FpsEvents.Push(fpsEvent)
+	return nil
+}
+
 // RecordTimeState is a no-op — TimeState is not in DatabaseModels, only used by memory backend.
 func (b *Backend) RecordTimeState(t *core.TimeState) error {
 	return nil

--- a/internal/storage/postgres/postgres.go
+++ b/internal/storage/postgres/postgres.go
@@ -328,23 +328,15 @@ func (b *Backend) RecordRadioEvent(e *core.RadioEvent) error {
 	return nil
 }
 
-// RecordServerFpsEvent converts and queues a server FPS event.
-func (b *Backend) RecordServerFpsEvent(e *core.ServerFpsEvent) error {
-	gormObj := convert.CoreToServerFpsEvent(*e)
-	b.queues.FpsEvents.Push(gormObj)
-	return nil
-}
-
-// RecordTelemetryEvent extracts FPS data and queues it.
+// RecordTelemetryEvent extracts FPS data and queues it for DB storage.
 // Full telemetry data is not stored in the database.
 func (b *Backend) RecordTelemetryEvent(e *core.TelemetryEvent) error {
-	fpsEvent := convert.CoreToServerFpsEvent(core.ServerFpsEvent{
+	b.queues.FpsEvents.Push(model.ServerFpsEvent{
 		Time:         e.Time,
 		CaptureFrame: e.CaptureFrame,
 		FpsAverage:   e.FpsAverage,
 		FpsMin:       e.FpsMin,
 	})
-	b.queues.FpsEvents.Push(fpsEvent)
 	return nil
 }
 

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -233,21 +233,6 @@ func TestRecordRadioEvent_QueuesToInternalQueue(t *testing.T) {
 	assert.Equal(t, 1, b.queues.RadioEvents.Len())
 }
 
-func TestRecordServerFpsEvent_QueuesToInternalQueue(t *testing.T) {
-	b := newTestBackend()
-	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
-	defer func() { require.NoError(t, b.Close()) }()
-
-	event := &core.ServerFpsEvent{
-		FpsAverage: 50.0,
-		FpsMin:     30.0,
-	}
-
-	err := b.RecordServerFpsEvent(event)
-	require.NoError(t, err)
-	assert.Equal(t, 1, b.queues.FpsEvents.Len())
-}
-
 func TestRecordAce3DeathEvent_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
 	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
@@ -614,7 +599,7 @@ func TestStartDBWriters_DrainsQueues(t *testing.T) {
 	require.NoError(t, b.RecordKillEvent(&core.KillEvent{CaptureFrame: 1}))
 	require.NoError(t, b.RecordChatEvent(&core.ChatEvent{Message: "hello", CaptureFrame: 1}))
 	require.NoError(t, b.RecordRadioEvent(&core.RadioEvent{CaptureFrame: 1}))
-	require.NoError(t, b.RecordServerFpsEvent(&core.ServerFpsEvent{FpsAverage: 50, FpsMin: 30, CaptureFrame: 1}))
+	require.NoError(t, b.RecordTelemetryEvent(&core.TelemetryEvent{FpsAverage: 50, FpsMin: 30, CaptureFrame: 1}))
 	require.NoError(t, b.RecordAce3DeathEvent(&core.Ace3DeathEvent{SoldierID: 1, CaptureFrame: 1}))
 	require.NoError(t, b.RecordAce3UnconsciousEvent(&core.Ace3UnconsciousEvent{SoldierID: 1, CaptureFrame: 1}))
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -32,7 +32,6 @@ type Backend interface {
 	RecordKillEvent(e *core.KillEvent) error
 	RecordChatEvent(e *core.ChatEvent) error
 	RecordRadioEvent(e *core.RadioEvent) error
-	RecordServerFpsEvent(e *core.ServerFpsEvent) error
 	RecordTelemetryEvent(e *core.TelemetryEvent) error
 	RecordTimeState(t *core.TimeState) error
 	RecordAce3DeathEvent(e *core.Ace3DeathEvent) error

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -33,6 +33,7 @@ type Backend interface {
 	RecordChatEvent(e *core.ChatEvent) error
 	RecordRadioEvent(e *core.RadioEvent) error
 	RecordServerFpsEvent(e *core.ServerFpsEvent) error
+	RecordTelemetryEvent(e *core.TelemetryEvent) error
 	RecordTimeState(t *core.TimeState) error
 	RecordAce3DeathEvent(e *core.Ace3DeathEvent) error
 	RecordAce3UnconsciousEvent(e *core.Ace3UnconsciousEvent) error

--- a/internal/storage/websocket/websocket.go
+++ b/internal/storage/websocket/websocket.go
@@ -165,10 +165,6 @@ func (b *Backend) RecordRadioEvent(e *core.RadioEvent) error {
 	return b.sendEnvelope(streaming.TypeRadioEvent, e)
 }
 
-func (b *Backend) RecordServerFpsEvent(e *core.ServerFpsEvent) error {
-	return b.sendEnvelope(streaming.TypeServerFps, e)
-}
-
 func (b *Backend) RecordTelemetryEvent(e *core.TelemetryEvent) error {
 	return b.sendEnvelope(streaming.TypeTelemetry, e)
 }

--- a/internal/storage/websocket/websocket.go
+++ b/internal/storage/websocket/websocket.go
@@ -169,6 +169,10 @@ func (b *Backend) RecordServerFpsEvent(e *core.ServerFpsEvent) error {
 	return b.sendEnvelope(streaming.TypeServerFps, e)
 }
 
+func (b *Backend) RecordTelemetryEvent(e *core.TelemetryEvent) error {
+	return b.sendEnvelope(streaming.TypeTelemetry, e)
+}
+
 func (b *Backend) RecordTimeState(t *core.TimeState) error {
 	return b.sendEnvelope(streaming.TypeTimeState, t)
 }

--- a/internal/storage/websocket/websocket_test.go
+++ b/internal/storage/websocket/websocket_test.go
@@ -158,7 +158,6 @@ func TestAllMessageTypes(t *testing.T) {
 	require.NoError(t, b.RecordKillEvent(&core.KillEvent{EventText: "killed"}))
 	require.NoError(t, b.RecordChatEvent(&core.ChatEvent{Message: "hello"}))
 	require.NoError(t, b.RecordRadioEvent(&core.RadioEvent{Radio: "ACRE"}))
-	require.NoError(t, b.RecordServerFpsEvent(&core.ServerFpsEvent{FpsAverage: 50}))
 	require.NoError(t, b.RecordTelemetryEvent(&core.TelemetryEvent{CaptureFrame: 1, FpsAverage: 45}))
 	require.NoError(t, b.RecordTimeState(&core.TimeState{MissionTime: 120}))
 	require.NoError(t, b.RecordAce3DeathEvent(&core.Ace3DeathEvent{SoldierID: 1, Reason: "bleeding"}))

--- a/internal/storage/websocket/websocket_test.go
+++ b/internal/storage/websocket/websocket_test.go
@@ -159,6 +159,7 @@ func TestAllMessageTypes(t *testing.T) {
 	require.NoError(t, b.RecordChatEvent(&core.ChatEvent{Message: "hello"}))
 	require.NoError(t, b.RecordRadioEvent(&core.RadioEvent{Radio: "ACRE"}))
 	require.NoError(t, b.RecordServerFpsEvent(&core.ServerFpsEvent{FpsAverage: 50}))
+	require.NoError(t, b.RecordTelemetryEvent(&core.TelemetryEvent{CaptureFrame: 1, FpsAverage: 45}))
 	require.NoError(t, b.RecordTimeState(&core.TimeState{MissionTime: 120}))
 	require.NoError(t, b.RecordAce3DeathEvent(&core.Ace3DeathEvent{SoldierID: 1, Reason: "bleeding"}))
 	require.NoError(t, b.RecordAce3UnconsciousEvent(&core.Ace3UnconsciousEvent{SoldierID: 1, IsUnconscious: true}))

--- a/internal/storage/websocket/websocket_test.go
+++ b/internal/storage/websocket/websocket_test.go
@@ -659,6 +659,38 @@ func TestWriteLoopExitsOnDone(t *testing.T) {
 	}
 }
 
+func TestWriteLoopSkipsNilConn(t *testing.T) {
+	srv, _ := testServer(t)
+	defer srv.Close()
+
+	c := newIdleConn(t, wsURL(srv))
+
+	// Set conn to nil so writeLoop hits the conn == nil continue path.
+	c.mu.Lock()
+	_ = c.conn.Close()
+	c.conn = nil
+	c.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		c.writeLoop()
+		close(done)
+	}()
+
+	// Push a message — writeLoop will see conn == nil and continue.
+	c.sendCh <- []byte(`{"type":"test"}`)
+
+	// Give it a moment to process, then shut down.
+	time.Sleep(50 * time.Millisecond)
+	c.close()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("writeLoop did not exit")
+	}
+}
+
 // --- readLoop error paths ---
 
 func TestReadLoopReconnectsOnError(t *testing.T) {

--- a/internal/worker/dispatch.go
+++ b/internal/worker/dispatch.go
@@ -29,7 +29,7 @@ func (m *Manager) RegisterHandlers(d *dispatcher.Dispatcher) {
 	d.Register(":EVENT:", m.handleGeneralEvent, dispatcher.Buffered(1000), dispatcher.Logged())
 	d.Register(":CHAT:", m.handleChatEvent, dispatcher.Buffered(1000), dispatcher.Logged())
 	d.Register(":RADIO:", m.handleRadioEvent, dispatcher.Buffered(1000), dispatcher.Logged())
-	d.Register(":FPS:", m.handleFpsEvent, dispatcher.Buffered(1000), dispatcher.Logged())
+	d.Register(":TELEMETRY:", m.handleTelemetryEvent, dispatcher.Buffered(100), dispatcher.Logged())
 
 	// ACE3 events - buffered
 	d.Register(":ACE3:DEATH:", m.handleAce3DeathEvent, dispatcher.Buffered(1000), dispatcher.Logged())
@@ -266,14 +266,14 @@ func (m *Manager) handleRadioEvent(e dispatcher.Event) (any, error) {
 	return nil, nil
 }
 
-func (m *Manager) handleFpsEvent(e dispatcher.Event) (any, error) {
-	obj, err := m.deps.ParserService.ParseFpsEvent(e.Args)
+func (m *Manager) handleTelemetryEvent(e dispatcher.Event) (any, error) {
+	obj, err := m.deps.ParserService.ParseTelemetryEvent(e.Args)
 	if err != nil {
-		return nil, fmt.Errorf("failed to log fps event: %w", err)
+		return nil, fmt.Errorf("failed to parse telemetry event: %w", err)
 	}
 
-	if err := m.backend.RecordServerFpsEvent(&obj); err != nil {
-		return nil, fmt.Errorf("record fps event: %w", err)
+	if err := m.backend.RecordTelemetryEvent(&obj); err != nil {
+		return nil, fmt.Errorf("record telemetry event: %w", err)
 	}
 	return nil, nil
 }

--- a/internal/worker/dispatch_test.go
+++ b/internal/worker/dispatch_test.go
@@ -55,7 +55,6 @@ type mockBackend struct {
 	killEvents     []*core.KillEvent
 	chatEvents        []*core.ChatEvent
 	radioEvents       []*core.RadioEvent
-	fpsEvents         []*core.ServerFpsEvent
 	telemetryEvents   []*core.TelemetryEvent
 	timeStates        []*core.TimeState
 	ace3Deaths        []*core.Ace3DeathEvent
@@ -188,13 +187,6 @@ func (b *mockBackend) RecordRadioEvent(e *core.RadioEvent) error {
 	return nil
 }
 
-func (b *mockBackend) RecordServerFpsEvent(e *core.ServerFpsEvent) error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	b.fpsEvents = append(b.fpsEvents, e)
-	return nil
-}
-
 func (b *mockBackend) RecordTelemetryEvent(e *core.TelemetryEvent) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -256,7 +248,6 @@ type mockParserService struct {
 	killEvent     parser.KillEvent
 	chatEvent     core.ChatEvent
 	radioEvent    core.RadioEvent
-	fpsEvent       core.ServerFpsEvent
 	telemetryEvent core.TelemetryEvent
 	timeState      core.TimeState
 	ace3Death     core.Ace3DeathEvent
@@ -371,16 +362,6 @@ func (h *mockParserService) ParseRadioEvent(args []string) (core.RadioEvent, err
 		return core.RadioEvent{}, errors.New(h.errorMsg)
 	}
 	return h.radioEvent, nil
-}
-
-func (h *mockParserService) ParseFpsEvent(args []string) (core.ServerFpsEvent, error) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.calls = append(h.calls, "ParseFpsEvent")
-	if h.returnError {
-		return core.ServerFpsEvent{}, errors.New(h.errorMsg)
-	}
-	return h.fpsEvent, nil
 }
 
 func (h *mockParserService) ParseTelemetryEvent(args []string) (core.TelemetryEvent, error) {

--- a/pkg/core/events.go
+++ b/pkg/core/events.go
@@ -158,3 +158,91 @@ type TimeState struct {
 	TimeMultiplier float32
 	MissionTime    float32
 }
+
+// TelemetryEvent represents a unified telemetry snapshot from the game server.
+// Replaces the old :FPS: and :METRIC: commands with a single :TELEMETRY: call.
+type TelemetryEvent struct {
+	Time         time.Time
+	CaptureFrame uint
+
+	// FPS data (also written to mission recording via ServerFpsEvent)
+	FpsAverage float32
+	FpsMin     float32
+
+	// Per-side entity counts: [east, west, independent, civilian]
+	SideEntityCounts [4]SideEntityCount
+
+	// Global entity counts (all sides combined)
+	GlobalCounts GlobalEntityCount
+
+	// Running script counts
+	Scripts ScriptCounts
+
+	// Weather snapshot
+	Weather WeatherData
+
+	// Per-player network stats (variable length)
+	Players []PlayerNetworkData
+}
+
+// SideEntityCount holds entity counts for a single side, split by locality.
+type SideEntityCount struct {
+	Local  EntityLocality
+	Remote EntityLocality
+}
+
+// EntityLocality holds entity counts for one locality (server-local or remote).
+type EntityLocality struct {
+	UnitsTotal    uint
+	UnitsAlive    uint
+	UnitsDead     uint
+	Groups        uint
+	Vehicles      uint
+	WeaponHolders uint
+}
+
+// GlobalEntityCount holds global entity counts across all sides.
+type GlobalEntityCount struct {
+	UnitsAlive        uint
+	UnitsDead         uint
+	Groups            uint
+	Vehicles          uint
+	WeaponHolders     uint
+	PlayersAlive      uint
+	PlayersDead       uint
+	PlayersConnected  uint
+}
+
+// ScriptCounts holds the number of running scripts by type.
+type ScriptCounts struct {
+	Spawn  uint
+	ExecVM uint
+	Exec   uint
+	ExecFSM uint
+	PFH    uint
+}
+
+// WeatherData holds a snapshot of the weather state.
+type WeatherData struct {
+	Fog           float32
+	Overcast      float32
+	Rain          float32
+	Humidity      float32
+	Waves         float32
+	WindDir       float32
+	WindStr       float32
+	Gusts         float32
+	Lightnings    float32
+	MoonIntensity float32
+	MoonPhase     float32
+	SunOrMoon     float32
+}
+
+// PlayerNetworkData holds network stats for a single player.
+type PlayerNetworkData struct {
+	UID     string
+	Name    string
+	Ping    float32
+	BW      float32
+	Desync  float32
+}

--- a/pkg/core/events.go
+++ b/pkg/core/events.go
@@ -88,15 +88,6 @@ type RadioEvent struct {
 	Code         string
 }
 
-// ServerFpsEvent represents server performance data
-type ServerFpsEvent struct {
-	ID           uint
-	Time         time.Time
-	CaptureFrame uint
-	FpsAverage   float32
-	FpsMin       float32
-}
-
 // Ace3DeathEvent represents ACE3 medical death
 type Ace3DeathEvent struct {
 	ID                 uint
@@ -165,7 +156,7 @@ type TelemetryEvent struct {
 	Time         time.Time
 	CaptureFrame uint
 
-	// FPS data (also written to mission recording via ServerFpsEvent)
+	// FPS data (also written to mission recording by DB backends)
 	FpsAverage float32
 	FpsMin     float32
 

--- a/pkg/core/events.go
+++ b/pkg/core/events.go
@@ -160,8 +160,8 @@ type TelemetryEvent struct {
 	FpsAverage float32
 	FpsMin     float32
 
-	// Per-side entity counts: [east, west, independent, civilian]
-	SideEntityCounts [4]SideEntityCount
+	// Per-side entity counts
+	SideEntityCounts SideEntityCounts
 
 	// Global entity counts (all sides combined)
 	GlobalCounts GlobalEntityCount
@@ -174,6 +174,14 @@ type TelemetryEvent struct {
 
 	// Per-player network stats (variable length)
 	Players []PlayerNetworkData
+}
+
+// SideEntityCounts holds entity counts for all four sides.
+type SideEntityCounts struct {
+	East        SideEntityCount
+	West        SideEntityCount
+	Independent SideEntityCount
+	Civilian    SideEntityCount
 }
 
 // SideEntityCount holds entity counts for a single side, split by locality.

--- a/pkg/streaming/messages.go
+++ b/pkg/streaming/messages.go
@@ -25,6 +25,7 @@ const (
 	TypeChatEvent       = "chat_event"
 	TypeRadioEvent      = "radio_event"
 	TypeServerFps       = "server_fps"
+	TypeTelemetry       = "telemetry"
 	TypeTimeState       = "time_state"
 	TypeAce3Death       = "ace3_death"
 	TypeAce3Unconscious = "ace3_unconscious"
@@ -37,7 +38,7 @@ var AllMessageTypes = []string{
 	TypeSoldierState, TypeVehicleState, TypeMarkerState, TypeDeleteMarker,
 	TypeFiredEvent, TypeProjectileEvent, TypeGeneralEvent,
 	TypeHitEvent, TypeKillEvent, TypeChatEvent, TypeRadioEvent,
-	TypeServerFps, TypeTimeState, TypeAce3Death, TypeAce3Unconscious,
+	TypeServerFps, TypeTelemetry, TypeTimeState, TypeAce3Death, TypeAce3Unconscious,
 }
 
 // Envelope wraps all messages sent over the WebSocket.

--- a/pkg/streaming/messages.go
+++ b/pkg/streaming/messages.go
@@ -24,7 +24,6 @@ const (
 	TypeKillEvent       = "kill_event"
 	TypeChatEvent       = "chat_event"
 	TypeRadioEvent      = "radio_event"
-	TypeServerFps       = "server_fps"
 	TypeTelemetry       = "telemetry"
 	TypeTimeState       = "time_state"
 	TypeAce3Death       = "ace3_death"
@@ -38,7 +37,7 @@ var AllMessageTypes = []string{
 	TypeSoldierState, TypeVehicleState, TypeMarkerState, TypeDeleteMarker,
 	TypeFiredEvent, TypeProjectileEvent, TypeGeneralEvent,
 	TypeHitEvent, TypeKillEvent, TypeChatEvent, TypeRadioEvent,
-	TypeServerFps, TypeTelemetry, TypeTimeState, TypeAce3Death, TypeAce3Unconscious,
+	TypeTelemetry, TypeTimeState, TypeAce3Death, TypeAce3Unconscious,
 }
 
 // Envelope wraps all messages sent over the WebSocket.


### PR DESCRIPTION
## Summary

- Add `:TELEMETRY:` command handler that receives a single JSON array containing FPS, per-side entity counts, global counts, running scripts, weather, and player network data
- Route FPS data to mission recording (all backends) for backwards-compatible playback
- Stream full telemetry over WebSocket for real-time web visualization
- Remove old `:FPS:` worker handler and `:METRIC:` lifecycle stub

## Design

Extension receives one call per 10s tick instead of 11+. The SQF addon sends raw counts; the extension owns all parsing and routing.

**Data flow:** SQF → single JSON array → `ParseTelemetryEvent` → `RecordTelemetryEvent` on storage backend

**Storage routing:**
| Backend | Behavior |
|---------|----------|
| Memory | Stores telemetry + extracts FPS to `serverFpsEvents` |
| Postgres/SQLite | Extracts FPS to existing `ServerFpsEvent` queue |
| WebSocket | Sends full `TelemetryEvent` as `"telemetry"` envelope |

## Files changed (13)

- `pkg/core/events.go` — `TelemetryEvent` + 6 sub-types
- `internal/parser/parser.go` — `ParseTelemetryEvent` on `Service` interface
- `internal/parser/parse_events.go` — JSON array parser implementation
- `internal/storage/storage.go` — `RecordTelemetryEvent` on `Backend` interface
- `internal/storage/memory/memory.go` — stores telemetry + extracts FPS
- `internal/storage/postgres/postgres.go` — extracts FPS to queue
- `internal/storage/websocket/websocket.go` — sends full telemetry
- `pkg/streaming/messages.go` — `TypeTelemetry = "telemetry"`
- `internal/worker/dispatch.go` — `:TELEMETRY:` replaces `:FPS:`
- `cmd/ocap_recorder/main.go` — removes `:METRIC:` stub

## Test plan

- [x] `go vet ./...` clean
- [x] `go test -count=1 ./...` — all 16 suites pass
- [x] Parser tests cover valid payload, empty players, bad JSON, missing elements, bad frame, bad FPS
- [x] Worker dispatch test validates `:TELEMETRY:` registration and end-to-end mock flow
- [x] WebSocket `TestAllMessageTypes` includes `"telemetry"` message type