### PR TITLE
fix: stop truncating args in debug and addon logs

### DIFF
--- a/cmd/ocap_recorder/main.go
+++ b/cmd/ocap_recorder/main.go
@@ -367,7 +367,7 @@ func registerLifecycleHandlers(d *dispatcher.Dispatcher) {
 	d.Register(":LOG:", func(e dispatcher.Event) (any, error) {
 		if len(e.Args) > 0 {
 			msg := util.FixEscapeQuotes(util.TrimQuotes(e.Args[0]))
-			Logger.Info("Addon log", "message", msg)
+			Logger.Info("Addon log", "message", msg, "args", e.Args[1:])
 		}
 		return nil, nil
 	})

--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -247,7 +247,7 @@ func (d *Dispatcher) withGate(ready <-chan struct{}, h HandlerFunc) HandlerFunc 
 func (d *Dispatcher) withLogging(command string, h HandlerFunc) HandlerFunc {
 	return func(e Event) (any, error) {
 		start := time.Now()
-		d.logger.Debug("handling event", "command", command, "numArgs", len(e.Args), "args", truncateArgs(e.Args, 3))
+		d.logger.Debug("handling event", "command", command, "numArgs", len(e.Args), "args", e.Args)
 
 		result, err := h(e)
 
@@ -261,9 +261,3 @@ func (d *Dispatcher) withLogging(command string, h HandlerFunc) HandlerFunc {
 	}
 }
 
-func truncateArgs(args []string, n int) []string {
-	if len(args) <= n {
-		return args
-	}
-	return append(args[:n:n], fmt.Sprintf("...(+%d more)", len(args)-n))
-}

--- a/internal/dispatcher/dispatcher_test.go
+++ b/internal/dispatcher/dispatcher_test.go
@@ -307,12 +307,13 @@ func TestDispatcher_LoggedArgPreview(t *testing.T) {
 	for _, msg := range logger.messages {
 		if strings.Contains(msg, "handling event") && strings.Contains(msg, "620") && strings.Contains(msg, "350.811") {
 			found = true
-			// Should NOT contain the 4th+ args (truncated to 3)
-			assert.NotContains(t, msg, "extra1", "args should be truncated to 3")
+			// All args should be present (no truncation)
+			assert.Contains(t, msg, "extra1", "all args should be logged")
+			assert.Contains(t, msg, "extra2", "all args should be logged")
 			break
 		}
 	}
-	assert.True(t, found, "expected arg preview in handling event log")
+	assert.True(t, found, "expected all args in handling event log")
 }
 
 func TestDispatcher_GatedHandler(t *testing.T) {

--- a/internal/dispatcher/dispatcher_test.go
+++ b/internal/dispatcher/dispatcher_test.go
@@ -308,8 +308,7 @@ func TestDispatcher_LoggedArgPreview(t *testing.T) {
 		if strings.Contains(msg, "handling event") && strings.Contains(msg, "620") && strings.Contains(msg, "350.811") {
 			found = true
 			// All args should be present (no truncation)
-			assert.Contains(t, msg, "extra1", "all args should be logged")
-			assert.Contains(t, msg, "extra2", "all args should be logged")
+			assert.Contains(t, msg, "args [620 350.811 1 extra1 extra2]", "all args should be logged")
 			break
 		}
 	}


### PR DESCRIPTION
## Summary
- Remove arg truncation in dispatcher debug logs — all args are now logged fully
- Include `args` field in `:LOG:` handler so addon log messages show their data, not just the message string
- Remove unused `truncateArgs` helper

## Test plan
- [x] Updated `TestDispatcher_LoggedArgPreview` to assert all args are present
- [x] All dispatcher tests pass