### PR TITLE
test: raise coverage for model, config, and worker packages

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,167 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoad_WithValidConfigFile(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	dir := t.TempDir()
+	cfg := `{
+		"logLevel": "debug",
+		"defaultTag": "PvP",
+		"db": { "host": "10.0.0.1", "port": "5433" }
+	}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ocap_recorder.cfg.json"), []byte(cfg), 0644))
+
+	err := Load(dir)
+	require.NoError(t, err)
+
+	assert.Equal(t, "debug", viper.GetString("logLevel"))
+	assert.Equal(t, "PvP", viper.GetString("defaultTag"))
+	assert.Equal(t, "10.0.0.1", viper.GetString("db.host"))
+	assert.Equal(t, "5433", viper.GetString("db.port"))
+}
+
+func TestLoad_DefaultValues(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ocap_recorder.cfg.json"), []byte(`{}`), 0644))
+
+	err := Load(dir)
+	require.NoError(t, err)
+
+	assert.Equal(t, "info", viper.GetString("logLevel"))
+	assert.Equal(t, "Op", viper.GetString("defaultTag"))
+	assert.Equal(t, "./ocaplogs", viper.GetString("logsDir"))
+	assert.Equal(t, "http://localhost:5000/api", viper.GetString("api.serverUrl"))
+	assert.Equal(t, "", viper.GetString("api.apiKey"))
+	assert.Equal(t, "localhost", viper.GetString("db.host"))
+	assert.Equal(t, "5432", viper.GetString("db.port"))
+	assert.Equal(t, "postgres", viper.GetString("db.username"))
+	assert.Equal(t, "postgres", viper.GetString("db.password"))
+	assert.Equal(t, "ocap", viper.GetString("db.database"))
+	assert.Equal(t, true, viper.GetBool("graylog.enabled"))
+	assert.Equal(t, "localhost:12201", viper.GetString("graylog.address"))
+	assert.Equal(t, true, viper.GetBool("logio.enabled"))
+	assert.Equal(t, "localhost", viper.GetString("logio.host"))
+	assert.Equal(t, "28777", viper.GetString("logio.port"))
+	assert.Equal(t, "memory", viper.GetString("storage.type"))
+	assert.Equal(t, "./recordings", viper.GetString("storage.memory.outputDir"))
+	assert.Equal(t, true, viper.GetBool("storage.memory.compressOutput"))
+	assert.Equal(t, "3m", viper.GetString("storage.sqlite.dumpInterval"))
+	assert.Equal(t, false, viper.GetBool("otel.enabled"))
+	assert.Equal(t, "ocap-recorder", viper.GetString("otel.serviceName"))
+	assert.Equal(t, "5s", viper.GetString("otel.batchTimeout"))
+	assert.Equal(t, "", viper.GetString("otel.endpoint"))
+	assert.Equal(t, true, viper.GetBool("otel.insecure"))
+}
+
+func TestLoad_MissingFile(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	err := Load("/nonexistent/path")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error reading config file")
+}
+
+func TestGetString(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	viper.Set("testKey", "testValue")
+	assert.Equal(t, "testValue", GetString("testKey"))
+}
+
+func TestGetInt(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	viper.Set("testInt", 42)
+	assert.Equal(t, 42, GetInt("testInt"))
+}
+
+func TestGetBool(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	viper.Set("testBool", true)
+	assert.Equal(t, true, GetBool("testBool"))
+}
+
+func TestGetStorageConfig_Defaults(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ocap_recorder.cfg.json"), []byte(`{}`), 0644))
+	require.NoError(t, Load(dir))
+
+	cfg := GetStorageConfig()
+	assert.Equal(t, "memory", cfg.Type)
+	assert.Equal(t, "./recordings", cfg.Memory.OutputDir)
+	assert.Equal(t, true, cfg.Memory.CompressOutput)
+	assert.Equal(t, 3*time.Minute, cfg.SQLite.DumpInterval)
+}
+
+func TestGetStorageConfig_Override(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	dir := t.TempDir()
+	cfg := `{
+		"storage": {
+			"type": "sqlite",
+			"memory": { "outputDir": "/tmp/out", "compressOutput": false },
+			"sqlite": { "dumpInterval": "10m" }
+		}
+	}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ocap_recorder.cfg.json"), []byte(cfg), 0644))
+	require.NoError(t, Load(dir))
+
+	sc := GetStorageConfig()
+	assert.Equal(t, "sqlite", sc.Type)
+	assert.Equal(t, "/tmp/out", sc.Memory.OutputDir)
+	assert.Equal(t, false, sc.Memory.CompressOutput)
+	assert.Equal(t, 10*time.Minute, sc.SQLite.DumpInterval)
+}
+
+func TestGetOTelConfig_Defaults(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ocap_recorder.cfg.json"), []byte(`{}`), 0644))
+	require.NoError(t, Load(dir))
+
+	cfg := GetOTelConfig()
+	assert.Equal(t, false, cfg.Enabled)
+	assert.Equal(t, "ocap-recorder", cfg.ServiceName)
+	assert.Equal(t, 5*time.Second, cfg.BatchTimeout)
+	assert.Equal(t, "", cfg.Endpoint)
+	assert.Equal(t, true, cfg.Insecure)
+}
+
+func TestGetOTelConfig_Override(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	dir := t.TempDir()
+	cfg := `{
+		"otel": {
+			"enabled": true,
+			"serviceName": "my-service",
+			"batchTimeout": "30s",
+			"endpoint": "localhost:4317",
+			"insecure": false
+		}
+	}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ocap_recorder.cfg.json"), []byte(cfg), 0644))
+	require.NoError(t, Load(dir))
+
+	oc := GetOTelConfig()
+	assert.Equal(t, true, oc.Enabled)
+	assert.Equal(t, "my-service", oc.ServiceName)
+	assert.Equal(t, 30*time.Second, oc.BatchTimeout)
+	assert.Equal(t, "localhost:4317", oc.Endpoint)
+	assert.Equal(t, false, oc.Insecure)
+}

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -1,0 +1,43 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTableNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    interface{ TableName() string }
+		expected string
+	}{
+		{"OcapInfo", &OcapInfo{}, "ocap_infos"},
+		{"FrameData", &FrameData{}, "frame_data"},
+		{"AfterActionReview", &AfterActionReview{}, "after_action_reviews"},
+		{"World", &World{}, "worlds"},
+		{"Mission", &Mission{}, "missions"},
+		{"Addon", &Addon{}, "addons"},
+		{"Soldier", &Soldier{}, "soldiers"},
+		{"SoldierState", &SoldierState{}, "soldier_states"},
+		{"Vehicle", &Vehicle{}, "vehicles"},
+		{"VehicleState", &VehicleState{}, "vehicle_states"},
+		{"ProjectileEvent", &ProjectileEvent{}, "projectile_events"},
+		{"GeneralEvent", &GeneralEvent{}, "general_events"},
+		{"KillEvent", &KillEvent{}, "kill_events"},
+		{"Ace3DeathEvent", &Ace3DeathEvent{}, "ace3_death_events"},
+		{"Ace3UnconsciousEvent", &Ace3UnconsciousEvent{}, "ace3_unconscious_events"},
+		{"ChatEvent", &ChatEvent{}, "chat_events"},
+		{"RadioEvent", &RadioEvent{}, "radio_events"},
+		{"ServerFpsEvent", &ServerFpsEvent{}, "server_fps_events"},
+		{"TimeState", &TimeState{}, "time_states"},
+		{"Marker", &Marker{}, "markers"},
+		{"MarkerState", &MarkerState{}, "marker_states"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.model.TableName())
+		})
+	}
+}

--- a/internal/worker/dispatch_test.go
+++ b/internal/worker/dispatch_test.go
@@ -644,7 +644,7 @@ func TestHandleSoldierState_ValidatesAndFillsGroupSide(t *testing.T) {
 }
 
 func TestHandleSoldierState_ReturnsErrorWhenNotCached(t *testing.T) {
-	d, _ := newTestDispatcher(t)
+	d, logger := newTestDispatcher(t)
 	entityCache := cache.NewEntityCache()
 	// No soldier cached
 
@@ -662,8 +662,7 @@ func TestHandleSoldierState_ReturnsErrorWhenNotCached(t *testing.T) {
 	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:SOLDIER:STATE:", Args: []string{}})
 	require.NoError(t, err) // dispatch itself doesn't error for buffered handlers
 
-	// Give buffer time to process
-	time.Sleep(200 * time.Millisecond)
+	waitForLogMsg(t, logger, "buffered handler failed")
 
 	// Backend should have no states since the soldier wasn't cached
 	backend.mu.Lock()
@@ -672,7 +671,7 @@ func TestHandleSoldierState_ReturnsErrorWhenNotCached(t *testing.T) {
 }
 
 func TestHandleVehicleState_ReturnsErrorWhenNotCached(t *testing.T) {
-	d, _ := newTestDispatcher(t)
+	d, logger := newTestDispatcher(t)
 	entityCache := cache.NewEntityCache()
 
 	parserService := &mockParserService{
@@ -689,7 +688,7 @@ func TestHandleVehicleState_ReturnsErrorWhenNotCached(t *testing.T) {
 	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:VEHICLE:STATE:", Args: []string{}})
 	require.NoError(t, err)
 
-	time.Sleep(200 * time.Millisecond)
+	waitForLogMsg(t, logger, "buffered handler failed")
 
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
@@ -949,7 +948,7 @@ func TestHandleMarkerMove_ResolvesMarkerName(t *testing.T) {
 }
 
 func TestHandleChatEvent_ValidatesSender(t *testing.T) {
-	d, _ := newTestDispatcher(t)
+	d, logger := newTestDispatcher(t)
 	entityCache := cache.NewEntityCache()
 	// No soldier cached — sender validation should fail
 
@@ -970,7 +969,7 @@ func TestHandleChatEvent_ValidatesSender(t *testing.T) {
 	_, err := d.Dispatch(dispatcher.Event{Command: ":CHAT:", Args: []string{}})
 	require.NoError(t, err) // buffered dispatch doesn't return handler errors
 
-	time.Sleep(200 * time.Millisecond)
+	waitForLogMsg(t, logger, "event failed")
 
 	// Chat event should not be recorded since sender doesn't exist
 	backend.mu.Lock()

--- a/internal/worker/dispatch_test.go
+++ b/internal/worker/dispatch_test.go
@@ -232,6 +232,26 @@ func (b *errorBackend) AddMarker(_ *core.Marker) (uint, error) {
 	return 0, b.err
 }
 
+// addSoldierErrorBackend returns an error from AddSoldier.
+type addSoldierErrorBackend struct {
+	mockBackend
+	err error
+}
+
+func (b *addSoldierErrorBackend) AddSoldier(_ *core.Soldier) error {
+	return b.err
+}
+
+// addVehicleErrorBackend returns an error from AddVehicle.
+type addVehicleErrorBackend struct {
+	mockBackend
+	err error
+}
+
+func (b *addVehicleErrorBackend) AddVehicle(_ *core.Vehicle) error {
+	return b.err
+}
+
 // mockParserService provides a minimal implementation for testing
 type mockParserService struct {
 	mu sync.Mutex
@@ -1386,4 +1406,598 @@ func TestClassifyEntity_NotFound(t *testing.T) {
 	soldierID, vehicleID := manager.classifyEntity(999)
 	assert.Nil(t, soldierID)
 	assert.Nil(t, vehicleID)
+}
+
+func TestClassifyEntity_Soldier(t *testing.T) {
+	entityCache := cache.NewEntityCache()
+	entityCache.AddSoldier(core.Soldier{ID: 7})
+
+	manager := NewManager(Dependencies{
+		EntityCache: entityCache,
+		LogManager:  logging.NewSlogManager(),
+	}, &mockBackend{})
+
+	soldierID, vehicleID := manager.classifyEntity(7)
+	require.NotNil(t, soldierID)
+	assert.Equal(t, uint(7), *soldierID)
+	assert.Nil(t, vehicleID)
+}
+
+func TestClassifyHitParts_EntityNotFound(t *testing.T) {
+	entityCache := cache.NewEntityCache()
+	// Entity 99 is not in either cache
+
+	manager := NewManager(Dependencies{
+		EntityCache: entityCache,
+		LogManager:  logging.NewSlogManager(),
+	}, &mockBackend{})
+
+	hits := manager.classifyHitParts([]parser.HitPart{
+		{EntityID: 99, ComponentsHit: []string{"body"}, CaptureFrame: 100},
+	})
+	assert.Empty(t, hits, "unknown entity should be skipped")
+}
+
+// --- Parser error tests for sync handlers ---
+
+func TestHandleNewSoldier_ParserError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{returnError: true, errorMsg: "bad soldier data"}
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:SOLDIER:", Args: []string{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to log new soldier")
+}
+
+func TestHandleNewVehicle_ParserError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{returnError: true, errorMsg: "bad vehicle data"}
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:VEHICLE:", Args: []string{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to log new vehicle")
+}
+
+func TestHandleMarkerCreate_ParserError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{returnError: true, errorMsg: "bad marker data"}
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+		MarkerCache:   cache.NewMarkerCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:MARKER:", Args: []string{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create marker")
+}
+
+// --- Backend error tests for sync handlers ---
+
+func TestHandleNewSoldier_BackendError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+	entityCache := cache.NewEntityCache()
+
+	parserService := &mockParserService{
+		soldier: core.Soldier{ID: 42, UnitName: "Test"},
+	}
+	backend := &addSoldierErrorBackend{err: errors.New("db write failed")}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   entityCache,
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:SOLDIER:", Args: []string{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "add soldier")
+
+	// Soldier should still be in cache (cached before backend call)
+	_, found := entityCache.GetSoldier(42)
+	assert.True(t, found, "soldier should be in cache even when backend fails")
+}
+
+func TestHandleNewVehicle_BackendError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+	entityCache := cache.NewEntityCache()
+
+	parserService := &mockParserService{
+		vehicle: core.Vehicle{ID: 99, OcapType: "tank"},
+	}
+	backend := &addVehicleErrorBackend{err: errors.New("db write failed")}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   entityCache,
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:VEHICLE:", Args: []string{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "add vehicle")
+
+	// Vehicle should still be in cache
+	_, found := entityCache.GetVehicle(99)
+	assert.True(t, found, "vehicle should be in cache even when backend fails")
+}
+
+// --- Parser error tests for buffered handlers ---
+
+func TestHandleSoldierState_ParserError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{returnError: true, errorMsg: "bad state"}
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:SOLDIER:STATE:", Args: []string{}})
+	require.NoError(t, err) // buffered dispatch doesn't return handler errors
+
+	time.Sleep(200 * time.Millisecond)
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.soldierStates)
+}
+
+func TestHandleVehicleState_ParserError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{returnError: true, errorMsg: "bad state"}
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:VEHICLE:STATE:", Args: []string{}})
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.vehicleStates)
+}
+
+func TestHandleTimeState_ParserError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{returnError: true, errorMsg: "bad time"}
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:TIME:STATE:", Args: []string{}})
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.timeStates)
+}
+
+func TestHandleProjectileEvent_ParserError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{returnError: true, errorMsg: "bad projectile"}
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":PROJECTILE:", Args: []string{}})
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.projectileEvents)
+}
+
+func TestHandleGeneralEvent_ParserError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{returnError: true, errorMsg: "bad event"}
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:", Args: []string{}})
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.generalEvents)
+}
+
+func TestHandleKillEvent_ParserError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{returnError: true, errorMsg: "bad kill"}
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":KILL:", Args: []string{}})
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.killEvents)
+}
+
+func TestHandleChatEvent_ParserError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{returnError: true, errorMsg: "bad chat"}
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":CHAT:", Args: []string{}})
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.chatEvents)
+}
+
+func TestHandleRadioEvent_ParserError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{returnError: true, errorMsg: "bad radio"}
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":RADIO:", Args: []string{}})
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.radioEvents)
+}
+
+func TestHandleTelemetryEvent_ParserError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{returnError: true, errorMsg: "bad telemetry"}
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":TELEMETRY:", Args: []string{}})
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.telemetryEvents)
+}
+
+func TestHandleAce3DeathEvent_ParserError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{returnError: true, errorMsg: "bad death"}
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":ACE3:DEATH:", Args: []string{}})
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.ace3Deaths)
+}
+
+func TestHandleAce3UnconsciousEvent_ParserError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{returnError: true, errorMsg: "bad uncon"}
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":ACE3:UNCONSCIOUS:", Args: []string{}})
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.ace3Uncon)
+}
+
+func TestHandleMarkerMove_ParserError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{returnError: true, errorMsg: "bad marker move"}
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+		MarkerCache:   cache.NewMarkerCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:MARKER:STATE:", Args: []string{}})
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.markerStates)
+}
+
+func TestHandleMarkerDelete_ParserError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{returnError: true, errorMsg: "bad marker delete"}
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+		MarkerCache:   cache.NewMarkerCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":DELETE:MARKER:", Args: []string{}})
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.deletedMarkers)
+}
+
+// --- Edge case tests ---
+
+func TestHandleChatEvent_NilSoldierID(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+	entityCache := cache.NewEntityCache()
+
+	parserService := &mockParserService{
+		chatEvent: core.ChatEvent{SoldierID: nil, CaptureFrame: 100, Channel: "system", Message: "Server message"},
+	}
+
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   entityCache,
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":CHAT:", Args: []string{}})
+	require.NoError(t, err)
+
+	waitFor(t, func() bool {
+		backend.mu.Lock()
+		n := len(backend.chatEvents)
+		backend.mu.Unlock()
+		return n > 0
+	}, "timed out waiting for chat event with nil sender")
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	require.Equal(t, 1, len(backend.chatEvents))
+	assert.Equal(t, "Server message", backend.chatEvents[0].Message)
+}
+
+func TestHandleRadioEvent_NilSoldierID(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+	entityCache := cache.NewEntityCache()
+
+	parserService := &mockParserService{
+		radioEvent: core.RadioEvent{SoldierID: nil, CaptureFrame: 100, Radio: "system"},
+	}
+
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   entityCache,
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":RADIO:", Args: []string{}})
+	require.NoError(t, err)
+
+	waitFor(t, func() bool {
+		backend.mu.Lock()
+		n := len(backend.radioEvents)
+		backend.mu.Unlock()
+		return n > 0
+	}, "timed out waiting for radio event with nil sender")
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	require.Equal(t, 1, len(backend.radioEvents))
+}
+
+func TestHandleRadioEvent_SenderNotCached(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+	entityCache := cache.NewEntityCache()
+
+	senderID := uint(77)
+	parserService := &mockParserService{
+		radioEvent: core.RadioEvent{SoldierID: &senderID, CaptureFrame: 100},
+	}
+
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   entityCache,
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":RADIO:", Args: []string{}})
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.radioEvents, "radio event should not be recorded when sender not cached")
+}
+
+func TestHandleMarkerMove_MarkerNotInCache(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+	markerCache := cache.NewMarkerCache()
+	// marker_beta is NOT in cache
+
+	parserService := &mockParserService{
+		markerMove: parser.MarkerMove{
+			CaptureFrame: 200,
+			MarkerName:   "marker_beta",
+		},
+	}
+
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+		MarkerCache:   markerCache,
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:MARKER:STATE:", Args: []string{}})
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.markerStates, "marker state should not be recorded when marker not in cache")
+}
+
+func TestHandleAce3DeathEvent_SoldierNotCached(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+	entityCache := cache.NewEntityCache()
+	// Soldier 50 is NOT in cache
+
+	parserService := &mockParserService{
+		ace3Death: core.Ace3DeathEvent{SoldierID: 50, CaptureFrame: 100, Reason: "bleedout"},
+	}
+
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   entityCache,
+		LogManager:    logging.NewSlogManager(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":ACE3:DEATH:", Args: []string{}})
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.ace3Deaths, "ace3 death should not be recorded when soldier not cached")
+}
+
+func TestHandleAce3DeathEvent_DamageSourceNotFound(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+	entityCache := cache.NewEntityCache()
+	entityCache.AddSoldier(core.Soldier{ID: 8}) // victim exists
+	// But damage source 99 is NOT in either cache
+
+	sourceID := uint(99)
+	parserService := &mockParserService{
+		ace3Death: core.Ace3DeathEvent{
+			SoldierID:          8,
+			CaptureFrame:       100,
+			Reason:             "bleedout",
+			LastDamageSourceID: &sourceID,
+		},
+	}
+
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   entityCache,
+		LogManager:    logging.NewSlogManager(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":ACE3:DEATH:", Args: []string{}})
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.ace3Deaths, "ace3 death should not be recorded when damage source not found")
+}
+
+func TestHandleAce3UnconsciousEvent_SoldierNotCached(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+	entityCache := cache.NewEntityCache()
+	// Soldier 60 is NOT in cache
+
+	parserService := &mockParserService{
+		ace3Uncon: core.Ace3UnconsciousEvent{SoldierID: 60, CaptureFrame: 100, IsUnconscious: true},
+	}
+
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   entityCache,
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":ACE3:UNCONSCIOUS:", Args: []string{}})
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.ace3Uncon, "ace3 unconscious should not be recorded when soldier not cached")
 }


### PR DESCRIPTION
## Summary
- Add `internal/model/model_test.go` — table-driven test for all 21 `TableName()` methods (0% → **100%**)
- Add `internal/config/config_test.go` — 10 tests covering `Load`, `Get*` wrappers, `GetStorageConfig`, `GetOTelConfig` with defaults and overrides (0% → **97.6%**)
- Extend `internal/worker/dispatch_test.go` — 27 new tests covering parser errors, backend errors, cache edge cases, and nil-sender bypass paths (78% → **92.4%**)

## Test plan
- [x] `go test ./internal/model/... ./internal/config/... ./internal/worker/... -cover` passes
- [x] `go test ./...` passes — no regressions