### PR TITLE
refactor: introduce Frame type for type-safe frame numbering

### DIFF
--- a/internal/model/convert/to_gorm.go
+++ b/internal/model/convert/to_gorm.go
@@ -52,7 +52,7 @@ func CoreToSoldier(s core.Soldier) model.Soldier {
 	return model.Soldier{
 		ObjectID:        s.ID,
 		JoinTime:        s.JoinTime,
-		JoinFrame:       s.JoinFrame,
+		JoinFrame:       uint(s.JoinFrame),
 		OcapType:        s.OcapType,
 		UnitName:        s.UnitName,
 		GroupID:         s.GroupID,
@@ -72,7 +72,7 @@ func CoreToVehicle(v core.Vehicle) model.Vehicle {
 	return model.Vehicle{
 		ObjectID:      v.ID,
 		JoinTime:      v.JoinTime,
-		JoinFrame:     v.JoinFrame,
+		JoinFrame:     uint(v.JoinFrame),
 		OcapType:      v.OcapType,
 		ClassName:     v.ClassName,
 		DisplayName:   v.DisplayName,
@@ -85,7 +85,7 @@ func CoreToMarker(m core.Marker) model.Marker {
 	return model.Marker{
 		ID:           m.ID,
 		Time:         m.Time,
-		CaptureFrame: m.CaptureFrame,
+		CaptureFrame: uint(m.CaptureFrame),
 		MarkerName:   m.MarkerName,
 		Direction:    m.Direction,
 		MarkerType:   m.MarkerType,
@@ -113,7 +113,7 @@ func CoreToSoldierState(s core.SoldierState) model.SoldierState {
 	return model.SoldierState{
 		SoldierObjectID:  s.SoldierID,
 		Time:             s.Time,
-		CaptureFrame:     s.CaptureFrame,
+		CaptureFrame:     uint(s.CaptureFrame),
 		Position:         position3DToPoint(s.Position),
 		ElevationASL:     float32(s.Position.Z),
 		Bearing:          s.Bearing,
@@ -145,7 +145,7 @@ func CoreToVehicleState(v core.VehicleState) model.VehicleState {
 	return model.VehicleState{
 		VehicleObjectID: v.VehicleID,
 		Time:            v.Time,
-		CaptureFrame:    v.CaptureFrame,
+		CaptureFrame:    uint(v.CaptureFrame),
 		Position:        position3DToPoint(v.Position),
 		ElevationASL:    float32(v.Position.Z),
 		Bearing:         v.Bearing,
@@ -169,7 +169,7 @@ func CoreToMarkerState(s core.MarkerState) model.MarkerState {
 		ID:           s.ID,
 		MarkerID:     s.MarkerID,
 		Time:         s.Time,
-		CaptureFrame: s.CaptureFrame,
+		CaptureFrame: uint(s.CaptureFrame),
 		Position:     position3DToPoint(s.Position),
 		Direction:    s.Direction,
 		Alpha:        s.Alpha,
@@ -188,7 +188,7 @@ func CoreToGeneralEvent(e core.GeneralEvent) model.GeneralEvent {
 	return model.GeneralEvent{
 		ID:           e.ID,
 		Time:         e.Time,
-		CaptureFrame: e.CaptureFrame,
+		CaptureFrame: uint(e.CaptureFrame),
 		Name:         e.Name,
 		Message:      e.Message,
 		ExtraData:    extraData,
@@ -200,7 +200,7 @@ func CoreToKillEvent(e core.KillEvent) model.KillEvent {
 	result := model.KillEvent{
 		ID:             e.ID,
 		Time:           e.Time,
-		CaptureFrame:   e.CaptureFrame,
+		CaptureFrame:   uint(e.CaptureFrame),
 		WeaponVehicle:  e.WeaponVehicle,
 		WeaponName:     e.WeaponName,
 		WeaponMagazine: e.WeaponMagazine,
@@ -229,7 +229,7 @@ func CoreToChatEvent(e core.ChatEvent) model.ChatEvent {
 	result := model.ChatEvent{
 		ID:           e.ID,
 		Time:         e.Time,
-		CaptureFrame: e.CaptureFrame,
+		CaptureFrame: uint(e.CaptureFrame),
 		Channel:      e.Channel,
 		FromName:     e.FromName,
 		SenderName:   e.SenderName,
@@ -249,7 +249,7 @@ func CoreToRadioEvent(e core.RadioEvent) model.RadioEvent {
 	result := model.RadioEvent{
 		ID:           e.ID,
 		Time:         e.Time,
-		CaptureFrame: e.CaptureFrame,
+		CaptureFrame: uint(e.CaptureFrame),
 		Radio:        e.Radio,
 		RadioType:    e.RadioType,
 		StartEnd:     e.StartEnd,
@@ -272,7 +272,7 @@ func CoreToAce3DeathEvent(e core.Ace3DeathEvent) model.Ace3DeathEvent {
 		ID:              e.ID,
 		SoldierObjectID: uint16(e.SoldierID),
 		Time:            e.Time,
-		CaptureFrame:    e.CaptureFrame,
+		CaptureFrame:    uint(e.CaptureFrame),
 		Reason:          e.Reason,
 	}
 
@@ -289,7 +289,7 @@ func CoreToAce3UnconsciousEvent(e core.Ace3UnconsciousEvent) model.Ace3Unconscio
 		ID:              e.ID,
 		SoldierObjectID: uint16(e.SoldierID),
 		Time:            e.Time,
-		CaptureFrame:    e.CaptureFrame,
+		CaptureFrame:    uint(e.CaptureFrame),
 		IsUnconscious:   e.IsUnconscious,
 	}
 }
@@ -299,7 +299,7 @@ func CoreToAce3UnconsciousEvent(e core.Ace3UnconsciousEvent) model.Ace3Unconscio
 // into separate HitSoldiers and HitVehicles slices.
 func CoreToProjectileEvent(e core.ProjectileEvent) model.ProjectileEvent {
 	result := model.ProjectileEvent{
-		CaptureFrame:    e.CaptureFrame,
+		CaptureFrame:    uint(e.CaptureFrame),
 		FirerObjectID:   e.FirerObjectID,
 		WeaponDisplay:   e.WeaponDisplay,
 		MagazineDisplay: e.MagazineDisplay,
@@ -317,7 +317,7 @@ func CoreToProjectileEvent(e core.ProjectileEvent) model.ProjectileEvent {
 	if len(e.Trajectory) >= 2 {
 		coords := make([]float64, 0, len(e.Trajectory)*4)
 		for _, tp := range e.Trajectory {
-			coords = append(coords, tp.Position.X, tp.Position.Y, tp.Position.Z, float64(tp.Frame))
+			coords = append(coords, tp.Position.X, tp.Position.Y, tp.Position.Z, float64(tp.FrameNum))
 		}
 		seq := geom.NewSequence(coords, geom.DimXYZM)
 		ls := geom.NewLineString(seq)
@@ -329,7 +329,7 @@ func CoreToProjectileEvent(e core.ProjectileEvent) model.ProjectileEvent {
 		if hit.SoldierID != nil {
 			result.HitSoldiers = append(result.HitSoldiers, model.ProjectileHitsSoldier{
 				SoldierObjectID: *hit.SoldierID,
-				CaptureFrame:    hit.CaptureFrame,
+				CaptureFrame:    uint(hit.CaptureFrame),
 				Position:        position3DToPoint(hit.Position),
 				ComponentsHit:   componentsToJSON(hit.ComponentsHit),
 			})
@@ -337,7 +337,7 @@ func CoreToProjectileEvent(e core.ProjectileEvent) model.ProjectileEvent {
 		if hit.VehicleID != nil {
 			result.HitVehicles = append(result.HitVehicles, model.ProjectileHitsVehicle{
 				VehicleObjectID: *hit.VehicleID,
-				CaptureFrame:    hit.CaptureFrame,
+				CaptureFrame:    uint(hit.CaptureFrame),
 				Position:        position3DToPoint(hit.Position),
 				ComponentsHit:   componentsToJSON(hit.ComponentsHit),
 			})
@@ -408,7 +408,7 @@ func CoreToWorld(w core.World) model.World {
 func CoreToTimeState(t core.TimeState) model.TimeState {
 	return model.TimeState{
 		Time:           t.Time,
-		CaptureFrame:   t.CaptureFrame,
+		CaptureFrame:   uint(t.CaptureFrame),
 		SystemTimeUTC:  t.SystemTimeUTC,
 		MissionDate:    t.MissionDate,
 		TimeMultiplier: t.TimeMultiplier,

--- a/internal/model/convert/to_gorm_test.go
+++ b/internal/model/convert/to_gorm_test.go
@@ -467,9 +467,9 @@ func TestCoreToProjectileEvent(t *testing.T) {
 		SimulationType:  "shotShell",
 		MagazineIcon:    `\A3\weapons_f\data\ui\icon_shell.paa`,
 		Trajectory: []core.TrajectoryPoint{
-			{Position: core.Position3D{X: 100.0, Y: 200.0, Z: 10.0}, Frame: 50},
-			{Position: core.Position3D{X: 150.0, Y: 250.0, Z: 15.0}, Frame: 52},
-			{Position: core.Position3D{X: 200.0, Y: 300.0, Z: 5.0}, Frame: 55},
+			{Position: core.Position3D{X: 100.0, Y: 200.0, Z: 10.0}, FrameNum: 50},
+			{Position: core.Position3D{X: 150.0, Y: 250.0, Z: 15.0}, FrameNum: 52},
+			{Position: core.Position3D{X: 200.0, Y: 300.0, Z: 5.0}, FrameNum: 55},
 		},
 		Hits: []core.ProjectileHit{
 			{SoldierID: &soldierHitID, CaptureFrame: 55, Position: core.Position3D{X: 200.0, Y: 300.0, Z: 5.0}, ComponentsHit: []string{"head"}},

--- a/internal/parser/parse_ace3.go
+++ b/internal/parser/parse_ace3.go
@@ -25,7 +25,7 @@ func (p *Parser) ParseAce3DeathEvent(data []string) (core.Ace3DeathEvent, error)
 	}
 
 	deathEvent.Time = time.Now()
-	deathEvent.CaptureFrame = uint(capframe)
+	deathEvent.CaptureFrame = core.Frame(capframe)
 
 	// parse victim ObjectID - set directly
 	victimObjectID, err := parseUintFromFloat(data[1])
@@ -65,7 +65,7 @@ func (p *Parser) ParseAce3UnconsciousEvent(data []string) (core.Ace3UnconsciousE
 		return unconsciousEvent, fmt.Errorf("error converting capture frame to int: %w", err)
 	}
 
-	unconsciousEvent.CaptureFrame = uint(capframe)
+	unconsciousEvent.CaptureFrame = core.Frame(capframe)
 
 	ocapID, err := parseUintFromFloat(data[1])
 	if err != nil {

--- a/internal/parser/parse_ace3_test.go
+++ b/internal/parser/parse_ace3_test.go
@@ -22,7 +22,7 @@ func TestParseAce3DeathEvent(t *testing.T) {
 			name:  "death with source",
 			input: []string{"100", "5", "bleeding", "10"},
 			check: func(t *testing.T, e core.Ace3DeathEvent) {
-				assert.Equal(t, uint(100), e.CaptureFrame)
+				assert.Equal(t, core.Frame(100), e.CaptureFrame)
 				assert.Equal(t, uint(5), e.SoldierID)
 				assert.Equal(t, "bleeding", e.Reason)
 				assert.NotNil(t, e.LastDamageSourceID)
@@ -42,7 +42,7 @@ func TestParseAce3DeathEvent(t *testing.T) {
 			name:  "float frame and objectIDs",
 			input: []string{"100.00", "5.00", "drowning", "10.00"},
 			check: func(t *testing.T, e core.Ace3DeathEvent) {
-				assert.Equal(t, uint(100), e.CaptureFrame)
+				assert.Equal(t, core.Frame(100), e.CaptureFrame)
 				assert.Equal(t, uint(5), e.SoldierID)
 				assert.Equal(t, uint(10), *e.LastDamageSourceID)
 			},
@@ -90,7 +90,7 @@ func TestParseAce3UnconsciousEvent(t *testing.T) {
 			name:  "goes unconscious",
 			input: []string{"100", "5", "true"},
 			check: func(t *testing.T, e core.Ace3UnconsciousEvent) {
-				assert.Equal(t, uint(100), e.CaptureFrame)
+				assert.Equal(t, core.Frame(100), e.CaptureFrame)
 				assert.Equal(t, uint(5), e.SoldierID)
 				assert.True(t, e.IsUnconscious)
 			},
@@ -107,7 +107,7 @@ func TestParseAce3UnconsciousEvent(t *testing.T) {
 			name:  "float IDs",
 			input: []string{"200.00", "42.00", "true"},
 			check: func(t *testing.T, e core.Ace3UnconsciousEvent) {
-				assert.Equal(t, uint(200), e.CaptureFrame)
+				assert.Equal(t, core.Frame(200), e.CaptureFrame)
 				assert.Equal(t, uint(42), e.SoldierID)
 			},
 		},

--- a/internal/parser/parse_chat.go
+++ b/internal/parser/parse_chat.go
@@ -26,7 +26,7 @@ func (p *Parser) ParseChatEvent(data []string) (core.ChatEvent, error) {
 	}
 
 	chatEvent.Time = time.Now()
-	chatEvent.CaptureFrame = uint(capframe)
+	chatEvent.CaptureFrame = core.Frame(capframe)
 
 	// parse sender ObjectID
 	senderObjectID, err := parseIntFromFloat(data[1])
@@ -81,7 +81,7 @@ func (p *Parser) ParseRadioEvent(data []string) (core.RadioEvent, error) {
 	}
 
 	radioEvent.Time = time.Now()
-	radioEvent.CaptureFrame = uint(capframe)
+	radioEvent.CaptureFrame = core.Frame(capframe)
 
 	// parse sender ObjectID
 	senderObjectID, err := parseIntFromFloat(data[1])

--- a/internal/parser/parse_chat_test.go
+++ b/internal/parser/parse_chat_test.go
@@ -22,7 +22,7 @@ func TestParseChatEvent(t *testing.T) {
 			name:  "player chat global channel",
 			input: []string{"50", "5", "0", "Player1", "Player1", "Hello world", "76561198000074241"},
 			check: func(t *testing.T, e core.ChatEvent) {
-				assert.Equal(t, uint(50), e.CaptureFrame)
+				assert.Equal(t, core.Frame(50), e.CaptureFrame)
 				assert.NotNil(t, e.SoldierID)
 				assert.Equal(t, uint(5), *e.SoldierID)
 				assert.Equal(t, "Global", e.Channel)
@@ -146,7 +146,7 @@ func TestParseRadioEvent(t *testing.T) {
 			name:  "TFAR start transmission",
 			input: []string{"50", "5", "TFAR_anprc152", "LR", "START", "1", "false", "87.5", "_lr_code"},
 			check: func(t *testing.T, e core.RadioEvent) {
-				assert.Equal(t, uint(50), e.CaptureFrame)
+				assert.Equal(t, core.Frame(50), e.CaptureFrame)
 				assert.NotNil(t, e.SoldierID)
 				assert.Equal(t, uint(5), *e.SoldierID)
 				assert.Equal(t, "TFAR_anprc152", e.Radio)

--- a/internal/parser/parse_events.go
+++ b/internal/parser/parse_events.go
@@ -30,7 +30,7 @@ func (p *Parser) ParseProjectileEvent(data []string) (ProjectileEvent, error) {
 	if err != nil {
 		return result, fmt.Errorf("error parsing firedFrame: %v", err)
 	}
-	result.CaptureFrame = uint(capframe)
+	result.CaptureFrame = core.Frame(capframe)
 
 	// [2] firerID - set directly
 	firerID, err := parseUintFromFloat(data[2])
@@ -85,7 +85,7 @@ func (p *Parser) ParseProjectileEvent(data []string) (ProjectileEvent, error) {
 
 		result.Trajectory = append(result.Trajectory, core.TrajectoryPoint{
 			Position: pos3d,
-			Frame:    uint(frameNo),
+			FrameNum: core.Frame(frameNo),
 		})
 	}
 
@@ -134,7 +134,7 @@ func (p *Parser) ParseProjectileEvent(data []string) (ProjectileEvent, error) {
 			result.HitParts = append(result.HitParts, HitPart{
 				EntityID:      uint16(hitEntityID),
 				ComponentsHit: hitComponents,
-				CaptureFrame:  uint(hitFrame),
+				CaptureFrame:  core.Frame(hitFrame),
 				Position:      hitPos3d,
 			})
 		}
@@ -165,7 +165,7 @@ func (p *Parser) ParseGeneralEvent(data []string) (core.GeneralEvent, error) {
 	}
 
 	thisEvent.Time = time.Now()
-	thisEvent.CaptureFrame = uint(capframe)
+	thisEvent.CaptureFrame = core.Frame(capframe)
 	thisEvent.Name = data[1]
 	thisEvent.Message = data[2]
 
@@ -200,7 +200,7 @@ func (p *Parser) ParseKillEvent(data []string) (KillEvent, error) {
 	}
 
 	result.Time = time.Now()
-	result.CaptureFrame = uint(capframe)
+	result.CaptureFrame = core.Frame(capframe)
 
 	// parse victim ObjectID
 	victimObjectID, err := parseUintFromFloat(data[1])
@@ -286,7 +286,7 @@ func (p *Parser) ParseTelemetryEvent(data []string) (core.TelemetryEvent, error)
 	if err != nil {
 		return result, fmt.Errorf("telemetry: parse frameNo: %w", err)
 	}
-	result.CaptureFrame = uint(frameNo)
+	result.CaptureFrame = core.Frame(frameNo)
 
 	// [1] Server FPS: [diag_fps, diag_fpsmin]
 	var fps [2]float64
@@ -428,7 +428,7 @@ func (p *Parser) ParseTimeState(data []string) (core.TimeState, error) {
 		return timeState, fmt.Errorf("error converting capture frame to int: %w", err)
 	}
 
-	timeState.CaptureFrame = uint(capframe)
+	timeState.CaptureFrame = core.Frame(capframe)
 	timeState.Time = time.Now()
 
 	timeState.SystemTimeUTC = data[1]

--- a/internal/parser/parse_events_test.go
+++ b/internal/parser/parse_events_test.go
@@ -135,7 +135,7 @@ func TestParseProjectileEvent(t *testing.T) {
 				"iconBullet",          // 19: magazineIcon
 			},
 			check: func(t *testing.T, r ProjectileEvent) {
-				assert.Equal(t, uint(100), r.CaptureFrame)
+				assert.Equal(t, core.Frame(100), r.CaptureFrame)
 				assert.Equal(t, uint16(5), r.FirerObjectID)
 				assert.Nil(t, r.VehicleObjectID)
 				assert.Equal(t, "MX 6.5 mm", r.WeaponDisplay)
@@ -175,7 +175,7 @@ func TestParseProjectileEvent(t *testing.T) {
 				assert.Equal(t, uint16(30), *r.VehicleObjectID)
 				assert.Len(t, r.HitParts, 1)
 				assert.Equal(t, uint16(42), r.HitParts[0].EntityID)
-				assert.Equal(t, uint(205), r.HitParts[0].CaptureFrame)
+				assert.Equal(t, core.Frame(205), r.HitParts[0].CaptureFrame)
 				assert.NotEqual(t, core.Position3D{}, r.HitParts[0].Position)
 			},
 		},
@@ -436,7 +436,7 @@ func TestParseProjectileEvent(t *testing.T) {
 			},
 			check: func(t *testing.T, r ProjectileEvent) {
 				// remoteControllerID is no longer parsed, so bad values don't error
-				assert.Equal(t, uint(100), r.CaptureFrame)
+				assert.Equal(t, core.Frame(100), r.CaptureFrame)
 			},
 		},
 		{
@@ -475,7 +475,7 @@ func TestParseGeneralEvent(t *testing.T) {
 			name:  "recording started",
 			input: []string{"0", "generalEvent", "Recording started.", "{}"},
 			check: func(t *testing.T, e core.GeneralEvent) {
-				assert.Equal(t, uint(0), e.CaptureFrame)
+				assert.Equal(t, core.Frame(0), e.CaptureFrame)
 				assert.Equal(t, "generalEvent", e.Name)
 				assert.Equal(t, "Recording started.", e.Message)
 			},
@@ -484,7 +484,7 @@ func TestParseGeneralEvent(t *testing.T) {
 			name:  "end mission with extraData",
 			input: []string{"1043", "endMission", "", `{"message":"BLUFOR wins","winner":"WEST"}`},
 			check: func(t *testing.T, e core.GeneralEvent) {
-				assert.Equal(t, uint(1043), e.CaptureFrame)
+				assert.Equal(t, core.Frame(1043), e.CaptureFrame)
 				assert.Equal(t, "endMission", e.Name)
 				assert.Equal(t, "", e.Message)
 				assert.Equal(t, "BLUFOR wins", e.ExtraData["message"])
@@ -538,7 +538,7 @@ func TestParseTimeState(t *testing.T) {
 			name:  "normal",
 			input: []string{"0", "2026-02-15T17:46:12.621", "2035-07-02T18:00:00", "1", "0"},
 			check: func(t *testing.T, ts core.TimeState) {
-				assert.Equal(t, uint(0), ts.CaptureFrame)
+				assert.Equal(t, core.Frame(0), ts.CaptureFrame)
 				assert.Equal(t, "2026-02-15T17:46:12.621", ts.SystemTimeUTC)
 				assert.Equal(t, "2035-07-02T18:00:00", ts.MissionDate)
 				assert.Equal(t, float32(1), ts.TimeMultiplier)
@@ -549,7 +549,7 @@ func TestParseTimeState(t *testing.T) {
 			name:  "with mission time",
 			input: []string{"10", "2026-02-15T17:47:00", "2035-07-02T18:05:00", "1", "5.013"},
 			check: func(t *testing.T, ts core.TimeState) {
-				assert.Equal(t, uint(10), ts.CaptureFrame)
+				assert.Equal(t, core.Frame(10), ts.CaptureFrame)
 				assert.InDelta(t, float32(5.013), ts.MissionTime, 0.001)
 			},
 		},
@@ -638,7 +638,7 @@ func TestParseTelemetryEvent(t *testing.T) {
 			name:  "RPT mission start (frame 0)",
 			input: missionStart,
 			check: func(t *testing.T, e core.TelemetryEvent) {
-				assert.Equal(t, uint(0), e.CaptureFrame)
+				assert.Equal(t, core.Frame(0), e.CaptureFrame)
 				assert.InDelta(t, 43.3604, float64(e.FpsAverage), 0.001)
 				assert.InDelta(t, 4.36681, float64(e.FpsMin), 0.001)
 
@@ -714,7 +714,7 @@ func TestParseTelemetryEvent(t *testing.T) {
 			name:  "RPT mid-mission (frame 114) — combat, scientific notation bandwidth",
 			input: midMission,
 			check: func(t *testing.T, e core.TelemetryEvent) {
-				assert.Equal(t, uint(114), e.CaptureFrame)
+				assert.Equal(t, core.Frame(114), e.CaptureFrame)
 				assert.InDelta(t, 122.137, float64(e.FpsAverage), 0.01)
 				assert.InDelta(t, 90.9091, float64(e.FpsMin), 0.01)
 
@@ -748,7 +748,7 @@ func TestParseTelemetryEvent(t *testing.T) {
 			name:  "RPT late mission (frame 234) — more casualties, weapon holders",
 			input: lateMission,
 			check: func(t *testing.T, e core.TelemetryEvent) {
-				assert.Equal(t, uint(234), e.CaptureFrame)
+				assert.Equal(t, core.Frame(234), e.CaptureFrame)
 				assert.InDelta(t, 132.231, float64(e.FpsAverage), 0.01)
 				assert.InDelta(t, 76.9231, float64(e.FpsMin), 0.01)
 
@@ -790,7 +790,7 @@ func TestParseTelemetryEvent(t *testing.T) {
 				"[0,0,0,0,0,0,0,0,0,0,0,0]", "[]",
 			},
 			check: func(t *testing.T, e core.TelemetryEvent) {
-				assert.Equal(t, uint(0), e.CaptureFrame)
+				assert.Equal(t, core.Frame(0), e.CaptureFrame)
 				assert.InDelta(t, 50.0, float64(e.FpsAverage), 0.01)
 				assert.Empty(t, e.Players)
 			},

--- a/internal/parser/parse_marker.go
+++ b/internal/parser/parse_marker.go
@@ -41,9 +41,10 @@ func (p *Parser) ParseMarkerCreate(data []string) (core.Marker, error) {
 	if err != nil {
 		return marker, fmt.Errorf("error parsing capture frame: %w", err)
 	}
-	marker.CaptureFrame = uint(capframe)
+	marker.CaptureFrame = core.Frame(capframe)
 
-	// data[5] is -1, skip
+	// data[5] is -1 from addon, meaning "forever" — set explicitly
+	marker.EndFrame = core.FrameForever
 
 	// ownerId
 	ownerId, err := strconv.Atoi(data[6])
@@ -118,7 +119,7 @@ func (p *Parser) ParseMarkerMove(data []string) (MarkerMove, error) {
 	if err != nil {
 		return result, fmt.Errorf("error parsing capture frame: %w", err)
 	}
-	result.CaptureFrame = uint(capframe)
+	result.CaptureFrame = core.Frame(capframe)
 
 	// position
 	pos := data[2]
@@ -165,6 +166,6 @@ func (p *Parser) ParseMarkerDelete(data []string) (*core.DeleteMarker, error) {
 
 	return &core.DeleteMarker{
 		Name:     data[0],
-		EndFrame: uint(capframe),
+		EndFrame: core.Frame(capframe),
 	}, nil
 }

--- a/internal/parser/parse_marker_test.go
+++ b/internal/parser/parse_marker_test.go
@@ -41,7 +41,7 @@ func TestParseMarkerCreate(t *testing.T) {
 				assert.Equal(t, float32(0), m.Direction)
 				assert.Equal(t, "mil_dot", m.MarkerType)
 				assert.Equal(t, "Respawn West", m.Text)
-				assert.Equal(t, uint(0), m.CaptureFrame)
+				assert.Equal(t, core.Frame(0), m.CaptureFrame)
 				assert.Equal(t, -1, m.OwnerID)
 				assert.Equal(t, "ColorBLUFOR", m.Color)
 				assert.Equal(t, "ICON", m.Shape)
@@ -74,7 +74,7 @@ func TestParseMarkerCreate(t *testing.T) {
 				assert.InDelta(t, float32(0.5), m.Alpha, 0.01)
 				assert.Equal(t, "grid", m.Brush)
 				assert.Equal(t, 5, m.OwnerID)
-				assert.Equal(t, uint(100), m.CaptureFrame)
+				assert.Equal(t, core.Frame(100), m.CaptureFrame)
 			},
 		},
 		{
@@ -206,7 +206,7 @@ func TestParseMarkerMove(t *testing.T) {
 			input: []string{"markerName", "517", "6069.06,5627.81,17.81", "0", "1"},
 			check: func(t *testing.T, r MarkerMove) {
 				assert.Equal(t, "markerName", r.MarkerName)
-				assert.Equal(t, uint(517), r.CaptureFrame)
+				assert.Equal(t, core.Frame(517), r.CaptureFrame)
 				assert.NotEqual(t, core.Position3D{}, r.Position)
 				assert.Equal(t, float32(0), r.Direction)
 				assert.Equal(t, float32(1), r.Alpha)
@@ -267,7 +267,7 @@ func TestParseMarkerDelete(t *testing.T) {
 		name      string
 		input     []string
 		wantName  string
-		wantFrame uint
+		wantFrame core.Frame
 		wantErr   bool
 	}{
 		{

--- a/internal/parser/parse_soldier.go
+++ b/internal/parser/parse_soldier.go
@@ -27,7 +27,7 @@ func (p *Parser) ParseSoldier(data []string) (core.Soldier, error) {
 		return soldier, fmt.Errorf("error converting capture frame to int: %w", err)
 	}
 
-	soldier.JoinFrame = uint(capframe)
+	soldier.JoinFrame = core.Frame(capframe)
 	soldier.JoinTime = time.Now()
 
 	ocapID, err := parseUintFromFloat(data[1])
@@ -73,7 +73,7 @@ func (p *Parser) ParseSoldierState(data []string) (core.SoldierState, error) {
 	if err != nil {
 		return soldierState, fmt.Errorf("error converting capture frame to int: %w", err)
 	}
-	soldierState.CaptureFrame = uint(capframe)
+	soldierState.CaptureFrame = core.Frame(capframe)
 
 	// parse ocapID and set directly (worker validates against cache)
 	ocapID, err := parseUintFromFloat(data[0])

--- a/internal/parser/parse_soldier_test.go
+++ b/internal/parser/parse_soldier_test.go
@@ -33,7 +33,7 @@ func TestParseSoldier(t *testing.T) {
 				"[]",             // 10: squadParams
 			},
 			check: func(t *testing.T, s core.Soldier) {
-				assert.Equal(t, uint(0), s.JoinFrame)
+				assert.Equal(t, core.Frame(0), s.JoinFrame)
 				assert.Equal(t, uint16(0), s.ID)
 				assert.Equal(t, "Farid Amin", s.UnitName)
 				assert.Equal(t, "Alpha 1-1", s.GroupID)
@@ -84,7 +84,7 @@ func TestParseSoldier(t *testing.T) {
 				"[]",             // 10: squadParams
 			},
 			check: func(t *testing.T, s core.Soldier) {
-				assert.Equal(t, uint(415), s.JoinFrame)
+				assert.Equal(t, core.Frame(415), s.JoinFrame)
 				assert.Equal(t, uint16(78), s.ID)
 				assert.Equal(t, "", s.UnitName)
 				assert.Equal(t, "UNKNOWN", s.Side)
@@ -106,7 +106,7 @@ func TestParseSoldier(t *testing.T) {
 				"[]",                     // 10: squadParams
 			},
 			check: func(t *testing.T, s core.Soldier) {
-				assert.Equal(t, uint(21), s.JoinFrame)
+				assert.Equal(t, core.Frame(21), s.JoinFrame)
 				assert.Equal(t, uint16(70), s.ID)
 				assert.Equal(t, "Team Leader", s.DisplayName)
 			},

--- a/internal/parser/parse_vehicle.go
+++ b/internal/parser/parse_vehicle.go
@@ -29,7 +29,7 @@ func (p *Parser) ParseVehicle(data []string) (core.Vehicle, error) {
 
 	vehicle.JoinTime = time.Now()
 
-	vehicle.JoinFrame = uint(capframe)
+	vehicle.JoinFrame = core.Frame(capframe)
 	ocapID, err := parseUintFromFloat(data[1])
 	if err != nil {
 		return vehicle, fmt.Errorf("error converting ocapID to uint: %w", err)
@@ -58,7 +58,7 @@ func (p *Parser) ParseVehicleState(data []string) (core.VehicleState, error) {
 	if err != nil {
 		return vehicleState, fmt.Errorf("error converting capture frame to int: %w", err)
 	}
-	vehicleState.CaptureFrame = uint(capframe)
+	vehicleState.CaptureFrame = core.Frame(capframe)
 
 	// parse ocapID and set directly (worker validates against cache)
 	ocapID, err := parseUintFromFloat(data[0])

--- a/internal/parser/parse_vehicle_test.go
+++ b/internal/parser/parse_vehicle_test.go
@@ -28,7 +28,7 @@ func TestParseVehicle(t *testing.T) {
 				`[["Black",1],[]]`,          // 5: customization
 			},
 			check: func(t *testing.T, v core.Vehicle) {
-				assert.Equal(t, uint(0), v.JoinFrame)
+				assert.Equal(t, core.Frame(0), v.JoinFrame)
 				assert.Equal(t, uint16(30), v.ID)
 				assert.Equal(t, "heli", v.OcapType)
 				assert.Equal(t, "UH-80 Ghost Hawk", v.DisplayName)
@@ -73,7 +73,7 @@ func TestParseVehicle(t *testing.T) {
 				"10.00", "50.00", "boat", "Speedboat", "C_Boat_Civil_01_F", "[]",
 			},
 			check: func(t *testing.T, v core.Vehicle) {
-				assert.Equal(t, uint(10), v.JoinFrame)
+				assert.Equal(t, core.Frame(10), v.JoinFrame)
 				assert.Equal(t, uint16(50), v.ID)
 			},
 		},
@@ -200,7 +200,7 @@ func TestParseVehicleState_AllFields(t *testing.T) {
 			},
 			check: func(t *testing.T, v core.VehicleState) {
 				assert.Equal(t, uint16(10), v.VehicleID)
-				assert.Equal(t, uint(500), v.CaptureFrame)
+				assert.Equal(t, core.Frame(500), v.CaptureFrame)
 				assert.True(t, v.IsAlive)
 				assert.Equal(t, "[20,21,22]", v.Crew)
 				assert.InDelta(t, float32(0.95), v.Fuel, 0.01)

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -11,14 +11,14 @@ import (
 type HitPart struct {
 	EntityID      uint16
 	ComponentsHit []string
-	CaptureFrame  uint
+	CaptureFrame  core.Frame
 	Position      core.Position3D
 }
 
 // ProjectileEvent represents a projectile event as parsed from ArmA data.
 // HitParts contain raw entity IDs that need classification by the worker.
 type ProjectileEvent struct {
-	CaptureFrame    uint
+	CaptureFrame    core.Frame
 	FirerObjectID   uint16
 	VehicleObjectID *uint16
 
@@ -38,7 +38,7 @@ type ProjectileEvent struct {
 // as soldier or vehicle.
 type KillEvent struct {
 	Time           time.Time
-	CaptureFrame   uint
+	CaptureFrame   core.Frame
 	VictimID       uint16
 	KillerID       uint16
 	WeaponVehicle  string
@@ -52,7 +52,7 @@ type KillEvent struct {
 // MarkerName needs resolution to a MarkerID via MarkerCache by the worker.
 type MarkerMove struct {
 	MarkerName   string
-	CaptureFrame uint
+	CaptureFrame core.Frame
 	Position     core.Position3D
 	Direction    float32
 	Alpha        float32

--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -72,7 +72,7 @@ func Build(data *MissionData) Export {
 	for _, ts := range data.TimeStates {
 		export.Times = append(export.Times, Time{
 			Date:           ts.MissionDate,
-			FrameNum:       uint(frameToV1(ts.CaptureFrame)),
+			FrameNum:       frameToV1(ts.CaptureFrame),
 			SystemTimeUTC:  ts.SystemTimeUTC,
 			Time:           ts.MissionTime,
 			TimeMultiplier: ts.TimeMultiplier,
@@ -123,7 +123,7 @@ func Build(data *MissionData) Export {
 			IsPlayer:      boolToInt(isPlayer),
 			Type:          "unit",
 			Role:          record.Soldier.RoleDescription,
-			StartFrameNum: uint(frameToV1(record.Soldier.JoinFrame)),
+			StartFrameNum: frameToV1(record.Soldier.JoinFrame),
 			Positions:     make([][]any, 0, len(record.States)),
 			FramesFired:   make([][]any, 0, len(record.FiredEvents)),
 		}
@@ -173,7 +173,7 @@ func Build(data *MissionData) Export {
 			IsPlayer:      0,
 			Type:          "vehicle",
 			Class:         record.Vehicle.OcapType,
-			StartFrameNum: uint(frameToV1(record.Vehicle.JoinFrame)),
+			StartFrameNum: frameToV1(record.Vehicle.JoinFrame),
 			Positions:     make([][]any, 0, len(record.States)),
 			FramesFired:   [][]any{},
 		}
@@ -206,7 +206,7 @@ func Build(data *MissionData) Export {
 	}
 
 	if maxFrame > 0 {
-		export.EndFrame = uint(frameToV1(maxFrame))
+		export.EndFrame = frameToV1(maxFrame)
 	}
 
 	// Convert general events

--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -398,7 +398,7 @@ func Build(data *MissionData) Export {
 			// EndFrame is the last trajectory point's frame
 			endFrame := -1
 			if len(pe.Trajectory) > 0 {
-				endFrame = int(frameToV1(pe.Trajectory[len(pe.Trajectory)-1].FrameNum))
+				endFrame = frameToV1(pe.Trajectory[len(pe.Trajectory)-1].FrameNum)
 			}
 
 			marker := []any{

--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -205,9 +205,7 @@ func Build(data *MissionData) Export {
 		export.Entities[record.Vehicle.ID] = entity
 	}
 
-	if maxFrame > 0 {
-		export.EndFrame = frameToV1(maxFrame)
-	}
+	export.EndFrame = frameToV1(maxFrame)
 
 	// Convert general events
 	// Format: [frameNum, "type", message]

--- a/internal/storage/memory/export/v1/builder_test.go
+++ b/internal/storage/memory/export/v1/builder_test.go
@@ -88,7 +88,7 @@ func TestBuildEmptyMission(t *testing.T) {
 	assert.Empty(t, export.Events)
 	assert.Empty(t, export.Markers)
 	assert.Empty(t, export.Times)
-	assert.Equal(t, uint(0), export.EndFrame)
+	assert.Equal(t, 0, export.EndFrame)
 }
 
 func TestBuildWithMissionMetadata(t *testing.T) {
@@ -136,13 +136,13 @@ func TestBuildWithTimeStates(t *testing.T) {
 	export := Build(data)
 
 	require.Len(t, export.Times, 2)
-	assert.Equal(t, uint(0), export.Times[0].FrameNum) // internal 1 → v1 0
+	assert.Equal(t, 0, export.Times[0].FrameNum) // internal 1 → v1 0
 	assert.Equal(t, "2035-06-24", export.Times[0].Date)
 	assert.Equal(t, "2024-01-01T10:00:00", export.Times[0].SystemTimeUTC)
 	assert.Equal(t, float32(0), export.Times[0].Time)
 	assert.Equal(t, float32(1.0), export.Times[0].TimeMultiplier)
 
-	assert.Equal(t, uint(99), export.Times[1].FrameNum) // internal 100 → v1 99
+	assert.Equal(t, 99, export.Times[1].FrameNum) // internal 100 → v1 99
 	assert.Equal(t, float32(60), export.Times[1].Time)
 	assert.Equal(t, float32(2.0), export.Times[1].TimeMultiplier)
 }
@@ -182,7 +182,7 @@ func TestBuildWithSoldier(t *testing.T) {
 	assert.Equal(t, 1, entity.IsPlayer)
 	assert.Equal(t, "unit", entity.Type)
 	assert.Equal(t, "Rifleman", entity.Role)
-	assert.Equal(t, uint(9), entity.StartFrameNum) // internal 10 → v1 9
+	assert.Equal(t, 9, entity.StartFrameNum) // internal 10 → v1 9
 
 	// Check positions
 	require.Len(t, entity.Positions, 2)
@@ -217,7 +217,7 @@ func TestBuildWithSoldier(t *testing.T) {
 	assert.Equal(t, 0.0, endPos[2])    // Z
 
 	// EndFrame should be max state frame (internal 20 → v1 19)
-	assert.Equal(t, uint(19), export.EndFrame)
+	assert.Equal(t, 19, export.EndFrame)
 }
 
 func TestBuildWithSoldierInVehicle(t *testing.T) {
@@ -274,7 +274,7 @@ func TestBuildWithVehicle(t *testing.T) {
 	assert.Equal(t, "vehicle", entity.Type)
 	assert.Equal(t, "UNKNOWN", entity.Side)
 	assert.Equal(t, 0, entity.IsPlayer)
-	assert.Equal(t, uint(4), entity.StartFrameNum) // internal 5 → v1 4
+	assert.Equal(t, 4, entity.StartFrameNum) // internal 5 → v1 4
 	assert.Empty(t, entity.FramesFired)
 
 	// Check positions
@@ -298,7 +298,7 @@ func TestBuildWithVehicle(t *testing.T) {
 	frameRange := pos[4].([]int)
 	assert.Equal(t, []int{4, 4}, frameRange)
 
-	assert.Equal(t, uint(14), export.EndFrame) // internal 15 → v1 14
+	assert.Equal(t, 14, export.EndFrame) // internal 15 → v1 14
 }
 
 func TestBuildWithVehicleCrewIDArray(t *testing.T) {
@@ -707,7 +707,7 @@ func TestBuildMaxFrameFromMultipleSources(t *testing.T) {
 
 	export := Build(data)
 
-	assert.Equal(t, uint(149), export.EndFrame) // internal 150 → v1 149
+	assert.Equal(t, 149, export.EndFrame) // internal 150 → v1 149
 }
 
 func TestBuildWithNoEntitiesButEvents(t *testing.T) {

--- a/internal/storage/memory/export/v1/builder_test.go
+++ b/internal/storage/memory/export/v1/builder_test.go
@@ -796,8 +796,8 @@ func TestBuildWithBulletProjectile(t *testing.T) {
 				FirerObjectID:  5,
 				SimulationType: "shotBullet",
 				Trajectory: []core.TrajectoryPoint{
-					{Position: core.Position3D{X: 1000, Y: 2000, Z: 1.5}, Frame: 15},
-					{Position: core.Position3D{X: 1200, Y: 2200, Z: 1.0}, Frame: 16},
+					{Position: core.Position3D{X: 1000, Y: 2000, Z: 1.5}, FrameNum:15},
+					{Position: core.Position3D{X: 1200, Y: 2200, Z: 1.0}, FrameNum:16},
 				},
 			},
 		},
@@ -837,8 +837,8 @@ func TestBuildWithThrownGrenade(t *testing.T) {
 				MagazineDisplay: "Smoke Grenade (White)",
 				MagazineIcon:    `\A3\Weapons_F\Data\UI\gear_smokegrenade_white_ca.paa`,
 				Trajectory: []core.TrajectoryPoint{
-					{Position: core.Position3D{X: 100, Y: 200, Z: 10}, Frame: 100},
-					{Position: core.Position3D{X: 150, Y: 250, Z: 5}, Frame: 105},
+					{Position: core.Position3D{X: 100, Y: 200, Z: 10}, FrameNum:100},
+					{Position: core.Position3D{X: 150, Y: 250, Z: 5}, FrameNum:105},
 				},
 			},
 		},
@@ -890,8 +890,8 @@ func TestBuildWithVehicleProjectile(t *testing.T) {
 				MagazineDisplay: ".50 BMG 200Rnd",
 				MagazineIcon:    `\A3\weapons_f\data\ui\icon_mg_ca.paa`,
 				Trajectory: []core.TrajectoryPoint{
-					{Position: core.Position3D{X: 100, Y: 200, Z: 10}, Frame: 50},
-					{Position: core.Position3D{X: 200, Y: 300, Z: 5}, Frame: 55},
+					{Position: core.Position3D{X: 100, Y: 200, Z: 10}, FrameNum:50},
+					{Position: core.Position3D{X: 200, Y: 300, Z: 5}, FrameNum:55},
 				},
 			},
 		},
@@ -925,8 +925,8 @@ func TestBuildWithOnFootLauncher(t *testing.T) {
 				MagazineDisplay: "HEAT Rocket",
 				MagazineIcon:    `\A3\weapons_f\data\ui\icon_at_ca.paa`,
 				Trajectory: []core.TrajectoryPoint{
-					{Position: core.Position3D{X: 100, Y: 200, Z: 10}, Frame: 80},
-					{Position: core.Position3D{X: 300, Y: 400, Z: 0}, Frame: 85},
+					{Position: core.Position3D{X: 100, Y: 200, Z: 10}, FrameNum:80},
+					{Position: core.Position3D{X: 300, Y: 400, Z: 0}, FrameNum:85},
 				},
 			},
 		},
@@ -957,7 +957,7 @@ func TestBuildWithShotGrenade(t *testing.T) {
 				MuzzleDisplay:   "3GL",
 				MagazineDisplay: "40mm HE",
 				Trajectory: []core.TrajectoryPoint{
-					{Position: core.Position3D{X: 100, Y: 200, Z: 10}, Frame: 60},
+					{Position: core.Position3D{X: 100, Y: 200, Z: 10}, FrameNum:60},
 				},
 			},
 		},
@@ -990,8 +990,8 @@ func TestBuildWithProjectileHitEvents(t *testing.T) {
 				MuzzleDisplay:   "MX 6.5 mm",
 				MagazineDisplay: "6.5 mm 30Rnd",
 				Trajectory: []core.TrajectoryPoint{
-					{Position: core.Position3D{X: 100, Y: 200, Z: 10}, Frame: 50},
-					{Position: core.Position3D{X: 300, Y: 400, Z: 5}, Frame: 52},
+					{Position: core.Position3D{X: 100, Y: 200, Z: 10}, FrameNum:50},
+					{Position: core.Position3D{X: 300, Y: 400, Z: 5}, FrameNum:52},
 				},
 				Hits: []core.ProjectileHit{
 					{CaptureFrame: 52, Position: core.Position3D{X: 300, Y: 400, Z: 5}, SoldierID: &soldierVictim},
@@ -1033,7 +1033,7 @@ func TestBuildWithEmptyMagazineIcon(t *testing.T) {
 				MagazineDisplay: "Unknown",
 				MagazineIcon:    "", // empty → fallback
 				Trajectory: []core.TrajectoryPoint{
-					{Position: core.Position3D{X: 100, Y: 200}, Frame: 50},
+					{Position: core.Position3D{X: 100, Y: 200}, FrameNum:50},
 				},
 			},
 		},
@@ -1066,8 +1066,8 @@ func TestBuildWithProjectileHitOnVehicle(t *testing.T) {
 				MuzzleDisplay:   "PCML",
 				MagazineDisplay: "PCML Missile",
 				Trajectory: []core.TrajectoryPoint{
-					{Position: core.Position3D{X: 0, Y: 0, Z: 10}, Frame: 60},
-					{Position: core.Position3D{X: 300, Y: 400, Z: 5}, Frame: 65},
+					{Position: core.Position3D{X: 0, Y: 0, Z: 10}, FrameNum:60},
+					{Position: core.Position3D{X: 300, Y: 400, Z: 5}, FrameNum:65},
 				},
 				Hits: []core.ProjectileHit{
 					{CaptureFrame: 65, Position: core.Position3D{X: 300, Y: 400, Z: 5}, VehicleID: &vehicleVictim},
@@ -1107,8 +1107,8 @@ func TestBuildWithProjectileHitEmptyMuzzleDisplay(t *testing.T) {
 				MuzzleDisplay:   "", // empty → falls back to WeaponDisplay
 				MagazineDisplay: "6.5 mm 30Rnd",
 				Trajectory: []core.TrajectoryPoint{
-					{Position: core.Position3D{X: 100, Y: 200, Z: 10}, Frame: 50},
-					{Position: core.Position3D{X: 300, Y: 400, Z: 5}, Frame: 52},
+					{Position: core.Position3D{X: 100, Y: 200, Z: 10}, FrameNum:50},
+					{Position: core.Position3D{X: 300, Y: 400, Z: 5}, FrameNum:52},
 				},
 				Hits: []core.ProjectileHit{
 					{CaptureFrame: 52, Position: core.Position3D{X: 300, Y: 400, Z: 5}, SoldierID: &soldierVictim},

--- a/internal/storage/memory/export/v1/builder_test.go
+++ b/internal/storage/memory/export/v1/builder_test.go
@@ -209,7 +209,7 @@ func TestBuildWithSoldier(t *testing.T) {
 	require.Len(t, entity.FramesFired, 1)
 	ff := entity.FramesFired[0]
 	require.Len(t, ff, 2)
-	assert.Equal(t, uint(14), ff[0]) // internal 15 → v1 14
+	assert.Equal(t, 14, ff[0]) // internal 15 → v1 14
 	endPos := ff[1].([]float64)
 	require.Len(t, endPos, 3)
 	assert.Equal(t, 1200.0, endPos[0]) // X
@@ -295,8 +295,8 @@ func TestBuildWithVehicle(t *testing.T) {
 	assert.Equal(t, float64(1), crewEntry[0])
 
 	// Frame range (internal 5 → v1 4)
-	frameRange := pos[4].([]uint)
-	assert.Equal(t, []uint{4, 4}, frameRange)
+	frameRange := pos[4].([]int)
+	assert.Equal(t, []int{4, 4}, frameRange)
 
 	assert.Equal(t, uint(14), export.EndFrame) // internal 15 → v1 14
 }
@@ -428,12 +428,12 @@ func TestBuildWithGeneralEvents(t *testing.T) {
 	require.Len(t, export.Events, 4)
 
 	// Plain string message (internal 10 → v1 9)
-	assert.Equal(t, uint(9), export.Events[0][0])
+	assert.Equal(t, 9, export.Events[0][0])
 	assert.Equal(t, "connected", export.Events[0][1])
 	assert.Equal(t, "Player joined", export.Events[0][2])
 
 	// JSON array should be parsed (internal 20 → v1 19)
-	assert.Equal(t, uint(19), export.Events[1][0])
+	assert.Equal(t, 19, export.Events[1][0])
 	parsedArray := export.Events[1][2].([]any)
 	assert.Len(t, parsedArray, 4)
 
@@ -471,7 +471,7 @@ func TestBuildWithHitEvents(t *testing.T) {
 
 	// Soldier hit (internal 10 → v1 9)
 	evt1 := export.Events[0]
-	assert.Equal(t, uint(9), evt1[0])
+	assert.Equal(t, 9, evt1[0])
 	assert.Equal(t, "hit", evt1[1])
 	assert.Equal(t, uint(5), evt1[2])  // victimID
 	causedBy1 := evt1[3].([]any)
@@ -505,7 +505,7 @@ func TestBuildWithKillEvents(t *testing.T) {
 
 	require.Len(t, export.Events, 1)
 	evt := export.Events[0]
-	assert.Equal(t, uint(99), evt[0]) // internal 100 → v1 99
+	assert.Equal(t, 99, evt[0]) // internal 100 → v1 99
 	assert.Equal(t, "killed", evt[1])
 	assert.Equal(t, uint(5), evt[2])
 	causedBy := evt[3].([]any)
@@ -541,7 +541,7 @@ func TestBuildWithMarker(t *testing.T) {
 
 	assert.Equal(t, "mil_objective", marker[0])  // type
 	assert.Equal(t, "Objective", marker[1])      // text
-	assert.Equal(t, uint(0), marker[2])          // startFrame (internal 1 → v1 0)
+	assert.Equal(t, 0, marker[2])                // startFrame (internal 1 → v1 0)
 	assert.Equal(t, -1, marker[3])               // endFrame (FrameForever → -1)
 	assert.Equal(t, 42, marker[4])               // playerId
 	assert.Equal(t, "800000", marker[5])         // color (# stripped)
@@ -550,8 +550,8 @@ func TestBuildWithMarker(t *testing.T) {
 	// Positions
 	positions := marker[7].([][]any)
 	require.Len(t, positions, 2)
-	assert.Equal(t, uint(0), positions[0][0])    // initial frame (internal 1 → v1 0)
-	assert.Equal(t, uint(49), positions[1][0])   // state change frame (internal 50 → v1 49)
+	assert.Equal(t, 0, positions[0][0])          // initial frame (internal 1 → v1 0)
+	assert.Equal(t, 49, positions[1][0])         // state change frame (internal 50 → v1 49)
 
 	assert.Equal(t, []float64{2.0, 3.0}, marker[8]) // size
 	assert.Equal(t, "ICON", marker[9])              // shape
@@ -583,7 +583,7 @@ func TestBuildWithDeletedMarker(t *testing.T) {
 	require.Len(t, export.Markers, 1)
 	marker := export.Markers[0]
 
-	assert.Equal(t, uint(99), marker[2]) // startFrame (internal 100 → v1 99)
+	assert.Equal(t, 99, marker[2]) // startFrame (internal 100 → v1 99)
 	assert.Equal(t, 105, marker[3])      // endFrame (internal 106 → v1 105, should NOT be -1)
 }
 
@@ -619,7 +619,7 @@ func TestBuildWithPolylineMarker(t *testing.T) {
 	require.Len(t, positions, 1) // Polylines have single frame entry
 
 	frameEntry := positions[0]
-	assert.Equal(t, uint(9), frameEntry[0]) // frameNum (internal 10 → v1 9)
+	assert.Equal(t, 9, frameEntry[0]) // frameNum (internal 10 → v1 9)
 
 	// Coordinates array
 	coords := frameEntry[1].([][]float64)
@@ -809,7 +809,7 @@ func TestBuildWithBulletProjectile(t *testing.T) {
 	entity := export.Entities[5]
 	require.Len(t, entity.FramesFired, 1)
 	ff := entity.FramesFired[0]
-	assert.Equal(t, uint(14), ff[0]) // captureFrame (internal 15 → v1 14)
+	assert.Equal(t, 14, ff[0]) // captureFrame (internal 15 → v1 14)
 	endPos := ff[1].([]float64)
 	assert.Equal(t, 1200.0, endPos[0])
 	assert.Equal(t, 2200.0, endPos[1])
@@ -850,7 +850,7 @@ func TestBuildWithThrownGrenade(t *testing.T) {
 	marker := export.Markers[0]
 	assert.Equal(t, "magIcons/gear_smokegrenade_white_ca.paa", marker[0]) // type
 	assert.Equal(t, "Smoke Grenade (White)", marker[1])                   // text (thrown = magDisp only)
-	assert.Equal(t, uint(99), marker[2])                                  // startFrame (internal 100 → v1 99)
+	assert.Equal(t, 99, marker[2])                                        // startFrame (internal 100 → v1 99)
 	assert.Equal(t, 104, marker[3])                                       // endFrame (internal 105 → v1 104)
 	assert.Equal(t, 3, marker[4])                                         // ownerID
 	assert.Equal(t, "ColorWhite", marker[5])                              // color
@@ -861,7 +861,7 @@ func TestBuildWithThrownGrenade(t *testing.T) {
 	// Check positions array
 	posArray := marker[7].([][]any)
 	require.Len(t, posArray, 2)
-	assert.Equal(t, uint(99), posArray[0][0]) // internal 100 → v1 99
+	assert.Equal(t, 99, posArray[0][0]) // internal 100 → v1 99
 	pos0 := posArray[0][1].([]float64)
 	assert.Equal(t, 100.0, pos0[0])
 	assert.Equal(t, 200.0, pos0[1])
@@ -1005,7 +1005,7 @@ func TestBuildWithProjectileHitEvents(t *testing.T) {
 	// Should generate a hit event
 	require.Len(t, export.Events, 1)
 	evt := export.Events[0]
-	assert.Equal(t, uint(51), evt[0]) // internal 52 → v1 51
+	assert.Equal(t, 51, evt[0]) // internal 52 → v1 51
 	assert.Equal(t, "hit", evt[1])
 	assert.Equal(t, uint(10), evt[2]) // victimID
 	causedBy := evt[3].([]any)
@@ -1080,7 +1080,7 @@ func TestBuildWithProjectileHitOnVehicle(t *testing.T) {
 
 	require.Len(t, export.Events, 1)
 	evt := export.Events[0]
-	assert.Equal(t, uint(64), evt[0]) // internal 65 → v1 64
+	assert.Equal(t, 64, evt[0]) // internal 65 → v1 64
 	assert.Equal(t, "hit", evt[1])
 	assert.Equal(t, uint(20), evt[2]) // victimID from VehicleID
 	causedBy := evt[3].([]any)

--- a/internal/storage/memory/export/v1/builder_test.go
+++ b/internal/storage/memory/export/v1/builder_test.go
@@ -128,7 +128,7 @@ func TestBuildWithTimeStates(t *testing.T) {
 		Vehicles: make(map[uint16]*VehicleRecord),
 		Markers:  make(map[string]*MarkerRecord),
 		TimeStates: []core.TimeState{
-			{CaptureFrame: 0, MissionDate: "2035-06-24", SystemTimeUTC: "2024-01-01T10:00:00", MissionTime: 0, TimeMultiplier: 1.0},
+			{CaptureFrame: 1, MissionDate: "2035-06-24", SystemTimeUTC: "2024-01-01T10:00:00", MissionTime: 0, TimeMultiplier: 1.0},
 			{CaptureFrame: 100, MissionDate: "2035-06-24", SystemTimeUTC: "2024-01-01T10:01:00", MissionTime: 60, TimeMultiplier: 2.0},
 		},
 	}
@@ -136,13 +136,13 @@ func TestBuildWithTimeStates(t *testing.T) {
 	export := Build(data)
 
 	require.Len(t, export.Times, 2)
-	assert.Equal(t, uint(0), export.Times[0].FrameNum)
+	assert.Equal(t, uint(0), export.Times[0].FrameNum) // internal 1 → v1 0
 	assert.Equal(t, "2035-06-24", export.Times[0].Date)
 	assert.Equal(t, "2024-01-01T10:00:00", export.Times[0].SystemTimeUTC)
 	assert.Equal(t, float32(0), export.Times[0].Time)
 	assert.Equal(t, float32(1.0), export.Times[0].TimeMultiplier)
 
-	assert.Equal(t, uint(100), export.Times[1].FrameNum)
+	assert.Equal(t, uint(99), export.Times[1].FrameNum) // internal 100 → v1 99
 	assert.Equal(t, float32(60), export.Times[1].Time)
 	assert.Equal(t, float32(2.0), export.Times[1].TimeMultiplier)
 }
@@ -182,7 +182,7 @@ func TestBuildWithSoldier(t *testing.T) {
 	assert.Equal(t, 1, entity.IsPlayer)
 	assert.Equal(t, "unit", entity.Type)
 	assert.Equal(t, "Rifleman", entity.Role)
-	assert.Equal(t, uint(10), entity.StartFrameNum)
+	assert.Equal(t, uint(9), entity.StartFrameNum) // internal 10 → v1 9
 
 	// Check positions
 	require.Len(t, entity.Positions, 2)
@@ -209,15 +209,15 @@ func TestBuildWithSoldier(t *testing.T) {
 	require.Len(t, entity.FramesFired, 1)
 	ff := entity.FramesFired[0]
 	require.Len(t, ff, 2)
-	assert.Equal(t, uint(15), ff[0]) // captureFrame
+	assert.Equal(t, uint(14), ff[0]) // internal 15 → v1 14
 	endPos := ff[1].([]float64)
 	require.Len(t, endPos, 3)
 	assert.Equal(t, 1200.0, endPos[0]) // X
 	assert.Equal(t, 2200.0, endPos[1]) // Y
 	assert.Equal(t, 0.0, endPos[2])    // Z
 
-	// EndFrame should be max state frame
-	assert.Equal(t, uint(20), export.EndFrame)
+	// EndFrame should be max state frame (internal 20 → v1 19)
+	assert.Equal(t, uint(19), export.EndFrame)
 }
 
 func TestBuildWithSoldierInVehicle(t *testing.T) {
@@ -227,9 +227,9 @@ func TestBuildWithSoldierInVehicle(t *testing.T) {
 		World:   &core.World{WorldName: "Altis"},
 		Soldiers: map[uint16]*SoldierRecord{
 			1: {
-				Soldier: core.Soldier{ID: 1, UnitName: "Driver"},
+				Soldier: core.Soldier{ID: 1, UnitName: "Driver", JoinFrame: 1},
 				States: []core.SoldierState{
-					{SoldierID: 1, CaptureFrame: 0, InVehicleObjectID: &inVehicleID},
+					{SoldierID: 1, CaptureFrame: 1, InVehicleObjectID: &inVehicleID},
 				},
 			},
 		},
@@ -274,7 +274,7 @@ func TestBuildWithVehicle(t *testing.T) {
 	assert.Equal(t, "vehicle", entity.Type)
 	assert.Equal(t, "UNKNOWN", entity.Side)
 	assert.Equal(t, 0, entity.IsPlayer)
-	assert.Equal(t, uint(5), entity.StartFrameNum)
+	assert.Equal(t, uint(4), entity.StartFrameNum) // internal 5 → v1 4
 	assert.Empty(t, entity.FramesFired)
 
 	// Check positions
@@ -294,11 +294,11 @@ func TestBuildWithVehicle(t *testing.T) {
 	crewEntry := crew[0].([]any)
 	assert.Equal(t, float64(1), crewEntry[0])
 
-	// Frame range
+	// Frame range (internal 5 → v1 4)
 	frameRange := pos[4].([]uint)
-	assert.Equal(t, []uint{5, 5}, frameRange)
+	assert.Equal(t, []uint{4, 4}, frameRange)
 
-	assert.Equal(t, uint(15), export.EndFrame)
+	assert.Equal(t, uint(14), export.EndFrame) // internal 15 → v1 14
 }
 
 func TestBuildWithVehicleCrewIDArray(t *testing.T) {
@@ -308,11 +308,11 @@ func TestBuildWithVehicleCrewIDArray(t *testing.T) {
 		Soldiers: make(map[uint16]*SoldierRecord),
 		Vehicles: map[uint16]*VehicleRecord{
 			10: {
-				Vehicle: core.Vehicle{ID: 10, OcapType: "apc"},
+				Vehicle: core.Vehicle{ID: 10, OcapType: "apc", JoinFrame: 1},
 				States: []core.VehicleState{
-					{VehicleID: 10, CaptureFrame: 0, Crew: "[20,21]", IsAlive: true},
-					{VehicleID: 10, CaptureFrame: 1, Crew: "[20]", IsAlive: true},
-					{VehicleID: 10, CaptureFrame: 2, Crew: "[]", IsAlive: true},
+					{VehicleID: 10, CaptureFrame: 1, Crew: "[20,21]", IsAlive: true},
+					{VehicleID: 10, CaptureFrame: 2, Crew: "[20]", IsAlive: true},
+					{VehicleID: 10, CaptureFrame: 3, Crew: "[]", IsAlive: true},
 				},
 			},
 		},
@@ -347,9 +347,9 @@ func TestBuildWithVehicleEmptyCrew(t *testing.T) {
 		Soldiers: make(map[uint16]*SoldierRecord),
 		Vehicles: map[uint16]*VehicleRecord{
 			1: {
-				Vehicle: core.Vehicle{ID: 1, OcapType: "car"},
+				Vehicle: core.Vehicle{ID: 1, OcapType: "car", JoinFrame: 1},
 				States: []core.VehicleState{
-					{VehicleID: 1, CaptureFrame: 0, Crew: ""},
+					{VehicleID: 1, CaptureFrame: 1, Crew: ""},
 				},
 			},
 		},
@@ -370,9 +370,9 @@ func TestBuildWithVehicleInvalidCrewJSON(t *testing.T) {
 		Soldiers: make(map[uint16]*SoldierRecord),
 		Vehicles: map[uint16]*VehicleRecord{
 			1: {
-				Vehicle: core.Vehicle{ID: 1, OcapType: "car"},
+				Vehicle: core.Vehicle{ID: 1, OcapType: "car", JoinFrame: 1},
 				States: []core.VehicleState{
-					{VehicleID: 1, CaptureFrame: 0, Crew: "invalid json"},
+					{VehicleID: 1, CaptureFrame: 1, Crew: "invalid json"},
 				},
 			},
 		},
@@ -393,7 +393,7 @@ func TestBuildWithDeadVehicle(t *testing.T) {
 		Soldiers: make(map[uint16]*SoldierRecord),
 		Vehicles: map[uint16]*VehicleRecord{
 			1: {
-				Vehicle: core.Vehicle{ID: 1, OcapType: "tank"},
+				Vehicle: core.Vehicle{ID: 1, OcapType: "tank", JoinFrame: 50},
 				States: []core.VehicleState{
 					{VehicleID: 1, CaptureFrame: 50, IsAlive: false},
 				},
@@ -427,13 +427,13 @@ func TestBuildWithGeneralEvents(t *testing.T) {
 
 	require.Len(t, export.Events, 4)
 
-	// Plain string message
-	assert.Equal(t, uint(10), export.Events[0][0])
+	// Plain string message (internal 10 → v1 9)
+	assert.Equal(t, uint(9), export.Events[0][0])
 	assert.Equal(t, "connected", export.Events[0][1])
 	assert.Equal(t, "Player joined", export.Events[0][2])
 
-	// JSON array should be parsed
-	assert.Equal(t, uint(20), export.Events[1][0])
+	// JSON array should be parsed (internal 20 → v1 19)
+	assert.Equal(t, uint(19), export.Events[1][0])
 	parsedArray := export.Events[1][2].([]any)
 	assert.Len(t, parsedArray, 4)
 
@@ -469,9 +469,9 @@ func TestBuildWithHitEvents(t *testing.T) {
 
 	require.Len(t, export.Events, 2)
 
-	// Soldier hit
+	// Soldier hit (internal 10 → v1 9)
 	evt1 := export.Events[0]
-	assert.Equal(t, uint(10), evt1[0])
+	assert.Equal(t, uint(9), evt1[0])
 	assert.Equal(t, "hit", evt1[1])
 	assert.Equal(t, uint(5), evt1[2])  // victimID
 	causedBy1 := evt1[3].([]any)
@@ -479,9 +479,9 @@ func TestBuildWithHitEvents(t *testing.T) {
 	assert.Equal(t, "rifle", causedBy1[1])
 	assert.Equal(t, float32(50), evt1[4])
 
-	// Vehicle hit
+	// Vehicle hit (internal 20 → v1 19)
 	evt2 := export.Events[1]
-	assert.Equal(t, uint(20), evt2[2]) // vehicleVictim takes precedence
+	assert.Equal(t, uint(20), evt2[2]) // vehicleVictim takes precedence (ID, not frame)
 	causedBy2 := evt2[3].([]any)
 	assert.Equal(t, uint(25), causedBy2[0])
 }
@@ -505,7 +505,7 @@ func TestBuildWithKillEvents(t *testing.T) {
 
 	require.Len(t, export.Events, 1)
 	evt := export.Events[0]
-	assert.Equal(t, uint(100), evt[0])
+	assert.Equal(t, uint(99), evt[0]) // internal 100 → v1 99
 	assert.Equal(t, "killed", evt[1])
 	assert.Equal(t, uint(5), evt[2])
 	causedBy := evt[3].([]any)
@@ -525,7 +525,7 @@ func TestBuildWithMarker(t *testing.T) {
 				Marker: core.Marker{
 					ID: 1, MarkerName: "obj_alpha", Text: "Objective", MarkerType: "mil_objective",
 					Color: "#800000", Side: "WEST", Shape: "ICON", OwnerID: 42, Size: "[2.0,3.0]", Brush: "Solid",
-					CaptureFrame: 0, Position: core.Position3D{X: 5000, Y: 6000}, Direction: 45, Alpha: 1.0,
+					CaptureFrame: 1, Position: core.Position3D{X: 5000, Y: 6000}, Direction: 45, Alpha: 1.0,
 				},
 				States: []core.MarkerState{
 					{MarkerID: 1, CaptureFrame: 50, Position: core.Position3D{X: 5100, Y: 6100}, Direction: 90, Alpha: 0.8},
@@ -541,8 +541,8 @@ func TestBuildWithMarker(t *testing.T) {
 
 	assert.Equal(t, "mil_objective", marker[0])  // type
 	assert.Equal(t, "Objective", marker[1])      // text
-	assert.Equal(t, uint(0), marker[2])          // startFrame
-	assert.Equal(t, -1, marker[3])               // endFrame
+	assert.Equal(t, uint(0), marker[2])          // startFrame (internal 1 → v1 0)
+	assert.Equal(t, -1, marker[3])               // endFrame (FrameForever → -1)
 	assert.Equal(t, 42, marker[4])               // playerId
 	assert.Equal(t, "800000", marker[5])         // color (# stripped)
 	assert.Equal(t, 1, marker[6])                // sideIndex (WEST = 1)
@@ -550,8 +550,8 @@ func TestBuildWithMarker(t *testing.T) {
 	// Positions
 	positions := marker[7].([][]any)
 	require.Len(t, positions, 2)
-	assert.Equal(t, uint(0), positions[0][0])    // initial frame
-	assert.Equal(t, uint(50), positions[1][0])   // state change frame
+	assert.Equal(t, uint(0), positions[0][0])    // initial frame (internal 1 → v1 0)
+	assert.Equal(t, uint(49), positions[1][0])   // state change frame (internal 50 → v1 49)
 
 	assert.Equal(t, []float64{2.0, 3.0}, marker[8]) // size
 	assert.Equal(t, "ICON", marker[9])              // shape
@@ -583,8 +583,8 @@ func TestBuildWithDeletedMarker(t *testing.T) {
 	require.Len(t, export.Markers, 1)
 	marker := export.Markers[0]
 
-	assert.Equal(t, uint(100), marker[2]) // startFrame
-	assert.Equal(t, 106, marker[3])       // endFrame (should NOT be -1)
+	assert.Equal(t, uint(99), marker[2]) // startFrame (internal 100 → v1 99)
+	assert.Equal(t, 105, marker[3])      // endFrame (internal 106 → v1 105, should NOT be -1)
 }
 
 func TestBuildWithPolylineMarker(t *testing.T) {
@@ -619,7 +619,7 @@ func TestBuildWithPolylineMarker(t *testing.T) {
 	require.Len(t, positions, 1) // Polylines have single frame entry
 
 	frameEntry := positions[0]
-	assert.Equal(t, uint(10), frameEntry[0]) // frameNum
+	assert.Equal(t, uint(9), frameEntry[0]) // frameNum (internal 10 → v1 9)
 
 	// Coordinates array
 	coords := frameEntry[1].([][]float64)
@@ -707,7 +707,7 @@ func TestBuildMaxFrameFromMultipleSources(t *testing.T) {
 
 	export := Build(data)
 
-	assert.Equal(t, uint(150), export.EndFrame)
+	assert.Equal(t, uint(149), export.EndFrame) // internal 150 → v1 149
 }
 
 func TestBuildWithNoEntitiesButEvents(t *testing.T) {
@@ -809,7 +809,7 @@ func TestBuildWithBulletProjectile(t *testing.T) {
 	entity := export.Entities[5]
 	require.Len(t, entity.FramesFired, 1)
 	ff := entity.FramesFired[0]
-	assert.Equal(t, uint(15), ff[0]) // captureFrame
+	assert.Equal(t, uint(14), ff[0]) // captureFrame (internal 15 → v1 14)
 	endPos := ff[1].([]float64)
 	assert.Equal(t, 1200.0, endPos[0])
 	assert.Equal(t, 2200.0, endPos[1])
@@ -850,8 +850,8 @@ func TestBuildWithThrownGrenade(t *testing.T) {
 	marker := export.Markers[0]
 	assert.Equal(t, "magIcons/gear_smokegrenade_white_ca.paa", marker[0]) // type
 	assert.Equal(t, "Smoke Grenade (White)", marker[1])                   // text (thrown = magDisp only)
-	assert.Equal(t, uint(100), marker[2])                                 // startFrame
-	assert.Equal(t, 105, marker[3])                                       // endFrame
+	assert.Equal(t, uint(99), marker[2])                                  // startFrame (internal 100 → v1 99)
+	assert.Equal(t, 104, marker[3])                                       // endFrame (internal 105 → v1 104)
 	assert.Equal(t, 3, marker[4])                                         // ownerID
 	assert.Equal(t, "ColorWhite", marker[5])                              // color
 	assert.Equal(t, -1, marker[6])                                        // sideIndex (GLOBAL)
@@ -861,7 +861,7 @@ func TestBuildWithThrownGrenade(t *testing.T) {
 	// Check positions array
 	posArray := marker[7].([][]any)
 	require.Len(t, posArray, 2)
-	assert.Equal(t, uint(100), posArray[0][0])
+	assert.Equal(t, uint(99), posArray[0][0]) // internal 100 → v1 99
 	pos0 := posArray[0][1].([]float64)
 	assert.Equal(t, 100.0, pos0[0])
 	assert.Equal(t, 200.0, pos0[1])
@@ -1005,7 +1005,7 @@ func TestBuildWithProjectileHitEvents(t *testing.T) {
 	// Should generate a hit event
 	require.Len(t, export.Events, 1)
 	evt := export.Events[0]
-	assert.Equal(t, uint(52), evt[0])
+	assert.Equal(t, uint(51), evt[0]) // internal 52 → v1 51
 	assert.Equal(t, "hit", evt[1])
 	assert.Equal(t, uint(10), evt[2]) // victimID
 	causedBy := evt[3].([]any)
@@ -1080,7 +1080,7 @@ func TestBuildWithProjectileHitOnVehicle(t *testing.T) {
 
 	require.Len(t, export.Events, 1)
 	evt := export.Events[0]
-	assert.Equal(t, uint(65), evt[0])
+	assert.Equal(t, uint(64), evt[0]) // internal 65 → v1 64
 	assert.Equal(t, "hit", evt[1])
 	assert.Equal(t, uint(20), evt[2]) // victimID from VehicleID
 	causedBy := evt[3].([]any)

--- a/internal/storage/memory/export/v1/builder_test.go
+++ b/internal/storage/memory/export/v1/builder_test.go
@@ -88,7 +88,7 @@ func TestBuildEmptyMission(t *testing.T) {
 	assert.Empty(t, export.Events)
 	assert.Empty(t, export.Markers)
 	assert.Empty(t, export.Times)
-	assert.Equal(t, 0, export.EndFrame)
+	assert.Equal(t, -1, export.EndFrame) // no frames → FrameForever(0) → v1 -1
 }
 
 func TestBuildWithMissionMetadata(t *testing.T) {

--- a/internal/storage/memory/export/v1/types.go
+++ b/internal/storage/memory/export/v1/types.go
@@ -11,7 +11,7 @@ type Export struct {
 	MissionName      string     `json:"missionName"`
 	MissionAuthor    string     `json:"missionAuthor"`
 	WorldName        string     `json:"worldName"`
-	EndFrame         uint       `json:"endFrame"`
+	EndFrame         int        `json:"endFrame"`
 	CaptureDelay     float32    `json:"captureDelay"`
 	Tags             string     `json:"tags"`
 	Times            []Time     `json:"times"`
@@ -23,7 +23,7 @@ type Export struct {
 // Time represents time synchronization data for a frame
 type Time struct {
 	Date           string  `json:"date"`
-	FrameNum       uint    `json:"frameNum"`
+	FrameNum       int     `json:"frameNum"`
 	SystemTimeUTC  string  `json:"systemTimeUTC"`
 	Time           float32 `json:"time"`
 	TimeMultiplier float32 `json:"timeMultiplier"`
@@ -39,7 +39,7 @@ type Entity struct {
 	Type          string  `json:"type"`
 	Role          string  `json:"role,omitempty"`
 	Class         string  `json:"class,omitempty"`
-	StartFrameNum uint    `json:"startFrameNum"`
+	StartFrameNum int     `json:"startFrameNum"`
 	Positions     [][]any `json:"positions"`
 	FramesFired   [][]any `json:"framesFired"`
 }

--- a/internal/storage/memory/export_test.go
+++ b/internal/storage/memory/export_test.go
@@ -102,11 +102,11 @@ func TestIntegrationFullExport(t *testing.T) {
 	assert.Equal(t, "2.0.0", export.ExtensionVersion)
 	assert.Equal(t, "Mon Jan 15 10:00:00 2024", export.ExtensionBuild)
 	assert.Equal(t, "PvP", export.Tags)
-	assert.Equal(t, uint(9), export.EndFrame, "EndFrame should be max state frame")
+	assert.Equal(t, 9, export.EndFrame, "EndFrame should be max state frame")
 
 	// Verify times
 	require.Len(t, export.Times, 1)
-	assert.Equal(t, uint(0), export.Times[0].FrameNum)
+	assert.Equal(t, 0, export.Times[0].FrameNum)
 	assert.Equal(t, "2024-01-15T10:30:00.000", export.Times[0].SystemTimeUTC)
 
 	// Verify entities (array is sparse: index = entity ID)
@@ -442,7 +442,7 @@ func TestMaxFrameCalculation(t *testing.T) {
 	require.NoError(t, b.RecordVehicleState(&core.VehicleState{VehicleID: 10, CaptureFrame: 100}))
 	require.NoError(t, b.RecordVehicleState(&core.VehicleState{VehicleID: 10, CaptureFrame: 75}))
 
-	assert.Equal(t, uint(99), b.BuildExport().EndFrame)
+	assert.Equal(t, 99, b.BuildExport().EndFrame)
 }
 
 func TestSoldierWithoutVehicle(t *testing.T) {
@@ -689,7 +689,7 @@ func TestVehicleWithJoinFrame(t *testing.T) {
 	// Sparse array: entity at index 20 (its ID)
 	require.Len(t, export.Entities, 21) // indices 0-20
 	entity := export.Entities[20]
-	assert.Equal(t, uint(499), entity.StartFrameNum)
+	assert.Equal(t, 499, entity.StartFrameNum)
 	assert.Equal(t, "vehicle", entity.Type)
 	assert.Equal(t, "plane", entity.Class)
 }
@@ -1020,14 +1020,14 @@ func TestTimesExport(t *testing.T) {
 	require.Len(t, export.Times, 2)
 
 	// Verify first time state
-	assert.Equal(t, uint(0), export.Times[0].FrameNum)
+	assert.Equal(t, 0, export.Times[0].FrameNum)
 	assert.Equal(t, "2026-01-25T18:46:48.850", export.Times[0].SystemTimeUTC)
 	assert.Equal(t, "2035-06-24T12:26:00", export.Times[0].Date)
 	assert.Equal(t, float32(1.0), export.Times[0].TimeMultiplier)
 	assert.Equal(t, float32(1597.56), export.Times[0].Time)
 
 	// Verify second time state
-	assert.Equal(t, uint(9), export.Times[1].FrameNum)
+	assert.Equal(t, 9, export.Times[1].FrameNum)
 	assert.Equal(t, "2026-01-25T18:47:18.854", export.Times[1].SystemTimeUTC)
 	assert.Equal(t, "2035-06-24T12:27:00", export.Times[1].Date)
 	assert.Equal(t, float32(2.0), export.Times[1].TimeMultiplier)

--- a/internal/storage/memory/export_test.go
+++ b/internal/storage/memory/export_test.go
@@ -343,8 +343,8 @@ func TestVehiclePositionFormat(t *testing.T) {
 	assert.Equal(t, 1, pos[2])
 
 	// Frame range
-	frameRange := pos[4].([]uint)
-	assert.Equal(t, []uint{2, 2}, frameRange)
+	frameRange := pos[4].([]int)
+	assert.Equal(t, []int{2, 2}, frameRange)
 }
 
 func TestFiredEventFormat(t *testing.T) {
@@ -366,7 +366,7 @@ func TestFiredEventFormat(t *testing.T) {
 	ff := export.Entities[1].FramesFired[0]
 	// v1 format: [frameNum, [x, y, z]] - matches old C++ extension
 	require.Len(t, ff, 2)
-	assert.Equal(t, uint(99), ff[0])
+	assert.Equal(t, 99, ff[0])
 
 	endPos, ok := ff[1].([]float64)
 	require.True(t, ok, "endPos should be []float64")
@@ -398,14 +398,14 @@ func TestMarkerPositionFormat(t *testing.T) {
 
 	// Position format: [frameNum, [x, y, z], direction, alpha]
 	initialPos := positions[0]
-	assert.Equal(t, uint(0), initialPos[0])      // frameNum
+	assert.Equal(t, 0, initialPos[0])             // frameNum
 	coords := initialPos[1].([]float64)
 	require.Len(t, coords, 3)
 	assert.Equal(t, 1000.0, coords[0])           // posX
 	assert.Equal(t, 2000.0, coords[1])           // posY
 	assert.Equal(t, 0.0, coords[2])              // posZ
 
-	assert.Equal(t, uint(49), positions[1][0])   // second position frameNum (input 50 → v1 output 49)
+	assert.Equal(t, 49, positions[1][0])         // second position frameNum (input 50 → v1 output 49)
 }
 
 func TestEmptyExport(t *testing.T) {
@@ -531,7 +531,7 @@ func TestEventWithoutExtraData(t *testing.T) {
 
 	require.Len(t, export.Events, 1)
 	assert.Equal(t, "endMission", export.Events[0][1])       // type at index 1
-	assert.Equal(t, uint(99), export.Events[0][0])           // frameNum at index 0 (input 100 → v1 output 99)
+	assert.Equal(t, 99, export.Events[0][0])                 // frameNum at index 0 (input 100 → v1 output 99)
 	assert.Equal(t, "Mission ended", export.Events[0][2])    // message at index 2
 }
 
@@ -662,10 +662,10 @@ func TestMultipleFiredEvents(t *testing.T) {
 	require.Len(t, entity.FramesFired, 3)
 
 	// v1 format: [frameNum, [x, y, z]] - verify frames and positions
-	frames := make(map[uint]bool)
+	frames := make(map[int]bool)
 	for _, ff := range entity.FramesFired {
 		require.Len(t, ff, 2)
-		frames[ff[0].(uint)] = true
+		frames[ff[0].(int)] = true
 	}
 	assert.True(t, frames[9], "frame 9 should be recorded (input 10 → v1 output 9)")
 	assert.True(t, frames[14], "frame 14 should be recorded (input 15 → v1 output 14)")

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -230,7 +230,7 @@ func (b *Backend) DeleteMarker(dm *core.DeleteMarker) error {
 	defer b.mu.Unlock()
 
 	if record, ok := b.markers[dm.Name]; ok {
-		record.Marker.EndFrame = int(dm.EndFrame)
+		record.Marker.EndFrame = dm.EndFrame
 	}
 	return nil
 }
@@ -355,7 +355,7 @@ func (b *Backend) computeExportMetadata() core.UploadMetadata {
 		return core.UploadMetadata{}
 	}
 
-	var endFrame uint
+	var endFrame core.Frame
 	for _, record := range b.soldiers {
 		for _, state := range record.States {
 			if state.CaptureFrame > endFrame {

--- a/internal/storage/memory/memory_test.go
+++ b/internal/storage/memory/memory_test.go
@@ -174,8 +174,8 @@ func TestRecordSoldierState(t *testing.T) {
 
 	record := b.soldiers[s.ID]
 	assert.Len(t, record.States, 2)
-	assert.Equal(t, uint(0), record.States[0].CaptureFrame)
-	assert.Equal(t, uint(1), record.States[1].CaptureFrame)
+	assert.Equal(t, core.Frame(0), record.States[0].CaptureFrame)
+	assert.Equal(t, core.Frame(1), record.States[1].CaptureFrame)
 
 	// Recording state for non-existent soldier should not error
 	orphanState := &core.SoldierState{SoldierID: 999, CaptureFrame: 0}
@@ -233,7 +233,7 @@ func TestRecordMarkerState(t *testing.T) {
 func TestDeleteMarker(t *testing.T) {
 	b := New(config.MemoryConfig{})
 
-	m := &core.Marker{MarkerName: "grenade_1", EndFrame: -1}
+	m := &core.Marker{MarkerName: "grenade_1", EndFrame: core.FrameForever}
 	_, err := b.AddMarker(m)
 	require.NoError(t, err)
 
@@ -241,7 +241,7 @@ func TestDeleteMarker(t *testing.T) {
 	require.NoError(t, b.DeleteMarker(&core.DeleteMarker{Name: "grenade_1", EndFrame: 100}))
 
 	record := b.markers["grenade_1"]
-	assert.Equal(t, 100, record.Marker.EndFrame)
+	assert.Equal(t, core.Frame(100), record.Marker.EndFrame)
 
 	// Deleting non-existent marker should not panic
 	require.NoError(t, b.DeleteMarker(&core.DeleteMarker{Name: "nonexistent", EndFrame: 50}))
@@ -393,7 +393,7 @@ func TestRecordTimeState(t *testing.T) {
 	require.NoError(t, b.RecordTimeState(state))
 
 	assert.Len(t, b.timeStates, 1)
-	assert.Equal(t, uint(100), b.timeStates[0].CaptureFrame)
+	assert.Equal(t, core.Frame(100), b.timeStates[0].CaptureFrame)
 	assert.Equal(t, float32(2.0), b.timeStates[0].TimeMultiplier)
 }
 
@@ -436,8 +436,8 @@ func TestRecordProjectileEvent(t *testing.T) {
 		SimulationType: "",
 		MagazineDisplay: "RGO Grenade",
 		Trajectory: []core.TrajectoryPoint{
-			{Position: core.Position3D{X: 100, Y: 200, Z: 10}, Frame: 100},
-			{Position: core.Position3D{X: 150, Y: 250, Z: 5}, Frame: 105},
+			{Position: core.Position3D{X: 100, Y: 200, Z: 10}, FrameNum: 100},
+			{Position: core.Position3D{X: 150, Y: 250, Z: 5}, FrameNum: 105},
 		},
 	}
 

--- a/internal/storage/postgres/postgres.go
+++ b/internal/storage/postgres/postgres.go
@@ -271,7 +271,7 @@ func (b *Backend) DeleteMarker(dm *core.DeleteMarker) error {
 
 	deleteState := model.MarkerState{
 		MarkerID:     markerID,
-		CaptureFrame: dm.EndFrame,
+		CaptureFrame: uint(dm.EndFrame),
 		Time:         time.Now(),
 		Alpha:        0,
 	}
@@ -333,7 +333,7 @@ func (b *Backend) RecordRadioEvent(e *core.RadioEvent) error {
 func (b *Backend) RecordTelemetryEvent(e *core.TelemetryEvent) error {
 	b.queues.FpsEvents.Push(model.ServerFpsEvent{
 		Time:         e.Time,
-		CaptureFrame: e.CaptureFrame,
+		CaptureFrame: uint(e.CaptureFrame),
 		FpsAverage:   e.FpsAverage,
 		FpsMin:       e.FpsMin,
 	})

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -162,8 +162,8 @@ func TestRecordProjectileEvent_QueuesToInternalQueue(t *testing.T) {
 		FirerObjectID: 1,
 		CaptureFrame:  620,
 		Trajectory: []core.TrajectoryPoint{
-			{Position: core.Position3D{X: 100, Y: 200, Z: 10}, Frame: 620},
-			{Position: core.Position3D{X: 110, Y: 210, Z: 11}, Frame: 621},
+			{Position: core.Position3D{X: 100, Y: 200, Z: 10}, FrameNum:620},
+			{Position: core.Position3D{X: 110, Y: 210, Z: 11}, FrameNum:621},
 		},
 	}
 

--- a/internal/storage/websocket/websocket_test.go
+++ b/internal/storage/websocket/websocket_test.go
@@ -216,7 +216,7 @@ func TestEnvelopeSerialization(t *testing.T) {
 	var dp core.DeleteMarker
 	require.NoError(t, json.Unmarshal(decoded.Payload, &dp))
 	assert.Equal(t, "mrk1", dp.Name)
-	assert.Equal(t, uint(42), dp.EndFrame)
+	assert.Equal(t, core.Frame(42), dp.EndFrame)
 }
 
 func TestMarkerIDResetsAfterEndMission(t *testing.T) {

--- a/internal/worker/dispatch_test.go
+++ b/internal/worker/dispatch_test.go
@@ -738,8 +738,8 @@ func TestHandleProjectile_ClassifiesHitParts(t *testing.T) {
 			FirerObjectID: 1,
 			CaptureFrame:  620,
 			Trajectory: []core.TrajectoryPoint{
-				{Position: core.Position3D{X: 6456.5, Y: 5345.7, Z: 10.0}, Frame: 620},
-				{Position: core.Position3D{X: 6448.0, Y: 5337.0, Z: 15.0}, Frame: 625},
+				{Position: core.Position3D{X: 6456.5, Y: 5345.7, Z: 10.0}, FrameNum:620},
+				{Position: core.Position3D{X: 6448.0, Y: 5337.0, Z: 15.0}, FrameNum:625},
 			},
 			HitParts: []parser.HitPart{
 				{EntityID: 7, ComponentsHit: []string{"head"}, CaptureFrame: 625},
@@ -812,9 +812,9 @@ func TestHandleProjectile_RecordsProjectileEvent(t *testing.T) {
 			MagazineIcon:    `\A3\Weapons_F\Data\UI\gear_M67_CA.paa`,
 			SimulationType:  "shotShell",
 			Trajectory: []core.TrajectoryPoint{
-				{Position: core.Position3D{X: 6456.5, Y: 5345.7, Z: 10.443}, Frame: 620},
-				{Position: core.Position3D{X: 6448.0, Y: 5337.0, Z: 15.0}, Frame: 625},
-				{Position: core.Position3D{X: 6441.55, Y: 5328.46, Z: 9.88}, Frame: 630},
+				{Position: core.Position3D{X: 6456.5, Y: 5345.7, Z: 10.443}, FrameNum:620},
+				{Position: core.Position3D{X: 6448.0, Y: 5337.0, Z: 15.0}, FrameNum:625},
+				{Position: core.Position3D{X: 6441.55, Y: 5328.46, Z: 9.88}, FrameNum:630},
 			},
 		},
 	}
@@ -857,15 +857,15 @@ func TestHandleProjectile_RecordsProjectileEvent(t *testing.T) {
 	require.Equal(t, 1, len(backend.projectileEvents), "expected 1 projectile event")
 	pe := backend.projectileEvents[0]
 	assert.Equal(t, uint16(1), pe.FirerObjectID)
-	assert.Equal(t, uint(620), pe.CaptureFrame)
+	assert.Equal(t, core.Frame(620), pe.CaptureFrame)
 	assert.Equal(t, "RGO Grenade", pe.MagazineDisplay)
 
 	// Trajectory should have 3 points
 	require.Len(t, pe.Trajectory, 3)
 	assert.Equal(t, 6456.5, pe.Trajectory[0].Position.X)
-	assert.Equal(t, uint(620), pe.Trajectory[0].Frame)
+	assert.Equal(t, core.Frame(620), pe.Trajectory[0].FrameNum)
 	assert.Equal(t, 6441.55, pe.Trajectory[2].Position.X)
-	assert.Equal(t, uint(630), pe.Trajectory[2].Frame)
+	assert.Equal(t, core.Frame(630), pe.Trajectory[2].FrameNum)
 
 	// No markers or fired events should be created
 	assert.Empty(t, backend.markers, "dispatch should not create markers")
@@ -985,7 +985,7 @@ func TestHandleMarkerDelete_WithBackend(t *testing.T) {
 	defer backend.mu.Unlock()
 	require.Len(t, backend.deletedMarkers, 1)
 	assert.Equal(t, "Projectile#123", backend.deletedMarkers[0].Name)
-	assert.Equal(t, uint(500), backend.deletedMarkers[0].EndFrame)
+	assert.Equal(t, core.Frame(500), backend.deletedMarkers[0].EndFrame)
 }
 
 func TestHandleVehicleState_HappyPath(t *testing.T) {
@@ -1048,7 +1048,7 @@ func TestHandleTimeState(t *testing.T) {
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
 	require.Equal(t, 1, len(backend.timeStates))
-	assert.Equal(t, uint(200), backend.timeStates[0].CaptureFrame)
+	assert.Equal(t, core.Frame(200), backend.timeStates[0].CaptureFrame)
 }
 
 func TestHandleGeneralEvent(t *testing.T) {

--- a/pkg/core/events.go
+++ b/pkg/core/events.go
@@ -10,7 +10,7 @@ import (
 type FiredEvent struct {
 	SoldierID    uint16 // ObjectID of the soldier who fired
 	Time         time.Time
-	CaptureFrame uint
+	CaptureFrame Frame
 	Weapon       string
 	Magazine     string
 	FiringMode   string
@@ -22,7 +22,7 @@ type FiredEvent struct {
 type GeneralEvent struct {
 	ID           uint
 	Time         time.Time
-	CaptureFrame uint
+	CaptureFrame Frame
 	Name         string
 	Message      string
 	ExtraData    map[string]any
@@ -32,7 +32,7 @@ type GeneralEvent struct {
 type HitEvent struct {
 	ID               uint
 	Time             time.Time
-	CaptureFrame     uint
+	CaptureFrame     Frame
 	VictimSoldierID  *uint
 	VictimVehicleID  *uint
 	ShooterSoldierID *uint
@@ -48,7 +48,7 @@ type HitEvent struct {
 type KillEvent struct {
 	ID              uint
 	Time            time.Time
-	CaptureFrame    uint
+	CaptureFrame    Frame
 	VictimSoldierID *uint
 	VictimVehicleID *uint
 	KillerSoldierID *uint
@@ -65,7 +65,7 @@ type ChatEvent struct {
 	ID           uint
 	SoldierID    *uint
 	Time         time.Time
-	CaptureFrame uint
+	CaptureFrame Frame
 	Channel      string
 	FromName     string
 	SenderName   string
@@ -78,7 +78,7 @@ type RadioEvent struct {
 	ID           uint
 	SoldierID    *uint
 	Time         time.Time
-	CaptureFrame uint
+	CaptureFrame Frame
 	Radio        string
 	RadioType    string
 	StartEnd     string
@@ -93,7 +93,7 @@ type Ace3DeathEvent struct {
 	ID                 uint
 	SoldierID          uint
 	Time               time.Time
-	CaptureFrame       uint
+	CaptureFrame       Frame
 	Reason             string
 	LastDamageSourceID *uint
 }
@@ -103,19 +103,19 @@ type Ace3UnconsciousEvent struct {
 	ID            uint
 	SoldierID     uint
 	Time          time.Time
-	CaptureFrame  uint
+	CaptureFrame  Frame
 	IsUnconscious bool // true = went unconscious, false = regained consciousness
 }
 
 // TrajectoryPoint represents a single position sample in a projectile trajectory.
 type TrajectoryPoint struct {
 	Position Position3D
-	Frame    uint
+	FrameNum Frame
 }
 
 // ProjectileHit represents a hit from a projectile on a soldier or vehicle.
 type ProjectileHit struct {
-	CaptureFrame  uint
+	CaptureFrame  Frame
 	Position      Position3D
 	SoldierID     *uint16  // set if soldier was hit
 	VehicleID     *uint16  // set if vehicle was hit
@@ -124,7 +124,7 @@ type ProjectileHit struct {
 
 // ProjectileEvent represents a raw projectile event from the game.
 type ProjectileEvent struct {
-	CaptureFrame    uint
+	CaptureFrame    Frame
 	FirerObjectID   uint16
 	VehicleObjectID *uint16 // nil if not fired from vehicle
 
@@ -143,7 +143,7 @@ type ProjectileEvent struct {
 type TimeState struct {
 	ID             uint
 	Time           time.Time
-	CaptureFrame   uint
+	CaptureFrame   Frame
 	SystemTimeUTC  string
 	MissionDate    string
 	TimeMultiplier float32
@@ -154,7 +154,7 @@ type TimeState struct {
 // Replaces the old :FPS: and :METRIC: commands with a single :TELEMETRY: call.
 type TelemetryEvent struct {
 	Time         time.Time
-	CaptureFrame uint
+	CaptureFrame Frame
 
 	// FPS data (also written to mission recording by DB backends)
 	FpsAverage float32

--- a/pkg/core/marker.go
+++ b/pkg/core/marker.go
@@ -7,8 +7,8 @@ import "time"
 type Marker struct {
 	ID           uint
 	Time         time.Time
-	CaptureFrame uint
-	EndFrame     int // -1 means persist until end, otherwise frame when marker disappears
+	CaptureFrame Frame
+	EndFrame     Frame // FrameForever (0) means persist until end, otherwise frame when marker disappears
 	MarkerName   string
 	Direction    float32
 	MarkerType   string
@@ -28,7 +28,7 @@ type Marker struct {
 // DeleteMarker represents a marker deletion at a specific frame
 type DeleteMarker struct {
 	Name     string
-	EndFrame uint
+	EndFrame Frame
 }
 
 // MarkerState tracks marker position changes over time
@@ -36,7 +36,7 @@ type MarkerState struct {
 	ID           uint
 	MarkerID     uint
 	Time         time.Time
-	CaptureFrame uint
+	CaptureFrame Frame
 	Position     Position3D
 	Direction    float32
 	Alpha        float32

--- a/pkg/core/soldier.go
+++ b/pkg/core/soldier.go
@@ -8,7 +8,7 @@ import "time"
 type Soldier struct {
 	ID              uint16 // ObjectID - game identifier
 	JoinTime        time.Time
-	JoinFrame       uint
+	JoinFrame       Frame
 	OcapType        string
 	UnitName        string
 	GroupID         string
@@ -26,7 +26,7 @@ type Soldier struct {
 type SoldierState struct {
 	SoldierID         uint16 // References Soldier.ID (ObjectID)
 	Time              time.Time
-	CaptureFrame      uint
+	CaptureFrame      Frame
 	Position          Position3D
 	Bearing           uint16
 	Lifestate         uint8

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -1,6 +1,14 @@
 // pkg/core/types.go
 package core
 
+// Frame represents a capture frame number in the recording timeline.
+// The zero value (FrameForever) means "unset" or "persists until mission end".
+// Valid frames start at 1; frame 0 means "unset".
+type Frame uint
+
+// FrameForever is the zero value — indicates no defined end (persists until mission end).
+const FrameForever Frame = 0
+
 // Position3D represents a 3D coordinate without GIS dependencies
 type Position3D struct {
 	X float64 `json:"x"` // easting

--- a/pkg/core/vehicle.go
+++ b/pkg/core/vehicle.go
@@ -8,7 +8,7 @@ import "time"
 type Vehicle struct {
 	ID            uint16 // ObjectID - game identifier
 	JoinTime      time.Time
-	JoinFrame     uint
+	JoinFrame     Frame
 	OcapType      string
 	ClassName     string
 	DisplayName   string
@@ -20,7 +20,7 @@ type Vehicle struct {
 type VehicleState struct {
 	VehicleID       uint16 // References Vehicle.ID (ObjectID)
 	Time            time.Time
-	CaptureFrame    uint
+	CaptureFrame    Frame
 	Position        Position3D
 	Bearing         uint16
 	IsAlive         bool


### PR DESCRIPTION
## Summary

- Defines `type Frame uint` with `FrameForever = 0` (Go zero value = unset/forever), valid frames starting at 1
- Updates all frame fields across core structs (`Soldier`, `Vehicle`, `Marker`, events), parsers, storage backends, model conversions, and tests
- V1 JSON export boundary: `frameToV1(f Frame) int` converts 1-based internal frames to 0-based v1 frames, with `FrameForever(0)` naturally mapping to `-1`
- V1 Export struct fields (`EndFrame`, `FrameNum`, `StartFrameNum`) changed from `uint` to `int` to match `frameToV1` directly — no casts, no wraparound risk
- Renames `TrajectoryPoint.Frame` → `TrajectoryPoint.FrameNum` to avoid shadowing the type name

**Part of a coordinated change across 3 repos:**
- **extension** (this PR)
- addon: OCAP2/addon#78
- web: OCAP2/web#227

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)