### PR TITLE
feat: add placed object lifecycle events for mines/explosives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,18 +62,21 @@ GORM models for PostgreSQL/SQLite:
 - `Vehicle`, `VehicleState` - Vehicle tracking
 - `ProjectileEvent`, `ProjectileHitsSoldier`, `ProjectileHitsVehicle` - Combat events
 - `Marker`, `MarkerState` - Map marker tracking
+- `PlacedObject`, `PlacedObjectEvent` - Placed object (mine/explosive) tracking
 
 ### Commands
 
 | Command | Purpose |
 |---------|---------|
-| `:NEW:UNIT:`, `:NEW:VEH:` | Register new units/vehicles |
-| `:UPDATE:UNIT:`, `:UPDATE:VEH:` | Update position/state data |
-| `:EVENT:`, `:FIRED:` | Log gameplay events |
-| `:MARKER:CREATE/DELETE/MOVE:` | Marker operations |
-| `:START:` | Begin recording mission |
-| `:SAVE:` | End recording and finalize |
-| `:LOG:` | Custom log events |
+| `:NEW:SOLDIER:`, `:NEW:VEHICLE:` | Register new units/vehicles |
+| `:NEW:SOLDIER:STATE:`, `:NEW:VEHICLE:STATE:` | Update position/state data |
+| `:PROJECTILE:`, `:KILL:` | Combat events |
+| `:EVENT:`, `:CHAT:`, `:RADIO:`, `:TELEMETRY:` | General gameplay events |
+| `:NEW:MARKER:`, `:NEW:MARKER:STATE:`, `:DELETE:MARKER:` | Marker operations |
+| `:NEW:PLACED:`, `:PLACED:EVENT:` | Placed object (mine/explosive) lifecycle |
+| `:ACE3:DEATH:`, `:ACE3:UNCONSCIOUS:` | ACE3 integration events |
+| `:INIT:`, `:INIT:STORAGE:` | Initialize extension and storage |
+| `:NEW:MISSION:`, `:SAVE:MISSION:` | Begin/end recording |
 
 ### Data Flow
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,13 @@ Copy `ocap_recorder.cfg.json.example` to `ocap_recorder.cfg.json` alongside the 
 | `:NEW:MARKER:STATE:` | 1,000 | Update marker position/appearance |
 | `:DELETE:MARKER:` | 500 | Delete marker |
 
+### Placed Object Commands
+
+| Command | Buffer | Purpose |
+|---------|--------|---------|
+| `:NEW:PLACED:` | Sync | Register placed object (mine, explosive) |
+| `:PLACED:EVENT:` | 1,000 | Placed object lifecycle event (detonated/deleted) |
+
 ### ACE3 Integration
 
 | Command | Buffer | Purpose |

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -12,6 +12,7 @@ type EntityCache struct {
 	m        sync.Mutex
 	soldiers map[uint16]core.Soldier
 	vehicles map[uint16]core.Vehicle
+	placed   map[uint16]core.PlacedObject
 }
 
 func NewEntityCache() *EntityCache {
@@ -19,6 +20,7 @@ func NewEntityCache() *EntityCache {
 		m:        sync.Mutex{},
 		soldiers: make(map[uint16]core.Soldier),
 		vehicles: make(map[uint16]core.Vehicle),
+		placed:   make(map[uint16]core.PlacedObject),
 	}
 }
 
@@ -27,6 +29,7 @@ func (c *EntityCache) Reset() {
 	defer c.m.Unlock()
 	c.soldiers = make(map[uint16]core.Soldier)
 	c.vehicles = make(map[uint16]core.Vehicle)
+	c.placed = make(map[uint16]core.PlacedObject)
 }
 
 func (c *EntityCache) SoldierCount() int {
@@ -44,19 +47,15 @@ func (c *EntityCache) VehicleCount() int {
 func (c *EntityCache) GetSoldier(id uint16) (core.Soldier, bool) {
 	c.m.Lock()
 	defer c.m.Unlock()
-	if s, ok := c.soldiers[id]; ok {
-		return s, true
-	}
-	return core.Soldier{}, false
+	s, ok := c.soldiers[id]
+	return s, ok
 }
 
 func (c *EntityCache) GetVehicle(id uint16) (core.Vehicle, bool) {
 	c.m.Lock()
 	defer c.m.Unlock()
-	if v, ok := c.vehicles[id]; ok {
-		return v, true
-	}
-	return core.Vehicle{}, false
+	v, ok := c.vehicles[id]
+	return v, ok
 }
 
 func (c *EntityCache) AddSoldier(s core.Soldier) {
@@ -76,4 +75,17 @@ func (c *EntityCache) AddVehicle(v core.Vehicle) {
 	c.m.Lock()
 	defer c.m.Unlock()
 	c.vehicles[v.ID] = v
+}
+
+func (c *EntityCache) GetPlacedObject(id uint16) (core.PlacedObject, bool) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	p, ok := c.placed[id]
+	return p, ok
+}
+
+func (c *EntityCache) AddPlacedObject(p core.PlacedObject) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.placed[p.ID] = p
 }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -71,10 +71,13 @@ func TestEntityCache_Reset(t *testing.T) {
 	cache.AddSoldier(core.Soldier{ID: 1, UnitName: "Soldier 1"})
 	cache.AddSoldier(core.Soldier{ID: 2, UnitName: "Soldier 2"})
 	cache.AddVehicle(core.Vehicle{ID: 10, ClassName: "Vehicle 1"})
+	cache.AddPlacedObject(core.PlacedObject{ID: 50, DisplayName: "Mine"})
 
 	// Verify data exists
 	assert.Equal(t, 2, cache.SoldierCount())
 	assert.Equal(t, 1, cache.VehicleCount())
+	_, ok := cache.GetPlacedObject(50)
+	require.True(t, ok)
 
 	// Reset
 	cache.Reset()
@@ -82,10 +85,12 @@ func TestEntityCache_Reset(t *testing.T) {
 	// Verify data is cleared
 	assert.Equal(t, 0, cache.SoldierCount())
 	assert.Equal(t, 0, cache.VehicleCount())
+	_, ok = cache.GetPlacedObject(50)
+	assert.False(t, ok, "expected placed object to be cleared after reset")
 
 	// Verify we can still add data after reset
 	cache.AddSoldier(core.Soldier{ID: 3, UnitName: "Soldier 3"})
-	_, ok := cache.GetSoldier(3)
+	_, ok = cache.GetSoldier(3)
 	assert.True(t, ok, "expected to find soldier added after reset")
 }
 
@@ -102,6 +107,56 @@ func TestEntityCache_UpdateSoldier(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "zigster", got.UnitName)
 	assert.True(t, got.IsPlayer)
+}
+
+func TestEntityCache_AddAndGetPlacedObject(t *testing.T) {
+	cache := NewEntityCache()
+
+	placed := core.PlacedObject{
+		ID:          100,
+		ClassName:   "APERSMine_Range_Ammo",
+		DisplayName: "APERS Mine",
+	}
+
+	cache.AddPlacedObject(placed)
+
+	got, ok := cache.GetPlacedObject(100)
+	require.True(t, ok, "expected to find placed object with ID 100")
+	assert.Equal(t, uint16(100), got.ID)
+	assert.Equal(t, "APERS Mine", got.DisplayName)
+}
+
+func TestEntityCache_GetPlacedObject_NotFound(t *testing.T) {
+	cache := NewEntityCache()
+
+	_, ok := cache.GetPlacedObject(999)
+	assert.False(t, ok, "expected not to find placed object with ID 999")
+}
+
+func TestEntityCache_Reset_ClearsPlacedObjects(t *testing.T) {
+	cache := NewEntityCache()
+
+	cache.AddPlacedObject(core.PlacedObject{ID: 100, DisplayName: "Mine 1"})
+	cache.AddPlacedObject(core.PlacedObject{ID: 101, DisplayName: "Mine 2"})
+
+	// Verify data exists
+	_, ok := cache.GetPlacedObject(100)
+	require.True(t, ok)
+
+	// Reset
+	cache.Reset()
+
+	// Verify placed objects are cleared
+	_, ok = cache.GetPlacedObject(100)
+	assert.False(t, ok, "expected placed object 100 to be cleared after reset")
+	_, ok = cache.GetPlacedObject(101)
+	assert.False(t, ok, "expected placed object 101 to be cleared after reset")
+
+	// Verify we can still add data after reset
+	cache.AddPlacedObject(core.PlacedObject{ID: 200, DisplayName: "New Mine"})
+	got, ok := cache.GetPlacedObject(200)
+	assert.True(t, ok, "expected to find placed object added after reset")
+	assert.Equal(t, "New Mine", got.DisplayName)
 }
 
 func TestEntityCache_Concurrent(t *testing.T) {

--- a/internal/model/convert/to_gorm.go
+++ b/internal/model/convert/to_gorm.go
@@ -314,7 +314,7 @@ func CoreToPlacedObject(p core.PlacedObject) model.PlacedObject {
 
 // CoreToPlacedObjectEvent converts a core.PlacedObjectEvent to a GORM model.PlacedObjectEvent.
 func CoreToPlacedObjectEvent(e core.PlacedObjectEvent) model.PlacedObjectEvent {
-	return model.PlacedObjectEvent{
+	result := model.PlacedObjectEvent{
 		PlacedObjectID: e.PlacedID,
 		EventType:      e.EventType,
 		PositionX:      e.Position.X,
@@ -322,6 +322,11 @@ func CoreToPlacedObjectEvent(e core.PlacedObjectEvent) model.PlacedObjectEvent {
 		PositionZ:      e.Position.Z,
 		CaptureFrame:   uint(e.CaptureFrame),
 	}
+	if e.HitEntityID != nil {
+		id := uint(*e.HitEntityID)
+		result.HitEntityID = &id
+	}
+	return result
 }
 
 // CoreToProjectileEvent converts a core.ProjectileEvent to a GORM model.ProjectileEvent.

--- a/internal/model/convert/to_gorm.go
+++ b/internal/model/convert/to_gorm.go
@@ -326,6 +326,7 @@ func CoreToPlacedObjectEvent(e core.PlacedObjectEvent) model.PlacedObjectEvent {
 		id := uint(*e.HitEntityID)
 		result.HitEntityID = &id
 	}
+	result.HitComponents = componentsToJSON(e.HitComponents)
 	return result
 }
 

--- a/internal/model/convert/to_gorm.go
+++ b/internal/model/convert/to_gorm.go
@@ -326,7 +326,6 @@ func CoreToPlacedObjectEvent(e core.PlacedObjectEvent) model.PlacedObjectEvent {
 		id := uint(*e.HitEntityID)
 		result.HitEntityID = &id
 	}
-	result.HitComponents = componentsToJSON(e.HitComponents)
 	return result
 }
 

--- a/internal/model/convert/to_gorm.go
+++ b/internal/model/convert/to_gorm.go
@@ -294,6 +294,36 @@ func CoreToAce3UnconsciousEvent(e core.Ace3UnconsciousEvent) model.Ace3Unconscio
 	}
 }
 
+// CoreToPlacedObject converts a core.PlacedObject to a GORM model.PlacedObject.
+func CoreToPlacedObject(p core.PlacedObject) model.PlacedObject {
+	return model.PlacedObject{
+		ObjectID:     p.ID,
+		JoinTime:     p.JoinTime,
+		JoinFrame:    uint(p.JoinFrame),
+		ClassName:    p.ClassName,
+		DisplayName:  p.DisplayName,
+		PositionX:    p.Position.X,
+		PositionY:    p.Position.Y,
+		PositionZ:    p.Position.Z,
+		OwnerID:      p.OwnerID,
+		Side:         p.Side,
+		Weapon:       p.Weapon,
+		MagazineIcon: p.MagazineIcon,
+	}
+}
+
+// CoreToPlacedObjectEvent converts a core.PlacedObjectEvent to a GORM model.PlacedObjectEvent.
+func CoreToPlacedObjectEvent(e core.PlacedObjectEvent) model.PlacedObjectEvent {
+	return model.PlacedObjectEvent{
+		PlacedObjectID: e.PlacedID,
+		EventType:      e.EventType,
+		PositionX:      e.Position.X,
+		PositionY:      e.Position.Y,
+		PositionZ:      e.Position.Z,
+		CaptureFrame:   uint(e.CaptureFrame),
+	}
+}
+
 // CoreToProjectileEvent converts a core.ProjectileEvent to a GORM model.ProjectileEvent.
 // Converts trajectory points to a LineStringZM geometry and splits unified Hits
 // into separate HitSoldiers and HitVehicles slices.

--- a/internal/model/convert/to_gorm_test.go
+++ b/internal/model/convert/to_gorm_test.go
@@ -617,6 +617,56 @@ func TestCoreToWorld(t *testing.T) {
 	assert.Equal(t, 200.0, coord.Y)
 }
 
+func TestCoreToPlacedObject(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+
+	input := core.PlacedObject{
+		ID:           50,
+		JoinTime:     now,
+		JoinFrame:    200,
+		ClassName:    "APERSMine_Range_Mag",
+		DisplayName:  "APERS Mine",
+		Position:     core.Position3D{X: 1000.5, Y: 2000.5, Z: 10.0},
+		OwnerID:      5,
+		Side:         "WEST",
+		Weapon:       "put",
+		MagazineIcon: `\A3\Weapons_F\Data\UI\gear_mine_AP_ca.paa`,
+	}
+
+	result := CoreToPlacedObject(input)
+
+	assert.Equal(t, uint16(50), result.ObjectID)
+	assert.Equal(t, now, result.JoinTime)
+	assert.Equal(t, uint(200), result.JoinFrame)
+	assert.Equal(t, "APERSMine_Range_Mag", result.ClassName)
+	assert.Equal(t, "APERS Mine", result.DisplayName)
+	assert.Equal(t, 1000.5, result.PositionX)
+	assert.Equal(t, 2000.5, result.PositionY)
+	assert.Equal(t, 10.0, result.PositionZ)
+	assert.Equal(t, uint16(5), result.OwnerID)
+	assert.Equal(t, "WEST", result.Side)
+	assert.Equal(t, "put", result.Weapon)
+	assert.Equal(t, `\A3\Weapons_F\Data\UI\gear_mine_AP_ca.paa`, result.MagazineIcon)
+}
+
+func TestCoreToPlacedObjectEvent(t *testing.T) {
+	input := core.PlacedObjectEvent{
+		CaptureFrame: 500,
+		PlacedID:     50,
+		EventType:    "detonated",
+		Position:     core.Position3D{X: 1000.5, Y: 2000.5, Z: 10.0},
+	}
+
+	result := CoreToPlacedObjectEvent(input)
+
+	assert.Equal(t, uint16(50), result.PlacedObjectID)
+	assert.Equal(t, "detonated", result.EventType)
+	assert.Equal(t, 1000.5, result.PositionX)
+	assert.Equal(t, 2000.5, result.PositionY)
+	assert.Equal(t, 10.0, result.PositionZ)
+	assert.Equal(t, uint(500), result.CaptureFrame)
+}
+
 // Compile-time interface checks for CoreToX functions
 var (
 	_ model.Soldier              = CoreToSoldier(core.Soldier{})
@@ -633,4 +683,6 @@ var (
 	_ model.Ace3UnconsciousEvent = CoreToAce3UnconsciousEvent(core.Ace3UnconsciousEvent{})
 	_ model.ProjectileEvent      = CoreToProjectileEvent(core.ProjectileEvent{})
 	_ model.TimeState            = CoreToTimeState(core.TimeState{})
+	_ model.PlacedObject         = CoreToPlacedObject(core.PlacedObject{})
+	_ model.PlacedObjectEvent    = CoreToPlacedObjectEvent(core.PlacedObjectEvent{})
 )

--- a/internal/model/convert/to_gorm_test.go
+++ b/internal/model/convert/to_gorm_test.go
@@ -650,21 +650,42 @@ func TestCoreToPlacedObject(t *testing.T) {
 }
 
 func TestCoreToPlacedObjectEvent(t *testing.T) {
-	input := core.PlacedObjectEvent{
-		CaptureFrame: 500,
-		PlacedID:     50,
-		EventType:    "detonated",
-		Position:     core.Position3D{X: 1000.5, Y: 2000.5, Z: 10.0},
-	}
+	t.Run("detonated event", func(t *testing.T) {
+		input := core.PlacedObjectEvent{
+			CaptureFrame: 500,
+			PlacedID:     50,
+			EventType:    "detonated",
+			Position:     core.Position3D{X: 1000.5, Y: 2000.5, Z: 10.0},
+		}
 
-	result := CoreToPlacedObjectEvent(input)
+		result := CoreToPlacedObjectEvent(input)
 
-	assert.Equal(t, uint16(50), result.PlacedObjectID)
-	assert.Equal(t, "detonated", result.EventType)
-	assert.Equal(t, 1000.5, result.PositionX)
-	assert.Equal(t, 2000.5, result.PositionY)
-	assert.Equal(t, 10.0, result.PositionZ)
-	assert.Equal(t, uint(500), result.CaptureFrame)
+		assert.Equal(t, uint16(50), result.PlacedObjectID)
+		assert.Equal(t, "detonated", result.EventType)
+		assert.Equal(t, 1000.5, result.PositionX)
+		assert.Equal(t, 2000.5, result.PositionY)
+		assert.Equal(t, 10.0, result.PositionZ)
+		assert.Equal(t, uint(500), result.CaptureFrame)
+		assert.Nil(t, result.HitEntityID)
+	})
+
+	t.Run("hit event with entity", func(t *testing.T) {
+		hitID := uint16(12)
+		input := core.PlacedObjectEvent{
+			CaptureFrame: 450,
+			PlacedID:     50,
+			EventType:    "hit",
+			Position:     core.Position3D{X: 5100.5, Y: 3100.2, Z: 10.0},
+			HitEntityID:  &hitID,
+		}
+
+		result := CoreToPlacedObjectEvent(input)
+
+		assert.Equal(t, "hit", result.EventType)
+		assert.Equal(t, uint(450), result.CaptureFrame)
+		require.NotNil(t, result.HitEntityID)
+		assert.Equal(t, uint(12), *result.HitEntityID)
+	})
 }
 
 // Compile-time interface checks for CoreToX functions

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -35,6 +35,8 @@ var DatabaseModels = []interface{}{
 	&Ace3UnconsciousEvent{},
 	&Marker{},
 	&MarkerState{},
+	&PlacedObject{},
+	&PlacedObjectEvent{},
 }
 
 ////////////////////////
@@ -598,6 +600,48 @@ type Marker struct {
 
 func (*Marker) TableName() string {
 	return "markers"
+}
+
+// PlacedObject represents a placed object (mine, explosive, etc.)
+// Uses composite primary key (MissionID, ObjectID)
+type PlacedObject struct {
+	MissionID    uint      `json:"missionId" gorm:"primaryKey;autoIncrement:false"`
+	ObjectID     uint16    `json:"ocapId" gorm:"primaryKey;autoIncrement:false"`
+	Mission      Mission   `gorm:"foreignkey:MissionID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	CreatedAt    time.Time `json:"createdAt"`
+	JoinTime     time.Time `json:"joinTime" gorm:"type:timestamptz;NOT NULL"`
+	JoinFrame    uint      `json:"joinFrame"`
+	ClassName    string    `json:"className" gorm:"size:64"`
+	DisplayName  string    `json:"displayName" gorm:"size:64"`
+	PositionX    float64   `json:"positionX"`
+	PositionY    float64   `json:"positionY"`
+	PositionZ    float64   `json:"positionZ"`
+	OwnerID      uint16    `json:"ownerOcapId"`
+	Side         string    `json:"side" gorm:"size:16"`
+	Weapon       string    `json:"weapon" gorm:"size:64"`
+	MagazineIcon string    `json:"magazineIcon" gorm:"size:128"`
+}
+
+func (*PlacedObject) TableName() string {
+	return "placed_objects"
+}
+
+// PlacedObjectEvent represents a lifecycle event for a placed object
+type PlacedObjectEvent struct {
+	ID             uint      `json:"id" gorm:"primarykey;autoIncrement;"`
+	MissionID      uint      `json:"missionId" gorm:"index:idx_placedobjectevent_mission_id"`
+	Mission        Mission   `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MissionID;"`
+	PlacedObjectID uint16    `json:"placedOcapId" gorm:"index:idx_placedobjectevent_placed_ocap_id"`
+	EventType      string    `json:"eventType" gorm:"size:32"`
+	PositionX      float64   `json:"positionX"`
+	PositionY      float64   `json:"positionY"`
+	PositionZ      float64   `json:"positionZ"`
+	CaptureFrame   uint      `json:"captureFrame" gorm:"index:idx_placedobjectevent_capture_frame"`
+	CreatedAt      time.Time `json:"createdAt"`
+}
+
+func (*PlacedObjectEvent) TableName() string {
+	return "placed_object_events"
 }
 
 // MarkerState tracks marker position/property changes over time

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -636,8 +636,9 @@ type PlacedObjectEvent struct {
 	PositionX      float64   `json:"positionX"`
 	PositionY      float64   `json:"positionY"`
 	PositionZ      float64   `json:"positionZ"`
-	HitEntityID    *uint     `json:"hitEntityOcapId,omitempty" gorm:"index:idx_placedobjectevent_hit_entity_ocap_id;default:NULL"`
-	CaptureFrame   uint      `json:"captureFrame" gorm:"index:idx_placedobjectevent_capture_frame"`
+	HitEntityID    *uint           `json:"hitEntityOcapId,omitempty" gorm:"index:idx_placedobjectevent_hit_entity_ocap_id;default:NULL"`
+	HitComponents  datatypes.JSON `json:"componentsHit,omitempty"`
+	CaptureFrame   uint           `json:"captureFrame" gorm:"index:idx_placedobjectevent_capture_frame"`
 	CreatedAt      time.Time `json:"createdAt"`
 }
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -636,9 +636,8 @@ type PlacedObjectEvent struct {
 	PositionX      float64   `json:"positionX"`
 	PositionY      float64   `json:"positionY"`
 	PositionZ      float64   `json:"positionZ"`
-	HitEntityID    *uint           `json:"hitEntityOcapId,omitempty" gorm:"index:idx_placedobjectevent_hit_entity_ocap_id;default:NULL"`
-	HitComponents  datatypes.JSON `json:"componentsHit,omitempty"`
-	CaptureFrame   uint           `json:"captureFrame" gorm:"index:idx_placedobjectevent_capture_frame"`
+	HitEntityID    *uint     `json:"hitEntityOcapId,omitempty" gorm:"index:idx_placedobjectevent_hit_entity_ocap_id;default:NULL"`
+	CaptureFrame   uint      `json:"captureFrame" gorm:"index:idx_placedobjectevent_capture_frame"`
 	CreatedAt      time.Time `json:"createdAt"`
 }
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -636,6 +636,7 @@ type PlacedObjectEvent struct {
 	PositionX      float64   `json:"positionX"`
 	PositionY      float64   `json:"positionY"`
 	PositionZ      float64   `json:"positionZ"`
+	HitEntityID    *uint     `json:"hitEntityOcapId,omitempty" gorm:"index:idx_placedobjectevent_hit_entity_ocap_id;default:NULL"`
 	CaptureFrame   uint      `json:"captureFrame" gorm:"index:idx_placedobjectevent_capture_frame"`
 	CreatedAt      time.Time `json:"createdAt"`
 }

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -33,6 +33,8 @@ func TestTableNames(t *testing.T) {
 		{"TimeState", &TimeState{}, "time_states"},
 		{"Marker", &Marker{}, "markers"},
 		{"MarkerState", &MarkerState{}, "marker_states"},
+		{"PlacedObject", &PlacedObject{}, "placed_objects"},
+		{"PlacedObjectEvent", &PlacedObjectEvent{}, "placed_object_events"},
 	}
 
 	for _, tt := range tests {

--- a/internal/parser/parse_placed.go
+++ b/internal/parser/parse_placed.go
@@ -3,7 +3,6 @@ package parser
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/OCAP2/extension/v5/internal/geo"
@@ -73,7 +72,7 @@ func (p *Parser) ParsePlacedObject(data []string) (core.PlacedObject, error) {
 }
 
 // ParsePlacedObjectEvent parses placed object event data into a core PlacedObjectEvent.
-// Args: [frame, id, eventType, "x,y,z", hitEntityOcapId?, "comp1|comp2|..."?]
+// Args: [frame, id, eventType, "x,y,z", hitEntityOcapId?]
 func (p *Parser) ParsePlacedObjectEvent(data []string) (core.PlacedObjectEvent, error) {
 	var result core.PlacedObjectEvent
 
@@ -118,11 +117,6 @@ func (p *Parser) ParsePlacedObjectEvent(data []string) (core.PlacedObjectEvent, 
 		}
 		hitID16 := uint16(hitID)
 		result.HitEntityID = &hitID16
-	}
-
-	// [5] componentsHit (optional, pipe-separated, only for "hit" events)
-	if len(data) >= 6 && data[5] != "" {
-		result.HitComponents = strings.Split(data[5], "|")
 	}
 
 	return result, nil

--- a/internal/parser/parse_placed.go
+++ b/internal/parser/parse_placed.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/OCAP2/extension/v5/internal/geo"
@@ -72,7 +73,7 @@ func (p *Parser) ParsePlacedObject(data []string) (core.PlacedObject, error) {
 }
 
 // ParsePlacedObjectEvent parses placed object event data into a core PlacedObjectEvent.
-// Args: [frame, id, eventType, "x,y,z", hitEntityOcapId?]
+// Args: [frame, id, eventType, "x,y,z", hitEntityOcapId?, "comp1|comp2|..."?]
 func (p *Parser) ParsePlacedObjectEvent(data []string) (core.PlacedObjectEvent, error) {
 	var result core.PlacedObjectEvent
 
@@ -117,6 +118,11 @@ func (p *Parser) ParsePlacedObjectEvent(data []string) (core.PlacedObjectEvent, 
 		}
 		hitID16 := uint16(hitID)
 		result.HitEntityID = &hitID16
+	}
+
+	// [5] componentsHit (optional, pipe-separated, only for "hit" events)
+	if len(data) >= 6 && data[5] != "" {
+		result.HitComponents = strings.Split(data[5], "|")
 	}
 
 	return result, nil

--- a/internal/parser/parse_placed.go
+++ b/internal/parser/parse_placed.go
@@ -72,7 +72,7 @@ func (p *Parser) ParsePlacedObject(data []string) (core.PlacedObject, error) {
 }
 
 // ParsePlacedObjectEvent parses placed object event data into a core PlacedObjectEvent.
-// Args: [frame, id, eventType, "x,y,z"]
+// Args: [frame, id, eventType, "x,y,z", hitEntityOcapId?]
 func (p *Parser) ParsePlacedObjectEvent(data []string) (core.PlacedObjectEvent, error) {
 	var result core.PlacedObjectEvent
 
@@ -108,6 +108,16 @@ func (p *Parser) ParsePlacedObjectEvent(data []string) (core.PlacedObjectEvent, 
 		return result, fmt.Errorf("error parsing position: %w", err)
 	}
 	result.Position = pos3d
+
+	// [4] hitEntityOcapId (optional, only for "hit" events)
+	if len(data) >= 5 {
+		hitID, err := parseUintFromFloat(data[4])
+		if err != nil {
+			return result, fmt.Errorf("error parsing hitEntityOcapId: %w", err)
+		}
+		hitID16 := uint16(hitID)
+		result.HitEntityID = &hitID16
+	}
 
 	return result, nil
 }

--- a/internal/parser/parse_placed.go
+++ b/internal/parser/parse_placed.go
@@ -1,0 +1,113 @@
+package parser
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/OCAP2/extension/v5/internal/geo"
+	"github.com/OCAP2/extension/v5/internal/util"
+	"github.com/OCAP2/extension/v5/pkg/core"
+)
+
+// ParsePlacedObject parses placed object data into a core PlacedObject.
+// Args: [frame, id, className, displayName, "x,y,z", ownerOcapId, side, weapon, magazineIcon]
+func (p *Parser) ParsePlacedObject(data []string) (core.PlacedObject, error) {
+	var result core.PlacedObject
+
+	if len(data) < 9 {
+		return result, fmt.Errorf("insufficient data fields: got %d, need 9", len(data))
+	}
+
+	// fix received data
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	// [0] captureFrameNo
+	capframe, err := strconv.ParseFloat(data[0], 64)
+	if err != nil {
+		return result, fmt.Errorf("error parsing captureFrame: %w", err)
+	}
+	result.JoinFrame = core.Frame(capframe)
+	result.JoinTime = time.Now()
+
+	// [1] placedId
+	placedID, err := parseUintFromFloat(data[1])
+	if err != nil {
+		return result, fmt.Errorf("error parsing placedId: %w", err)
+	}
+	result.ID = uint16(placedID)
+
+	// [2] className
+	result.ClassName = data[2]
+
+	// [3] displayName
+	result.DisplayName = data[3]
+
+	// [4] position "x,y,z"
+	pos3d, err := geo.Position3DFromString(data[4])
+	if err != nil {
+		return result, fmt.Errorf("error parsing position: %w", err)
+	}
+	result.Position = pos3d
+
+	// [5] firerOcapId
+	ownerID, err := parseUintFromFloat(data[5])
+	if err != nil {
+		return result, fmt.Errorf("error parsing firerOcapId: %w", err)
+	}
+	result.OwnerID = uint16(ownerID)
+
+	// [6] side
+	result.Side = data[6]
+
+	// [7] weapon
+	result.Weapon = data[7]
+
+	// [8] magazineIcon
+	result.MagazineIcon = data[8]
+
+	return result, nil
+}
+
+// ParsePlacedObjectEvent parses placed object event data into a core PlacedObjectEvent.
+// Args: [frame, id, eventType, "x,y,z"]
+func (p *Parser) ParsePlacedObjectEvent(data []string) (core.PlacedObjectEvent, error) {
+	var result core.PlacedObjectEvent
+
+	if len(data) < 4 {
+		return result, fmt.Errorf("insufficient data fields: got %d, need 4", len(data))
+	}
+
+	// fix received data
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	// [0] captureFrameNo
+	capframe, err := strconv.ParseFloat(data[0], 64)
+	if err != nil {
+		return result, fmt.Errorf("error parsing captureFrame: %w", err)
+	}
+	result.CaptureFrame = core.Frame(capframe)
+
+	// [1] placedId
+	placedID, err := parseUintFromFloat(data[1])
+	if err != nil {
+		return result, fmt.Errorf("error parsing placedId: %w", err)
+	}
+	result.PlacedID = uint16(placedID)
+
+	// [2] eventType
+	result.EventType = data[2]
+
+	// [3] position "x,y,z"
+	pos3d, err := geo.Position3DFromString(data[3])
+	if err != nil {
+		return result, fmt.Errorf("error parsing position: %w", err)
+	}
+	result.Position = pos3d
+
+	return result, nil
+}

--- a/internal/parser/parse_placed_test.go
+++ b/internal/parser/parse_placed_test.go
@@ -154,13 +154,14 @@ func TestParsePlacedObjectEvent(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "hit event with target",
+			name: "hit event with target and components",
 			input: []string{
 				"450",              // 0: frame
 				"50",               // 1: placedId
 				"hit",              // 2: eventType
 				"5100.5,3100.2,10", // 3: position (victim pos)
 				"12",               // 4: hitEntityOcapId
+				"body|legs|head",   // 5: componentsHit
 			},
 			check: func(t *testing.T, evt core.PlacedObjectEvent) {
 				assert.Equal(t, core.Frame(450), evt.CaptureFrame)
@@ -171,6 +172,22 @@ func TestParsePlacedObjectEvent(t *testing.T) {
 				assert.InDelta(t, 10.0, evt.Position.Z, 0.01)
 				require.NotNil(t, evt.HitEntityID)
 				assert.Equal(t, uint16(12), *evt.HitEntityID)
+				assert.Equal(t, []string{"body", "legs", "head"}, evt.HitComponents)
+			},
+		},
+		{
+			name: "hit event without components",
+			input: []string{
+				"450",              // 0: frame
+				"50",               // 1: placedId
+				"hit",              // 2: eventType
+				"5100.5,3100.2,10", // 3: position (victim pos)
+				"12",               // 4: hitEntityOcapId
+			},
+			check: func(t *testing.T, evt core.PlacedObjectEvent) {
+				require.NotNil(t, evt.HitEntityID)
+				assert.Equal(t, uint16(12), *evt.HitEntityID)
+				assert.Nil(t, evt.HitComponents)
 			},
 		},
 		{

--- a/internal/parser/parse_placed_test.go
+++ b/internal/parser/parse_placed_test.go
@@ -1,0 +1,169 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/OCAP2/extension/v5/pkg/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePlacedObject(t *testing.T) {
+	p := newTestParser()
+
+	tests := []struct {
+		name    string
+		input   []string
+		check   func(t *testing.T, obj core.PlacedObject)
+		wantErr bool
+	}{
+		{
+			name: "mine placement",
+			input: []string{
+				"100",              // 0: frame
+				"50",               // 1: placedId
+				"APERSMine_Range",  // 2: className
+				"APERS Mine",      // 3: displayName
+				"5000.5,3000.2,10", // 4: position
+				"12",               // 5: firerOcapId
+				"WEST",             // 6: side
+				"put",              // 7: weapon
+				`\A3\icon.paa`,    // 8: magazineIcon
+			},
+			check: func(t *testing.T, obj core.PlacedObject) {
+				assert.Equal(t, core.Frame(100), obj.JoinFrame)
+				assert.Equal(t, uint16(50), obj.ID)
+				assert.Equal(t, "APERSMine_Range", obj.ClassName)
+				assert.Equal(t, "APERS Mine", obj.DisplayName)
+				assert.InDelta(t, 5000.5, obj.Position.X, 0.01)
+				assert.InDelta(t, 3000.2, obj.Position.Y, 0.01)
+				assert.InDelta(t, 10.0, obj.Position.Z, 0.01)
+				assert.Equal(t, uint16(12), obj.OwnerID)
+				assert.Equal(t, "WEST", obj.Side)
+				assert.Equal(t, "put", obj.Weapon)
+				assert.Equal(t, `\A3\icon.paa`, obj.MagazineIcon)
+			},
+		},
+		{
+			name: "float IDs",
+			input: []string{
+				"200.00", "25.00", "SatchelCharge", "Satchel Charge",
+				"1000,2000,5", "8.00", "EAST", "put", "icon.paa",
+			},
+			check: func(t *testing.T, obj core.PlacedObject) {
+				assert.Equal(t, core.Frame(200), obj.JoinFrame)
+				assert.Equal(t, uint16(25), obj.ID)
+				assert.Equal(t, uint16(8), obj.OwnerID)
+			},
+		},
+		{
+			name:    "error: insufficient fields",
+			input:   []string{"100", "50", "Mine"},
+			wantErr: true,
+		},
+		{
+			name:    "error: bad frame",
+			input:   []string{"abc", "50", "Mine", "Mine", "1,2,3", "12", "WEST", "put", "icon"},
+			wantErr: true,
+		},
+		{
+			name:    "error: bad placedId",
+			input:   []string{"100", "abc", "Mine", "Mine", "1,2,3", "12", "WEST", "put", "icon"},
+			wantErr: true,
+		},
+		{
+			name:    "error: bad position",
+			input:   []string{"100", "50", "Mine", "Mine", "bad", "12", "WEST", "put", "icon"},
+			wantErr: true,
+		},
+		{
+			name:    "error: bad ownerID",
+			input:   []string{"100", "50", "Mine", "Mine", "1,2,3", "abc", "WEST", "put", "icon"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := p.ParsePlacedObject(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			tt.check(t, result)
+		})
+	}
+}
+
+func TestParsePlacedObjectEvent(t *testing.T) {
+	p := newTestParser()
+
+	tests := []struct {
+		name    string
+		input   []string
+		check   func(t *testing.T, evt core.PlacedObjectEvent)
+		wantErr bool
+	}{
+		{
+			name: "detonation",
+			input: []string{
+				"500",              // 0: frame
+				"50",               // 1: placedId
+				"detonated",        // 2: eventType
+				"5000.5,3000.2,10", // 3: position
+			},
+			check: func(t *testing.T, evt core.PlacedObjectEvent) {
+				assert.Equal(t, core.Frame(500), evt.CaptureFrame)
+				assert.Equal(t, uint16(50), evt.PlacedID)
+				assert.Equal(t, "detonated", evt.EventType)
+				assert.InDelta(t, 5000.5, evt.Position.X, 0.01)
+				assert.InDelta(t, 3000.2, evt.Position.Y, 0.01)
+				assert.InDelta(t, 10.0, evt.Position.Z, 0.01)
+			},
+		},
+		{
+			name: "deleted",
+			input: []string{
+				"600.00", "25.00", "deleted", "1000,2000,5",
+			},
+			check: func(t *testing.T, evt core.PlacedObjectEvent) {
+				assert.Equal(t, core.Frame(600), evt.CaptureFrame)
+				assert.Equal(t, uint16(25), evt.PlacedID)
+				assert.Equal(t, "deleted", evt.EventType)
+			},
+		},
+		{
+			name:    "error: insufficient fields",
+			input:   []string{"500", "50"},
+			wantErr: true,
+		},
+		{
+			name:    "error: bad frame",
+			input:   []string{"abc", "50", "detonated", "1,2,3"},
+			wantErr: true,
+		},
+		{
+			name:    "error: bad placedId",
+			input:   []string{"500", "abc", "detonated", "1,2,3"},
+			wantErr: true,
+		},
+		{
+			name:    "error: bad position",
+			input:   []string{"500", "50", "detonated", "bad"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := p.ParsePlacedObjectEvent(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			tt.check(t, result)
+		})
+	}
+}

--- a/internal/parser/parse_placed_test.go
+++ b/internal/parser/parse_placed_test.go
@@ -154,14 +154,13 @@ func TestParsePlacedObjectEvent(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "hit event with target and components",
+			name: "hit event with target",
 			input: []string{
 				"450",              // 0: frame
 				"50",               // 1: placedId
 				"hit",              // 2: eventType
 				"5100.5,3100.2,10", // 3: position (victim pos)
 				"12",               // 4: hitEntityOcapId
-				"body|legs|head",   // 5: componentsHit
 			},
 			check: func(t *testing.T, evt core.PlacedObjectEvent) {
 				assert.Equal(t, core.Frame(450), evt.CaptureFrame)
@@ -172,22 +171,6 @@ func TestParsePlacedObjectEvent(t *testing.T) {
 				assert.InDelta(t, 10.0, evt.Position.Z, 0.01)
 				require.NotNil(t, evt.HitEntityID)
 				assert.Equal(t, uint16(12), *evt.HitEntityID)
-				assert.Equal(t, []string{"body", "legs", "head"}, evt.HitComponents)
-			},
-		},
-		{
-			name: "hit event without components",
-			input: []string{
-				"450",              // 0: frame
-				"50",               // 1: placedId
-				"hit",              // 2: eventType
-				"5100.5,3100.2,10", // 3: position (victim pos)
-				"12",               // 4: hitEntityOcapId
-			},
-			check: func(t *testing.T, evt core.PlacedObjectEvent) {
-				require.NotNil(t, evt.HitEntityID)
-				assert.Equal(t, uint16(12), *evt.HitEntityID)
-				assert.Nil(t, evt.HitComponents)
 			},
 		},
 		{

--- a/internal/parser/parse_placed_test.go
+++ b/internal/parser/parse_placed_test.go
@@ -153,6 +153,41 @@ func TestParsePlacedObjectEvent(t *testing.T) {
 			input:   []string{"500", "50", "detonated", "bad"},
 			wantErr: true,
 		},
+		{
+			name: "hit event with target",
+			input: []string{
+				"450",              // 0: frame
+				"50",               // 1: placedId
+				"hit",              // 2: eventType
+				"5100.5,3100.2,10", // 3: position (victim pos)
+				"12",               // 4: hitEntityOcapId
+			},
+			check: func(t *testing.T, evt core.PlacedObjectEvent) {
+				assert.Equal(t, core.Frame(450), evt.CaptureFrame)
+				assert.Equal(t, uint16(50), evt.PlacedID)
+				assert.Equal(t, "hit", evt.EventType)
+				assert.InDelta(t, 5100.5, evt.Position.X, 0.01)
+				assert.InDelta(t, 3100.2, evt.Position.Y, 0.01)
+				assert.InDelta(t, 10.0, evt.Position.Z, 0.01)
+				require.NotNil(t, evt.HitEntityID)
+				assert.Equal(t, uint16(12), *evt.HitEntityID)
+			},
+		},
+		{
+			name: "detonation has no hit entity",
+			input: []string{
+				"500", "50", "detonated", "5000.5,3000.2,10",
+			},
+			check: func(t *testing.T, evt core.PlacedObjectEvent) {
+				assert.Equal(t, "detonated", evt.EventType)
+				assert.Nil(t, evt.HitEntityID)
+			},
+		},
+		{
+			name:    "error: bad hitEntityOcapId",
+			input:   []string{"500", "50", "hit", "1,2,3", "abc"},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -70,6 +70,8 @@ type Service interface {
 	ParseMarkerMove(args []string) (MarkerMove, error)
 	ParseMarkerDelete(args []string) (*core.DeleteMarker, error)
 	ParseTelemetryEvent(args []string) (core.TelemetryEvent, error)
+	ParsePlacedObject(args []string) (core.PlacedObject, error)
+	ParsePlacedObjectEvent(args []string) (core.PlacedObjectEvent, error)
 }
 
 var _ Service = (*Parser)(nil)

--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -392,6 +392,23 @@ func Build(data *MissionData) Export {
 
 		_ = id // keyed by ID in the map, used for uniqueness
 		export.Markers = append(export.Markers, marker)
+
+		// Emit hit events from placed object HitExplosion data
+		for _, evt := range record.Events {
+			if evt.EventType == "hit" && evt.HitEntityID != nil {
+				dx := record.PlacedObject.Position.X - evt.Position.X
+				dy := record.PlacedObject.Position.Y - evt.Position.Y
+				dist := float32(math.Sqrt(dx*dx + dy*dy))
+
+				export.Events = append(export.Events, []any{
+					frameToV1(evt.CaptureFrame),
+					"hit",
+					uint(*evt.HitEntityID),
+					[]any{uint(record.PlacedObject.OwnerID), record.PlacedObject.DisplayName},
+					dist,
+				})
+			}
+		}
 	}
 
 	// Convert projectile events into firelines, markers, and hit events

--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -382,8 +382,8 @@ func Build(data *MissionData) Export {
 			frameToV1(record.PlacedObject.JoinFrame),    // [2] startFrame
 			placedEndFrame,                         // [3] endFrame
 			int(record.PlacedObject.OwnerID),       // [4] playerId
-			"ColorOrange",                          // [5] color
-			sideToIndex(record.PlacedObject.Side),  // [6] sideIndex
+			"D96600",                               // [5] color (orange hex)
+			-1,                                     // [6] sideIndex (GLOBAL — visible to all sides)
 			posArray,                               // [7] positions
 			[]float64{1, 1},                        // [8] size
 			"ICON",                                 // [9] shape

--- a/internal/storage/memory/export/v1/builder_test.go
+++ b/internal/storage/memory/export/v1/builder_test.go
@@ -1160,8 +1160,8 @@ func TestBuildWithPlacedObjectMarker(t *testing.T) {
 	assert.Equal(t, 199, marker[2])                              // startFrame (internal 200 → v1 199)
 	assert.Equal(t, 499, marker[3])                              // endFrame (internal 500 → v1 499)
 	assert.Equal(t, int(5), marker[4])                          // playerId (ownerID)
-	assert.Equal(t, "ColorOrange", marker[5])                   // color
-	assert.Equal(t, 1, marker[6])                               // sideIndex (WEST = 1)
+	assert.Equal(t, "D96600", marker[5])                        // color (orange hex)
+	assert.Equal(t, -1, marker[6])                              // sideIndex (GLOBAL)
 	assert.Equal(t, "ICON", marker[9])                          // shape
 	assert.Equal(t, "Solid", marker[10])                        // brush
 
@@ -1202,7 +1202,7 @@ func TestBuildWithPlacedObjectNoIcon(t *testing.T) {
 
 	assert.Equal(t, "Minefield", marker[0]) // fallback type
 	assert.Equal(t, -1, marker[3])          // endFrame -1 (no detonation/deletion event)
-	assert.Equal(t, 0, marker[6])           // sideIndex (EAST = 0)
+	assert.Equal(t, -1, marker[6])          // sideIndex (GLOBAL)
 }
 
 func TestBuildWithPlacedObjectDeletedEvent(t *testing.T) {
@@ -1234,7 +1234,7 @@ func TestBuildWithPlacedObjectDeletedEvent(t *testing.T) {
 
 	assert.Equal(t, "magIcons/gear_satchel_ca.paa", marker[0])
 	assert.Equal(t, 349, marker[3]) // endFrame from "deleted" event (internal 350 → v1 349)
-	assert.Equal(t, 2, marker[6])   // sideIndex (GUER = 2)
+	assert.Equal(t, -1, marker[6])  // sideIndex (GLOBAL)
 }
 
 func TestIsProjectileMarker(t *testing.T) {

--- a/internal/storage/memory/export/v1/builder_test.go
+++ b/internal/storage/memory/export/v1/builder_test.go
@@ -1126,6 +1126,117 @@ func TestBuildWithProjectileHitEmptyMuzzleDisplay(t *testing.T) {
 	assert.Equal(t, "MX Rifle [6.5 mm 30Rnd]", causedBy[1])
 }
 
+func TestBuildWithPlacedObjectMarker(t *testing.T) {
+	data := &MissionData{
+		Mission:  &core.Mission{MissionName: "Test"},
+		World:    &core.World{WorldName: "Altis"},
+		Soldiers: make(map[uint16]*SoldierRecord),
+		Vehicles: make(map[uint16]*VehicleRecord),
+		Markers:  make(map[string]*MarkerRecord),
+		PlacedObjects: map[uint16]*PlacedObjectRecord{
+			50: {
+				PlacedObject: core.PlacedObject{
+					ID: 50, JoinFrame: 200, DisplayName: "APERS Mine",
+					Position:     core.Position3D{X: 1000, Y: 2000, Z: 0},
+					OwnerID:      5,
+					Side:         "WEST",
+					MagazineIcon: `\A3\Weapons_F\Data\UI\gear_mine_AP_ca.paa`,
+				},
+				Events: []core.PlacedObjectEvent{
+					{CaptureFrame: 500, PlacedID: 50, EventType: "detonated", Position: core.Position3D{X: 1000, Y: 2000, Z: 0}},
+				},
+			},
+		},
+	}
+
+	export := Build(data)
+
+	require.Len(t, export.Markers, 1)
+	marker := export.Markers[0]
+
+	// With MagazineIcon → magIcons/ prefix
+	assert.Equal(t, "magIcons/gear_mine_AP_ca.paa", marker[0]) // type
+	assert.Equal(t, "APERS Mine", marker[1])                    // text
+	assert.Equal(t, 199, marker[2])                              // startFrame (internal 200 → v1 199)
+	assert.Equal(t, 499, marker[3])                              // endFrame (internal 500 → v1 499)
+	assert.Equal(t, int(5), marker[4])                          // playerId (ownerID)
+	assert.Equal(t, "ColorOrange", marker[5])                   // color
+	assert.Equal(t, 1, marker[6])                               // sideIndex (WEST = 1)
+	assert.Equal(t, "ICON", marker[9])                          // shape
+	assert.Equal(t, "Solid", marker[10])                        // brush
+
+	// Check positions array
+	posArray := marker[7].([][]any)
+	require.Len(t, posArray, 1)
+	assert.Equal(t, 199, posArray[0][0])
+	pos0 := posArray[0][1].([]float64)
+	assert.Equal(t, 1000.0, pos0[0])
+	assert.Equal(t, 2000.0, pos0[1])
+}
+
+func TestBuildWithPlacedObjectNoIcon(t *testing.T) {
+	data := &MissionData{
+		Mission:  &core.Mission{MissionName: "Test"},
+		World:    &core.World{WorldName: "Altis"},
+		Soldiers: make(map[uint16]*SoldierRecord),
+		Vehicles: make(map[uint16]*VehicleRecord),
+		Markers:  make(map[string]*MarkerRecord),
+		PlacedObjects: map[uint16]*PlacedObjectRecord{
+			60: {
+				PlacedObject: core.PlacedObject{
+					ID: 60, JoinFrame: 100, DisplayName: "Unknown Explosive",
+					Position:     core.Position3D{X: 500, Y: 600, Z: 0},
+					OwnerID:      3,
+					Side:         "EAST",
+					MagazineIcon: "", // empty → fallback to Minefield
+				},
+				Events: nil, // no events → undetonated
+			},
+		},
+	}
+
+	export := Build(data)
+
+	require.Len(t, export.Markers, 1)
+	marker := export.Markers[0]
+
+	assert.Equal(t, "Minefield", marker[0]) // fallback type
+	assert.Equal(t, -1, marker[3])          // endFrame -1 (no detonation/deletion event)
+	assert.Equal(t, 0, marker[6])           // sideIndex (EAST = 0)
+}
+
+func TestBuildWithPlacedObjectDeletedEvent(t *testing.T) {
+	data := &MissionData{
+		Mission:  &core.Mission{MissionName: "Test"},
+		World:    &core.World{WorldName: "Altis"},
+		Soldiers: make(map[uint16]*SoldierRecord),
+		Vehicles: make(map[uint16]*VehicleRecord),
+		Markers:  make(map[string]*MarkerRecord),
+		PlacedObjects: map[uint16]*PlacedObjectRecord{
+			70: {
+				PlacedObject: core.PlacedObject{
+					ID: 70, JoinFrame: 300, DisplayName: "Satchel Charge",
+					Position: core.Position3D{X: 800, Y: 900, Z: 0},
+					OwnerID:  7, Side: "GUER",
+					MagazineIcon: `\A3\Weapons_F\Data\UI\gear_satchel_ca.paa`,
+				},
+				Events: []core.PlacedObjectEvent{
+					{CaptureFrame: 350, PlacedID: 70, EventType: "deleted", Position: core.Position3D{X: 800, Y: 900, Z: 0}},
+				},
+			},
+		},
+	}
+
+	export := Build(data)
+
+	require.Len(t, export.Markers, 1)
+	marker := export.Markers[0]
+
+	assert.Equal(t, "magIcons/gear_satchel_ca.paa", marker[0])
+	assert.Equal(t, 349, marker[3]) // endFrame from "deleted" event (internal 350 → v1 349)
+	assert.Equal(t, 2, marker[6])   // sideIndex (GUER = 2)
+}
+
 func TestIsProjectileMarker(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/storage/memory/export_test.go
+++ b/internal/storage/memory/export_test.go
@@ -1365,12 +1365,12 @@ func TestPlacedObjectExport(t *testing.T) {
 	// Mine with icon: magIcons type, detonated endFrame
 	assert.Equal(t, "magIcons/gear_mine_AP_ca.paa", mineMarker[0])
 	assert.Equal(t, 499, mineMarker[3])    // endFrame from detonation (internal 500 → v1 499)
-	assert.Equal(t, 1, mineMarker[6])      // WEST = 1
+	assert.Equal(t, -1, mineMarker[6])     // GLOBAL (placed objects always visible)
 
 	// Unknown without icon: Minefield fallback, persists
 	assert.Equal(t, "Minefield", unknownMarker[0])
 	assert.Equal(t, -1, unknownMarker[3]) // no events → persists
-	assert.Equal(t, 0, unknownMarker[6])  // EAST = 0
+	assert.Equal(t, -1, unknownMarker[6]) // GLOBAL (placed objects always visible)
 }
 
 func TestMarkerSideValues(t *testing.T) {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -36,6 +36,10 @@ type Backend interface {
 	RecordTimeState(t *core.TimeState) error
 	RecordAce3DeathEvent(e *core.Ace3DeathEvent) error
 	RecordAce3UnconsciousEvent(e *core.Ace3UnconsciousEvent) error
+
+	// Placed objects
+	AddPlacedObject(p *core.PlacedObject) error
+	RecordPlacedObjectEvent(e *core.PlacedObjectEvent) error
 }
 
 // Uploadable is an optional interface for storage backends that produce

--- a/internal/storage/websocket/websocket.go
+++ b/internal/storage/websocket/websocket.go
@@ -180,3 +180,11 @@ func (b *Backend) RecordAce3DeathEvent(e *core.Ace3DeathEvent) error {
 func (b *Backend) RecordAce3UnconsciousEvent(e *core.Ace3UnconsciousEvent) error {
 	return b.sendEnvelope(streaming.TypeAce3Unconscious, e)
 }
+
+func (b *Backend) AddPlacedObject(p *core.PlacedObject) error {
+	return b.sendEnvelope(streaming.TypeAddPlaced, p)
+}
+
+func (b *Backend) RecordPlacedObjectEvent(e *core.PlacedObjectEvent) error {
+	return b.sendEnvelope(streaming.TypePlacedEvent, e)
+}

--- a/internal/storage/websocket/websocket_test.go
+++ b/internal/storage/websocket/websocket_test.go
@@ -162,6 +162,8 @@ func TestAllMessageTypes(t *testing.T) {
 	require.NoError(t, b.RecordTimeState(&core.TimeState{MissionTime: 120}))
 	require.NoError(t, b.RecordAce3DeathEvent(&core.Ace3DeathEvent{SoldierID: 1, Reason: "bleeding"}))
 	require.NoError(t, b.RecordAce3UnconsciousEvent(&core.Ace3UnconsciousEvent{SoldierID: 1, IsUnconscious: true}))
+	require.NoError(t, b.AddPlacedObject(&core.PlacedObject{ID: 200, ClassName: "APERSMine"}))
+	require.NoError(t, b.RecordPlacedObjectEvent(&core.PlacedObjectEvent{PlacedID: 200, EventType: "detonated"}))
 
 	require.NoError(t, b.EndMission())
 

--- a/pkg/core/placed.go
+++ b/pkg/core/placed.go
@@ -23,6 +23,5 @@ type PlacedObjectEvent struct {
 	PlacedID     uint16
 	EventType    string // "detonated", "deleted", or "hit"
 	Position     Position3D
-	HitEntityID   *uint16  // OCAP ID of hit entity (only for "hit" events)
-	HitComponents []string // body/vehicle components hit (only for "hit" events)
+	HitEntityID *uint16 // OCAP ID of hit entity (only for "hit" events)
 }

--- a/pkg/core/placed.go
+++ b/pkg/core/placed.go
@@ -21,6 +21,7 @@ type PlacedObject struct {
 type PlacedObjectEvent struct {
 	CaptureFrame Frame
 	PlacedID     uint16
-	EventType    string // "detonated" or "deleted"
+	EventType    string // "detonated", "deleted", or "hit"
 	Position     Position3D
+	HitEntityID  *uint16 // OCAP ID of hit entity (only for "hit" events)
 }

--- a/pkg/core/placed.go
+++ b/pkg/core/placed.go
@@ -23,5 +23,6 @@ type PlacedObjectEvent struct {
 	PlacedID     uint16
 	EventType    string // "detonated", "deleted", or "hit"
 	Position     Position3D
-	HitEntityID  *uint16 // OCAP ID of hit entity (only for "hit" events)
+	HitEntityID   *uint16  // OCAP ID of hit entity (only for "hit" events)
+	HitComponents []string // body/vehicle components hit (only for "hit" events)
 }

--- a/pkg/core/placed.go
+++ b/pkg/core/placed.go
@@ -1,0 +1,26 @@
+package core
+
+import "time"
+
+// PlacedObject represents a placed object (mine, explosive, etc.) in the game world.
+// ID is the ObjectID - the game's identifier for this entity.
+type PlacedObject struct {
+	ID           uint16    // ObjectID - game identifier
+	JoinTime     time.Time
+	JoinFrame    Frame
+	ClassName    string
+	DisplayName  string
+	Position     Position3D
+	OwnerID      uint16 // OCAP ID of soldier who placed it
+	Side         string
+	Weapon       string
+	MagazineIcon string
+}
+
+// PlacedObjectEvent represents a lifecycle event (detonation or deletion) for a placed object.
+type PlacedObjectEvent struct {
+	CaptureFrame Frame
+	PlacedID     uint16
+	EventType    string // "detonated" or "deleted"
+	Position     Position3D
+}

--- a/pkg/streaming/messages.go
+++ b/pkg/streaming/messages.go
@@ -28,6 +28,8 @@ const (
 	TypeTimeState       = "time_state"
 	TypeAce3Death       = "ace3_death"
 	TypeAce3Unconscious = "ace3_unconscious"
+	TypeAddPlaced       = "add_placed"
+	TypePlacedEvent     = "placed_event"
 )
 
 // AllMessageTypes lists every streaming message type.
@@ -38,6 +40,7 @@ var AllMessageTypes = []string{
 	TypeFiredEvent, TypeProjectileEvent, TypeGeneralEvent,
 	TypeHitEvent, TypeKillEvent, TypeChatEvent, TypeRadioEvent,
 	TypeTelemetry, TypeTimeState, TypeAce3Death, TypeAce3Unconscious,
+	TypeAddPlaced, TypePlacedEvent,
 }
 
 // Envelope wraps all messages sent over the WebSocket.


### PR DESCRIPTION
## Summary

- Adds passthrough support for `:NEW:PLACED:` and `:PLACED:EVENT:` commands, enabling proper lifecycle tracking of placed objects (mines, explosives) as distinct from projectiles
- Mines are no longer shoehorned into `:PROJECTILE:` events — they get their own creation + lifecycle event flow, matching the existing vehicle pattern (`:NEW:VEHICLE:` + `:NEW:VEHICLE:STATE:`)
- Extension remains a pure passthrough — no deduplication logic, just parsing and forwarding

## Changes

**Core types** (`pkg/core/placed.go`):
- `PlacedObject` struct: ID, position, class, display name, owner, side, weapon, icon
- `PlacedObjectEvent` struct: frame, placed ID, event type ("detonated"/"deleted"), position

**Streaming** (`pkg/streaming/messages.go`):
- `TypeAddPlaced = "add_placed"` and `TypePlacedEvent = "placed_event"`

**Parser** (`internal/parser/parse_placed.go`):
- `ParsePlacedObject` — 9-element array from addon
- `ParsePlacedObjectEvent` — 4-element array from addon

**Dispatch** (`internal/worker/dispatch.go`):
- `:NEW:PLACED:` → sync handler (no buffer, like vehicles)
- `:PLACED:EVENT:` → buffered 1000

**Backend** (`internal/storage/`):
- `AddPlacedObject` and `RecordPlacedObjectEvent` on Backend interface
- WebSocket: full passthrough via `sendEnvelope`
- Memory/Postgres: no-op stubs (streaming-only for now)

**Cache** (`internal/cache/cache.go`):
- Placed object cache for validating events reference known objects

## Test plan

- [x] Parser tests: happy path + error cases for both ParsePlacedObject and ParsePlacedObjectEvent
- [x] Dispatch tests: handler registration, TestAllMessageTypes updated
- [x] `go test ./...` passes