### PR TITLE
fix: update entity metadata when player takes over AI unit

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -65,6 +65,13 @@ func (c *EntityCache) AddSoldier(s core.Soldier) {
 	c.soldiers[s.ID] = s
 }
 
+// UpdateSoldier replaces the cached soldier entry for the given ID.
+func (c *EntityCache) UpdateSoldier(s core.Soldier) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.soldiers[s.ID] = s
+}
+
 func (c *EntityCache) AddVehicle(v core.Vehicle) {
 	c.m.Lock()
 	defer c.m.Unlock()

--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -97,12 +97,24 @@ func Build(data *MissionData) Export {
 
 	// Convert soldiers - place at index matching their ID
 	for _, record := range data.Soldiers {
+		// Derive IsPlayer and Name from states (source of truth for time-varying fields).
+		// "Ever-a-player": once a player takes over an AI unit, the entity stays a player.
+		isPlayer := record.Soldier.IsPlayer
+		name := record.Soldier.UnitName
+		for _, state := range record.States {
+			if state.IsPlayer && !isPlayer {
+				isPlayer = true
+				name = state.UnitName
+				break
+			}
+		}
+
 		entity := Entity{
 			ID:            record.Soldier.ID,
-			Name:          record.Soldier.UnitName,
+			Name:          name,
 			Group:         record.Soldier.GroupID,
 			Side:          record.Soldier.Side,
-			IsPlayer:      boolToInt(record.Soldier.IsPlayer),
+			IsPlayer:      boolToInt(isPlayer),
 			Type:          "unit",
 			Role:          record.Soldier.RoleDescription,
 			StartFrameNum: record.Soldier.JoinFrame,

--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -102,10 +102,9 @@ func Build(data *MissionData) Export {
 		isPlayer := record.Soldier.IsPlayer
 		name := record.Soldier.UnitName
 		for _, state := range record.States {
-			if state.IsPlayer && !isPlayer {
+			if state.IsPlayer {
 				isPlayer = true
 				name = state.UnitName
-				break
 			}
 		}
 

--- a/internal/worker/dispatch.go
+++ b/internal/worker/dispatch.go
@@ -90,6 +90,13 @@ func (m *Manager) handleSoldierState(e dispatcher.Event) (any, error) {
 		obj.Side = soldier.Side
 	}
 
+	// Player takeover: once IsPlayer becomes true, update cached entity
+	if obj.IsPlayer && !soldier.IsPlayer {
+		soldier.IsPlayer = true
+		soldier.UnitName = obj.UnitName
+		m.deps.EntityCache.UpdateSoldier(soldier)
+	}
+
 	if err := m.backend.RecordSoldierState(&obj); err != nil {
 		return nil, fmt.Errorf("record soldier state: %w", err)
 	}

--- a/internal/worker/dispatch.go
+++ b/internal/worker/dispatch.go
@@ -90,8 +90,8 @@ func (m *Manager) handleSoldierState(e dispatcher.Event) (any, error) {
 		obj.Side = soldier.Side
 	}
 
-	// Player takeover: once IsPlayer becomes true, update cached entity
-	if obj.IsPlayer && !soldier.IsPlayer {
+	// Player takeover: update cached entity when isPlayer escalates or player name changes
+	if obj.IsPlayer && (!soldier.IsPlayer || soldier.UnitName != obj.UnitName) {
 		soldier.IsPlayer = true
 		soldier.UnitName = obj.UnitName
 		m.deps.EntityCache.UpdateSoldier(soldier)


### PR DESCRIPTION
## Summary

- When a player joins mid-game and takes over an AI unit, the entity-level metadata (name, isPlayer) was never updated — only per-frame `SoldierState` carried the correct values
- The JSON export used the stale initial `Soldier` registration data, so the player didn't appear in the player list on the web frontend
- Fix derives entity metadata from per-frame states (the single source of truth) rather than adding an `UpdateSoldier` method to the storage backend interface

## Changes

- **`internal/cache/cache.go`**: Add `UpdateSoldier` method for runtime cache updates
- **`internal/worker/dispatch.go`**: Detect `isPlayer` escalation in `handleSoldierState` and update cache
- **`internal/storage/memory/export/v1/builder.go`**: Scan states for first `isPlayer=true` frame and override entity-level Name/IsPlayer ("ever-a-player" semantics)

## Test plan

- [x] `TestHandleSoldierState_UpdatesCacheWhenPlayerTakesOver` — verifies cache updates on player takeover
- [x] `TestPlayerTakeoverUpdatesEntityMetadata` — verifies export builder derives correct entity metadata from states
- [x] Full test suite passes (`go test ./...`)