### PR TITLE
refactor: standardize command names to :RESOURCE:ACTION: pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,17 +66,19 @@ GORM models for PostgreSQL/SQLite:
 
 ### Commands
 
+All commands follow a `:RESOURCE:ACTION:` naming convention. New commands must use this pattern — resource noun first, then verb/qualifier (e.g., `:SOLDIER:CREATE:`, `:EVENT:KILL:`, `:SYS:INIT:`).
+
 | Command | Purpose |
 |---------|---------|
-| `:NEW:SOLDIER:`, `:NEW:VEHICLE:` | Register new units/vehicles |
-| `:NEW:SOLDIER:STATE:`, `:NEW:VEHICLE:STATE:` | Update position/state data |
-| `:PROJECTILE:`, `:KILL:` | Combat events |
-| `:EVENT:`, `:CHAT:`, `:RADIO:`, `:TELEMETRY:` | General gameplay events |
-| `:NEW:MARKER:`, `:NEW:MARKER:STATE:`, `:DELETE:MARKER:` | Marker operations |
-| `:NEW:PLACED:`, `:PLACED:EVENT:` | Placed object (mine/explosive) lifecycle |
+| `:SOLDIER:CREATE:`, `:VEHICLE:CREATE:` | Register new units/vehicles |
+| `:SOLDIER:STATE:`, `:VEHICLE:STATE:` | Update position/state data |
+| `:EVENT:PROJECTILE:`, `:EVENT:KILL:` | Combat events |
+| `:EVENT:GENERAL:`, `:EVENT:CHAT:`, `:EVENT:RADIO:`, `:TELEMETRY:FRAME:` | General gameplay events |
+| `:MARKER:CREATE:`, `:MARKER:STATE:`, `:MARKER:DELETE:` | Marker operations |
+| `:PLACED:CREATE:`, `:PLACED:EVENT:` | Placed object (mine/explosive) lifecycle |
 | `:ACE3:DEATH:`, `:ACE3:UNCONSCIOUS:` | ACE3 integration events |
-| `:INIT:`, `:INIT:STORAGE:` | Initialize extension and storage |
-| `:NEW:MISSION:`, `:SAVE:MISSION:` | Begin/end recording |
+| `:SYS:INIT:`, `:STORAGE:INIT:` | Initialize extension and storage |
+| `:MISSION:START:`, `:MISSION:SAVE:` | Begin/end recording |
 
 ### Data Flow
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Dispatcher.Dispatch(Event)
                                      └─ SQLite → Queue → DB writer (batch insert every 2s) → SQLite
 ```
 
-Buffered handlers are gated on `:INIT:STORAGE:` — events queue in channels until the storage backend is ready.
+Buffered handlers are gated on `:STORAGE:INIT:` — events queue in channels until the storage backend is ready.
 
 ### DLL Entry Points
 
@@ -102,45 +102,47 @@ Copy `ocap_recorder.cfg.json.example` to `ocap_recorder.cfg.json` alongside the 
 
 ## Supported Commands
 
+All commands follow a `:RESOURCE:ACTION:` naming convention. New commands must use this pattern — resource noun first, then verb/qualifier (e.g., `:SOLDIER:CREATE:`, `:EVENT:KILL:`, `:SYS:INIT:`).
+
 ### Entity Commands
 
 | Command | Buffer | Purpose |
 |---------|--------|---------|
-| `:NEW:SOLDIER:` | Sync | Register new unit |
-| `:NEW:VEHICLE:` | Sync | Register new vehicle |
-| `:NEW:SOLDIER:STATE:` | 10,000 | Update unit position/state |
-| `:NEW:VEHICLE:STATE:` | 10,000 | Update vehicle position/state |
+| `:SOLDIER:CREATE:` | Sync | Register new unit |
+| `:VEHICLE:CREATE:` | Sync | Register new vehicle |
+| `:SOLDIER:STATE:` | 10,000 | Update unit position/state |
+| `:VEHICLE:STATE:` | 10,000 | Update vehicle position/state |
 
 ### Combat Commands
 
 | Command | Buffer | Purpose |
 |---------|--------|---------|
-| `:PROJECTILE:` | 5,000 | Projectile tracking (positions + hits) |
-| `:KILL:` | 2,000 | Kill event |
+| `:EVENT:PROJECTILE:` | 5,000 | Projectile tracking (positions + hits) |
+| `:EVENT:KILL:` | 2,000 | Kill event |
 
 ### General Commands
 
 | Command | Buffer | Purpose |
 |---------|--------|---------|
-| `:EVENT:` | 1,000 | General gameplay event |
-| `:CHAT:` | 1,000 | Chat message |
-| `:RADIO:` | 1,000 | Radio transmission |
-| `:TELEMETRY:` | 1,000 | Server telemetry (FPS, entity counts, weather, player network stats) |
-| `:NEW:TIME:STATE:` | 100 | Mission time/date tracking |
+| `:EVENT:GENERAL:` | 1,000 | General gameplay event |
+| `:EVENT:CHAT:` | 1,000 | Chat message |
+| `:EVENT:RADIO:` | 1,000 | Radio transmission |
+| `:TELEMETRY:FRAME:` | 100 | Server telemetry (FPS, entity counts, weather, player network stats) |
+| `:TIME:STATE:` | 100 | Mission time/date tracking |
 
 ### Marker Commands
 
 | Command | Buffer | Purpose |
 |---------|--------|---------|
-| `:NEW:MARKER:` | Sync | Create map marker (needs immediate DB ID) |
-| `:NEW:MARKER:STATE:` | 1,000 | Update marker position/appearance |
-| `:DELETE:MARKER:` | 500 | Delete marker |
+| `:MARKER:CREATE:` | Sync | Create map marker (needs immediate DB ID) |
+| `:MARKER:STATE:` | 1,000 | Update marker position/appearance |
+| `:MARKER:DELETE:` | 500 | Delete marker |
 
 ### Placed Object Commands
 
 | Command | Buffer | Purpose |
 |---------|--------|---------|
-| `:NEW:PLACED:` | Sync | Register placed object (mine, explosive) |
+| `:PLACED:CREATE:` | Sync | Register placed object (mine, explosive) |
 | `:PLACED:EVENT:` | 1,000 | Placed object lifecycle event (detonated/deleted) |
 
 ### ACE3 Integration
@@ -154,8 +156,8 @@ Copy `ocap_recorder.cfg.json.example` to `ocap_recorder.cfg.json` alongside the 
 
 | Command | Purpose |
 |---------|---------|
-| `:INIT:` | Initialize extension, send `:EXT:READY:` callback |
-| `:INIT:STORAGE:` | Initialize storage backend, ungate buffered handlers |
-| `:NEW:MISSION:` | Start recording mission |
-| `:SAVE:MISSION:` | End recording, flush data, upload if configured |
-| `:VERSION:` | Get extension version |
+| `:SYS:INIT:` | Initialize extension, send `:SYS:READY:` callback |
+| `:STORAGE:INIT:` | Initialize storage backend, ungate buffered handlers |
+| `:MISSION:START:` | Start recording mission |
+| `:MISSION:SAVE:` | End recording, flush data, upload if configured |
+| `:SYS:VERSION:` | Get extension version |

--- a/cmd/ocap_recorder/storage.go
+++ b/cmd/ocap_recorder/storage.go
@@ -17,7 +17,7 @@ import (
 )
 
 func initStorage() error {
-	Logger.Debug("Received :INIT:STORAGE: call")
+	Logger.Debug("Received :STORAGE:INIT: call")
 
 	storageCfg := config.GetStorageConfig()
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -190,7 +190,7 @@ func (*Addon) TableName() string {
 // Soldier is a player or AI unit
 // Uses composite primary key (MissionID, ObjectID) - ObjectID is the OCAP-assigned sequential ID
 //
-// SQF Command: :NEW:SOLDIER:
+// SQF Command: :SOLDIER:CREATE:
 // Args: [frameNo, ocapId, name, groupId, side, isPlayer, roleDescription, className, displayName, playerUID, squadParams]
 type Soldier struct {
 	MissionID       uint           `json:"missionId" gorm:"primaryKey;autoIncrement:false"`
@@ -220,7 +220,7 @@ func (*Soldier) TableName() string {
 // SoldierState tracks soldier state at a point in time
 // References Soldier by (MissionID, SoldierObjectID) composite FK
 //
-// SQF Command: :NEW:SOLDIER:STATE:
+// SQF Command: :SOLDIER:STATE:
 // Args: [ocapId, pos, dir, lifeState, inVehicle, name, isPlayer, role, frameNo, hasStableVitals, isDragged, scores, vehicleRole, vehicleOcapId, stance, groupID, side]
 type SoldierState struct {
 	ID              uint      `json:"id" gorm:"primarykey;autoIncrement;"`
@@ -266,7 +266,7 @@ type SoldierScores struct {
 // Vehicle is a vehicle or static weapon
 // Uses composite primary key (MissionID, ObjectID) - ObjectID is the OCAP-assigned sequential ID
 //
-// SQF Command: :NEW:VEHICLE:
+// SQF Command: :VEHICLE:CREATE:
 // Args: [frameNo, ocapId, vehicleClass, displayName, className, customization]
 type Vehicle struct {
 	MissionID     uint           `json:"missionId" gorm:"primaryKey;autoIncrement:false"`
@@ -290,7 +290,7 @@ func (*Vehicle) TableName() string {
 // VehicleState tracks vehicle state at a point in time
 // References Vehicle by (MissionID, VehicleObjectID) composite FK
 //
-// SQF Command: :NEW:VEHICLE:STATE:
+// SQF Command: :VEHICLE:STATE:
 // Args: [ocapId, pos, dir, alive, crew, frameNo, fuel, damage, engineOn, locked, side, vectorDir, vectorUp, turretAz, turretEl]
 type VehicleState struct {
 	ID              uint      `json:"id" gorm:"primarykey;autoIncrement;"`
@@ -324,7 +324,7 @@ func (*VehicleState) TableName() string {
 // ProjectileEvent represents a weapon being fired and its full lifetime tracking
 // References Soldier by ObjectID for Firer and ActualFirer (remote controller)
 //
-// SQF Command: :PROJECTILE:
+// SQF Command: :EVENT:PROJECTILE:
 // Args: [firedFrame, firedTime, firerID, vehicleID, vehicleRole, remoteControllerID,
 //
 //	weapon, weaponDisplay, muzzle, muzzleDisplay, magazine, magazineDisplay,
@@ -370,7 +370,7 @@ func (p *ProjectileEvent) TableName() string {
 }
 
 // ProjectileHitsSoldier records when a projectile hits a soldier
-// Part of hitParts array in :PROJECTILE: command: [hitOcapId, component, "x,y,z", frameNo]
+// Part of hitParts array in :EVENT:PROJECTILE: command: [hitOcapId, component, "x,y,z", frameNo]
 type ProjectileHitsSoldier struct {
 	ID                uint            `json:"id" gorm:"primarykey;autoIncrement;"`
 	ProjectileEventID uint            `json:"projectileEventId" gorm:"index:idx_projectile_hit_soldier_projectile_event_id"`
@@ -384,7 +384,7 @@ type ProjectileHitsSoldier struct {
 }
 
 // ProjectileHitsVehicle records when a projectile hits a vehicle
-// Part of hitParts array in :PROJECTILE: command: [hitOcapId, component, "x,y,z", frameNo]
+// Part of hitParts array in :EVENT:PROJECTILE: command: [hitOcapId, component, "x,y,z", frameNo]
 type ProjectileHitsVehicle struct {
 	ID                uint            `json:"id" gorm:"primarykey;autoIncrement;"`
 	ProjectileEventID uint            `json:"projectileEventId" gorm:"index:idx_projectile_hit_vehicle_projectile_event_id"`
@@ -399,7 +399,7 @@ type ProjectileHitsVehicle struct {
 
 // GeneralEvent is a generic event for player connections, mission end, custom events
 //
-// SQF Command: :EVENT:
+// SQF Command: :EVENT:GENERAL:
 // Args: [frameNo, eventType, message, extraDataJSON]
 // Common eventTypes: "connected", "disconnected", "endMission"
 type GeneralEvent struct {
@@ -420,7 +420,7 @@ func (g *GeneralEvent) TableName() string {
 // KillEvent represents an entity being killed/destroyed
 // Stores ObjectIDs directly - victim/killer could be soldier or vehicle
 //
-// SQF Command: :KILL:
+// SQF Command: :EVENT:KILL:
 // Args: [frameNo, victimOcapId, killerOcapId, weaponText, distance]
 type KillEvent struct {
 	ID   uint      `json:"id" gorm:"primarykey;autoIncrement;"`
@@ -492,7 +492,7 @@ func (a *Ace3UnconsciousEvent) TableName() string {
 
 // ChatEvent records chat messages
 //
-// SQF Command: :CHAT:
+// SQF Command: :EVENT:CHAT:
 // Args: [frameNo, senderOcapId, channel, from, name, text, playerUID]
 type ChatEvent struct {
 	ID              uint          `json:"id" gorm:"primarykey;autoIncrement;"`
@@ -514,7 +514,7 @@ func (c *ChatEvent) TableName() string {
 
 // RadioEvent records TFAR radio transmissions
 //
-// SQF Command: :RADIO:
+// SQF Command: :EVENT:RADIO:
 // Args: [frameNo, senderOcapId, radio, radioType, startEnd, channel, isAdditional, frequency, code]
 type RadioEvent struct {
 	ID              uint          `json:"id" gorm:"primarykey;autoIncrement;"`
@@ -538,7 +538,7 @@ func (r *RadioEvent) TableName() string {
 }
 
 // ServerFpsEvent records server performance metrics.
-// Populated from :TELEMETRY: command data (FPS fields).
+// Populated from :TELEMETRY:FRAME: command data (FPS fields).
 type ServerFpsEvent struct {
 	Time         time.Time `json:"time" gorm:"type:timestamptz;"`                              // Server time when measurement taken
 	MissionID    uint      `json:"missionId" gorm:"index:idx_serverfpsevent_mission_id"`
@@ -554,7 +554,7 @@ func (s *ServerFpsEvent) TableName() string {
 
 // TimeState represents mission time synchronization data
 //
-// SQF Command: :NEW:TIME:STATE:
+// SQF Command: :TIME:STATE:
 // Args: [frameNo, systemTimeUTC, missionDateTime, timeMultiplier, missionTime]
 type TimeState struct {
 	Time           time.Time `json:"time" gorm:"type:timestamptz;"`                              // Server time when recorded
@@ -573,7 +573,7 @@ func (t *TimeState) TableName() string {
 
 // Marker represents a map marker
 //
-// SQF Command: :NEW:MARKER:
+// SQF Command: :MARKER:CREATE:
 // Args: [markerName, direction, type, text, frameNo, -1, ownerOcapId, color, size, side, position, shape, alpha, brush]
 type Marker struct {
 	ID           uint      `json:"id" gorm:"primarykey;autoIncrement;"`
@@ -647,7 +647,7 @@ func (*PlacedObjectEvent) TableName() string {
 
 // MarkerState tracks marker position/property changes over time
 //
-// SQF Command: :NEW:MARKER:STATE:
+// SQF Command: :MARKER:STATE:
 // Args: [markerName, frameNo, position, direction, alpha]
 type MarkerState struct {
 	ID           uint      `json:"id" gorm:"primarykey;autoIncrement;"`

--- a/internal/worker/dispatch.go
+++ b/internal/worker/dispatch.go
@@ -11,39 +11,39 @@ import (
 // RegisterHandlers registers all event handlers with the dispatcher.
 func (m *Manager) RegisterHandlers(d *dispatcher.Dispatcher) {
 	// Entity creation - sync (need to cache before states arrive)
-	d.Register(":NEW:SOLDIER:", m.handleNewSoldier, dispatcher.Logged())
-	d.Register(":NEW:VEHICLE:", m.handleNewVehicle, dispatcher.Logged())
+	d.Register(":SOLDIER:CREATE:", m.handleNewSoldier, dispatcher.Logged())
+	d.Register(":VEHICLE:CREATE:", m.handleNewVehicle, dispatcher.Logged())
 
 	// High-volume state updates - buffered
-	d.Register(":NEW:SOLDIER:STATE:", m.handleSoldierState, dispatcher.Buffered(10000), dispatcher.Logged())
-	d.Register(":NEW:VEHICLE:STATE:", m.handleVehicleState, dispatcher.Buffered(10000), dispatcher.Logged())
+	d.Register(":SOLDIER:STATE:", m.handleSoldierState, dispatcher.Buffered(10000), dispatcher.Logged())
+	d.Register(":VEHICLE:STATE:", m.handleVehicleState, dispatcher.Buffered(10000), dispatcher.Logged())
 
 	// Time state tracking - buffered
-	d.Register(":NEW:TIME:STATE:", m.handleTimeState, dispatcher.Buffered(100), dispatcher.Logged())
+	d.Register(":TIME:STATE:", m.handleTimeState, dispatcher.Buffered(100), dispatcher.Logged())
 
 	// Combat events - buffered
-	d.Register(":PROJECTILE:", m.handleProjectileEvent, dispatcher.Buffered(5000), dispatcher.Logged())
-	d.Register(":KILL:", m.handleKillEvent, dispatcher.Buffered(2000), dispatcher.Logged())
+	d.Register(":EVENT:PROJECTILE:", m.handleProjectileEvent, dispatcher.Buffered(5000), dispatcher.Logged())
+	d.Register(":EVENT:KILL:", m.handleKillEvent, dispatcher.Buffered(2000), dispatcher.Logged())
 
 	// General events - buffered
-	d.Register(":EVENT:", m.handleGeneralEvent, dispatcher.Buffered(1000), dispatcher.Logged())
-	d.Register(":CHAT:", m.handleChatEvent, dispatcher.Buffered(1000), dispatcher.Logged())
-	d.Register(":RADIO:", m.handleRadioEvent, dispatcher.Buffered(1000), dispatcher.Logged())
-	d.Register(":TELEMETRY:", m.handleTelemetryEvent, dispatcher.Buffered(100), dispatcher.Logged())
+	d.Register(":EVENT:GENERAL:", m.handleGeneralEvent, dispatcher.Buffered(1000), dispatcher.Logged())
+	d.Register(":EVENT:CHAT:", m.handleChatEvent, dispatcher.Buffered(1000), dispatcher.Logged())
+	d.Register(":EVENT:RADIO:", m.handleRadioEvent, dispatcher.Buffered(1000), dispatcher.Logged())
+	d.Register(":TELEMETRY:FRAME:", m.handleTelemetryEvent, dispatcher.Buffered(100), dispatcher.Logged())
 
 	// ACE3 events - buffered
 	d.Register(":ACE3:DEATH:", m.handleAce3DeathEvent, dispatcher.Buffered(1000), dispatcher.Logged())
 	d.Register(":ACE3:UNCONSCIOUS:", m.handleAce3UnconsciousEvent, dispatcher.Buffered(1000), dispatcher.Logged())
 
 	// Placed objects - sync creation (need to cache), buffered events
-	d.Register(":NEW:PLACED:", m.handleNewPlaced, dispatcher.Logged())
+	d.Register(":PLACED:CREATE:", m.handleNewPlaced, dispatcher.Logged())
 	d.Register(":PLACED:EVENT:", m.handlePlacedEvent, dispatcher.Buffered(1000), dispatcher.Logged())
 
 	// Marker creation - sync (need to cache before states arrive)
-	d.Register(":NEW:MARKER:", m.handleMarkerCreate, dispatcher.Logged())
+	d.Register(":MARKER:CREATE:", m.handleMarkerCreate, dispatcher.Logged())
 	// Marker updates - buffered
-	d.Register(":NEW:MARKER:STATE:", m.handleMarkerMove, dispatcher.Buffered(1000), dispatcher.Logged())
-	d.Register(":DELETE:MARKER:", m.handleMarkerDelete, dispatcher.Buffered(500), dispatcher.Logged())
+	d.Register(":MARKER:STATE:", m.handleMarkerMove, dispatcher.Buffered(1000), dispatcher.Logged())
+	d.Register(":MARKER:DELETE:", m.handleMarkerDelete, dispatcher.Buffered(500), dispatcher.Logged())
 }
 
 func (m *Manager) handleNewSoldier(e dispatcher.Event) (any, error) {

--- a/internal/worker/dispatch_test.go
+++ b/internal/worker/dispatch_test.go
@@ -514,24 +514,24 @@ func TestRegisterHandlers_RegistersAllCommands(t *testing.T) {
 	manager.RegisterHandlers(d)
 
 	expectedCommands := []string{
-		":NEW:SOLDIER:",
-		":NEW:VEHICLE:",
-		":NEW:SOLDIER:STATE:",
-		":NEW:VEHICLE:STATE:",
-		":NEW:TIME:STATE:",
-		":PROJECTILE:",
-		":KILL:",
-		":EVENT:",
-		":CHAT:",
-		":RADIO:",
-		":TELEMETRY:",
+		":SOLDIER:CREATE:",
+		":VEHICLE:CREATE:",
+		":SOLDIER:STATE:",
+		":VEHICLE:STATE:",
+		":TIME:STATE:",
+		":EVENT:PROJECTILE:",
+		":EVENT:KILL:",
+		":EVENT:GENERAL:",
+		":EVENT:CHAT:",
+		":EVENT:RADIO:",
+		":TELEMETRY:FRAME:",
 		":ACE3:DEATH:",
 		":ACE3:UNCONSCIOUS:",
-		":NEW:PLACED:",
+		":PLACED:CREATE:",
 		":PLACED:EVENT:",
-		":NEW:MARKER:",
-		":NEW:MARKER:STATE:",
-		":DELETE:MARKER:",
+		":MARKER:CREATE:",
+		":MARKER:STATE:",
+		":MARKER:DELETE:",
 	}
 
 	for _, cmd := range expectedCommands {
@@ -562,7 +562,7 @@ func TestHandleNewSoldier_CachesEntityWithBackend(t *testing.T) {
 	manager.RegisterHandlers(d)
 
 	// Dispatch new soldier event
-	result, err := d.Dispatch(dispatcher.Event{Command: ":NEW:SOLDIER:", Args: []string{}})
+	result, err := d.Dispatch(dispatcher.Event{Command: ":SOLDIER:CREATE:", Args: []string{}})
 
 	require.NoError(t, err)
 	assert.Nil(t, result, "expected nil result")
@@ -592,7 +592,7 @@ func TestHandleNewVehicle_CachesEntityWithBackend(t *testing.T) {
 	manager.RegisterHandlers(d)
 
 	// Dispatch new vehicle event
-	result, err := d.Dispatch(dispatcher.Event{Command: ":NEW:VEHICLE:", Args: []string{}})
+	result, err := d.Dispatch(dispatcher.Event{Command: ":VEHICLE:CREATE:", Args: []string{}})
 
 	require.NoError(t, err)
 	assert.Nil(t, result, "expected nil result")
@@ -628,7 +628,7 @@ func TestHandleSoldierState_ValidatesAndFillsGroupSide(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:SOLDIER:STATE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":SOLDIER:STATE:", Args: []string{}})
 	require.NoError(t, err)
 
 	// Wait for buffered handler
@@ -671,7 +671,7 @@ func TestHandleSoldierState_ReturnsErrorWhenNotCached(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:SOLDIER:STATE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":SOLDIER:STATE:", Args: []string{}})
 	require.NoError(t, err) // dispatch itself doesn't error for buffered handlers
 
 	waitForLogMsg(t, logger, "buffered handler failed")
@@ -697,7 +697,7 @@ func TestHandleVehicleState_ReturnsErrorWhenNotCached(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:VEHICLE:STATE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":VEHICLE:STATE:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitForLogMsg(t, logger, "buffered handler failed")
@@ -730,7 +730,7 @@ func TestHandleKillEvent_ClassifiesVictimAndKiller(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":KILL:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:KILL:", Args: []string{}})
 	require.NoError(t, err)
 
 	// Wait for buffered handler
@@ -796,7 +796,7 @@ func TestHandleProjectile_ClassifiesHitParts(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":PROJECTILE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:PROJECTILE:", Args: []string{}})
 	require.NoError(t, err)
 
 	// Wait for buffered handler
@@ -868,7 +868,7 @@ func TestHandleProjectile_RecordsProjectileEvent(t *testing.T) {
 	manager.RegisterHandlers(d)
 
 	// Dispatch a projectile event
-	_, err := d.Dispatch(dispatcher.Event{Command: ":PROJECTILE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:PROJECTILE:", Args: []string{}})
 	require.NoError(t, err)
 
 	// Wait for the buffered handler to process
@@ -933,7 +933,7 @@ func TestHandleMarkerMove_ResolvesMarkerName(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:MARKER:STATE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":MARKER:STATE:", Args: []string{}})
 	require.NoError(t, err)
 
 	// Wait for buffered handler
@@ -978,7 +978,7 @@ func TestHandleChatEvent_ValidatesSender(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":CHAT:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:CHAT:", Args: []string{}})
 	require.NoError(t, err) // buffered dispatch doesn't return handler errors
 
 	waitForLogMsg(t, logger, "event failed")
@@ -1007,11 +1007,11 @@ func TestHandleMarkerDelete_WithBackend(t *testing.T) {
 	manager.RegisterHandlers(d)
 
 	// First create a marker so it exists in cache (sync handler)
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:MARKER:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":MARKER:CREATE:", Args: []string{}})
 	require.NoError(t, err, "failed to create marker")
 
 	// Now delete it (buffered handler - processes asynchronously)
-	_, err = d.Dispatch(dispatcher.Event{Command: ":DELETE:MARKER:", Args: []string{}})
+	_, err = d.Dispatch(dispatcher.Event{Command: ":MARKER:DELETE:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitFor(t, func() bool {
@@ -1044,7 +1044,7 @@ func TestHandleVehicleState_HappyPath(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:VEHICLE:STATE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":VEHICLE:STATE:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitFor(t, func() bool {
@@ -1075,7 +1075,7 @@ func TestHandleTimeState(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:TIME:STATE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":TIME:STATE:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitFor(t, func() bool {
@@ -1105,7 +1105,7 @@ func TestHandleGeneralEvent(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:GENERAL:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitFor(t, func() bool {
@@ -1138,7 +1138,7 @@ func TestHandleRadioEvent_ValidSender(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":RADIO:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:RADIO:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitFor(t, func() bool {
@@ -1175,7 +1175,7 @@ func TestHandleTelemetryEvent(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":TELEMETRY:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":TELEMETRY:FRAME:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitFor(t, func() bool {
@@ -1321,7 +1321,7 @@ func TestHandleChatEvent_ValidSender(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":CHAT:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:CHAT:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitFor(t, func() bool {
@@ -1353,7 +1353,7 @@ func TestHandleMarkerCreate_BackendError(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:MARKER:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":MARKER:CREATE:", Args: []string{}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "add marker")
 
@@ -1386,7 +1386,7 @@ func TestHandleSoldierState_UpdatesCacheWhenPlayerTakesOver(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:SOLDIER:STATE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":SOLDIER:STATE:", Args: []string{}})
 	require.NoError(t, err)
 
 	// Wait for buffered handler
@@ -1477,7 +1477,7 @@ func TestHandleNewSoldier_ParserError(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:SOLDIER:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":SOLDIER:CREATE:", Args: []string{}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to log new soldier")
 }
@@ -1493,7 +1493,7 @@ func TestHandleNewVehicle_ParserError(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:VEHICLE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":VEHICLE:CREATE:", Args: []string{}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to log new vehicle")
 }
@@ -1510,7 +1510,7 @@ func TestHandleMarkerCreate_ParserError(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:MARKER:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":MARKER:CREATE:", Args: []string{}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create marker")
 }
@@ -1531,7 +1531,7 @@ func TestHandleNewSoldier_BackendError(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:SOLDIER:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":SOLDIER:CREATE:", Args: []string{}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "add soldier")
 
@@ -1554,7 +1554,7 @@ func TestHandleNewVehicle_BackendError(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:VEHICLE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":VEHICLE:CREATE:", Args: []string{}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "add vehicle")
 
@@ -1576,7 +1576,7 @@ func TestHandleSoldierState_ParserError(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:SOLDIER:STATE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":SOLDIER:STATE:", Args: []string{}})
 	require.NoError(t, err) // buffered dispatch doesn't return handler errors
 
 	waitForLogMsg(t, logger, "event failed")
@@ -1596,7 +1596,7 @@ func TestHandleVehicleState_ParserError(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:VEHICLE:STATE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":VEHICLE:STATE:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitForLogMsg(t, logger, "event failed")
@@ -1616,7 +1616,7 @@ func TestHandleTimeState_ParserError(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:TIME:STATE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":TIME:STATE:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitForLogMsg(t, logger, "event failed")
@@ -1636,7 +1636,7 @@ func TestHandleProjectileEvent_ParserError(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":PROJECTILE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:PROJECTILE:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitForLogMsg(t, logger, "event failed")
@@ -1656,7 +1656,7 @@ func TestHandleGeneralEvent_ParserError(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:GENERAL:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitForLogMsg(t, logger, "event failed")
@@ -1676,7 +1676,7 @@ func TestHandleKillEvent_ParserError(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":KILL:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:KILL:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitForLogMsg(t, logger, "event failed")
@@ -1696,7 +1696,7 @@ func TestHandleChatEvent_ParserError(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":CHAT:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:CHAT:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitForLogMsg(t, logger, "event failed")
@@ -1716,7 +1716,7 @@ func TestHandleRadioEvent_ParserError(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":RADIO:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:RADIO:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitForLogMsg(t, logger, "event failed")
@@ -1736,7 +1736,7 @@ func TestHandleTelemetryEvent_ParserError(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":TELEMETRY:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":TELEMETRY:FRAME:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitForLogMsg(t, logger, "event failed")
@@ -1797,7 +1797,7 @@ func TestHandleMarkerMove_ParserError(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:MARKER:STATE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":MARKER:STATE:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitForLogMsg(t, logger, "event failed")
@@ -1818,7 +1818,7 @@ func TestHandleMarkerDelete_ParserError(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":DELETE:MARKER:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":MARKER:DELETE:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitForLogMsg(t, logger, "event failed")
@@ -1844,7 +1844,7 @@ func TestHandleChatEvent_NilSoldierID(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":CHAT:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:CHAT:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitFor(t, func() bool {
@@ -1875,7 +1875,7 @@ func TestHandleRadioEvent_NilSoldierID(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":RADIO:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:RADIO:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitFor(t, func() bool {
@@ -1906,7 +1906,7 @@ func TestHandleRadioEvent_SenderNotCached(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":RADIO:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:RADIO:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitForLogMsg(t, logger, "event failed")
@@ -1935,7 +1935,7 @@ func TestHandleMarkerMove_MarkerNotInCache(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:MARKER:STATE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":MARKER:STATE:", Args: []string{}})
 	require.NoError(t, err)
 
 	waitForLogMsg(t, logger, "event failed")
@@ -2189,7 +2189,7 @@ func TestHandleSoldierState_BackendError(t *testing.T) {
 	}, &configurableErrorBackend{failOn: map[string]error{"RecordSoldierState": errInjected}})
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:SOLDIER:STATE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":SOLDIER:STATE:", Args: []string{}})
 	require.NoError(t, err)
 	waitForLogMsg(t, logger, "event failed")
 }
@@ -2209,7 +2209,7 @@ func TestHandleVehicleState_BackendError(t *testing.T) {
 	}, &configurableErrorBackend{failOn: map[string]error{"RecordVehicleState": errInjected}})
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:VEHICLE:STATE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":VEHICLE:STATE:", Args: []string{}})
 	require.NoError(t, err)
 	waitForLogMsg(t, logger, "event failed")
 }
@@ -2227,7 +2227,7 @@ func TestHandleTimeState_BackendError(t *testing.T) {
 	}, &configurableErrorBackend{failOn: map[string]error{"RecordTimeState": errInjected}})
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:TIME:STATE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":TIME:STATE:", Args: []string{}})
 	require.NoError(t, err)
 	waitForLogMsg(t, logger, "event failed")
 }
@@ -2245,7 +2245,7 @@ func TestHandleProjectileEvent_BackendError(t *testing.T) {
 	}, &configurableErrorBackend{failOn: map[string]error{"RecordProjectileEvent": errInjected}})
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":PROJECTILE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:PROJECTILE:", Args: []string{}})
 	require.NoError(t, err)
 	waitForLogMsg(t, logger, "event failed")
 }
@@ -2263,7 +2263,7 @@ func TestHandleGeneralEvent_BackendError(t *testing.T) {
 	}, &configurableErrorBackend{failOn: map[string]error{"RecordGeneralEvent": errInjected}})
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:GENERAL:", Args: []string{}})
 	require.NoError(t, err)
 	waitForLogMsg(t, logger, "event failed")
 }
@@ -2281,7 +2281,7 @@ func TestHandleKillEvent_BackendError(t *testing.T) {
 	}, &configurableErrorBackend{failOn: map[string]error{"RecordKillEvent": errInjected}})
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":KILL:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:KILL:", Args: []string{}})
 	require.NoError(t, err)
 	waitForLogMsg(t, logger, "event failed")
 }
@@ -2302,7 +2302,7 @@ func TestHandleChatEvent_BackendError(t *testing.T) {
 	}, &configurableErrorBackend{failOn: map[string]error{"RecordChatEvent": errInjected}})
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":CHAT:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:CHAT:", Args: []string{}})
 	require.NoError(t, err)
 	waitForLogMsg(t, logger, "event failed")
 }
@@ -2323,7 +2323,7 @@ func TestHandleRadioEvent_BackendError(t *testing.T) {
 	}, &configurableErrorBackend{failOn: map[string]error{"RecordRadioEvent": errInjected}})
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":RADIO:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:RADIO:", Args: []string{}})
 	require.NoError(t, err)
 	waitForLogMsg(t, logger, "event failed")
 }
@@ -2341,7 +2341,7 @@ func TestHandleTelemetryEvent_BackendError(t *testing.T) {
 	}, &configurableErrorBackend{failOn: map[string]error{"RecordTelemetryEvent": errInjected}})
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":TELEMETRY:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":TELEMETRY:FRAME:", Args: []string{}})
 	require.NoError(t, err)
 	waitForLogMsg(t, logger, "event failed")
 }
@@ -2403,7 +2403,7 @@ func TestHandleMarkerMove_BackendError(t *testing.T) {
 	}, &configurableErrorBackend{failOn: map[string]error{"RecordMarkerState": errInjected}})
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:MARKER:STATE:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":MARKER:STATE:", Args: []string{}})
 	require.NoError(t, err)
 	waitForLogMsg(t, logger, "event failed")
 }
@@ -2431,7 +2431,7 @@ func TestHandleNewPlaced_CachesEntityWithBackend(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	result, err := d.Dispatch(dispatcher.Event{Command: ":NEW:PLACED:", Args: []string{}})
+	result, err := d.Dispatch(dispatcher.Event{Command: ":PLACED:CREATE:", Args: []string{}})
 
 	require.NoError(t, err)
 	assert.Nil(t, result, "expected nil result")
@@ -2456,7 +2456,7 @@ func TestHandleNewPlaced_ParserError(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:PLACED:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":PLACED:CREATE:", Args: []string{}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse new placed object")
 }
@@ -2475,7 +2475,7 @@ func TestHandleNewPlaced_BackendError(t *testing.T) {
 	}, backend)
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":NEW:PLACED:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":PLACED:CREATE:", Args: []string{}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "add placed object")
 
@@ -2602,7 +2602,7 @@ func TestHandleMarkerDelete_BackendError(t *testing.T) {
 	}, &configurableErrorBackend{failOn: map[string]error{"DeleteMarker": errInjected}})
 	manager.RegisterHandlers(d)
 
-	_, err := d.Dispatch(dispatcher.Event{Command: ":DELETE:MARKER:", Args: []string{}})
+	_, err := d.Dispatch(dispatcher.Event{Command: ":MARKER:DELETE:", Args: []string{}})
 	require.NoError(t, err)
 	waitForLogMsg(t, logger, "event failed")
 }

--- a/pkg/a3interface/rvextension.go
+++ b/pkg/a3interface/rvextension.go
@@ -41,7 +41,7 @@ func RVExtension(output *C.char, outputsize C.size_t, input *C.char) {
 	commandSubstr := strings.Split(command, "|")[0]
 
 	// Handle built-in timestamp command
-	if command == ":TIMESTAMP:" {
+	if command == ":SYS:TIMESTAMP:" {
 		replyToSyncArmaCall(fmt.Sprintf(`["ok", "%s"]`, getTimestamp()), output, outputsize)
 		return
 	}
@@ -80,7 +80,7 @@ func RVExtensionArgs(output *C.char, outputsize C.size_t, input *C.char, argv **
 	args := parseArgsFromC(argv, argc)
 
 	// Handle built-in timestamp command
-	if command == ":TIMESTAMP:" {
+	if command == ":SYS:TIMESTAMP:" {
 		replyToSyncArmaCall(fmt.Sprintf(`["ok", "%s"]`, getTimestamp()), output, outputsize)
 		return
 	}

--- a/pkg/a3interface/rvextension_test.go
+++ b/pkg/a3interface/rvextension_test.go
@@ -18,21 +18,21 @@ func TestFormatDispatchResponse(t *testing.T) {
 	}{
 		{
 			name:     "success with string array (VERSION)",
-			command:  ":VERSION:",
+			command:  ":SYS:VERSION:",
 			result:   []string{"0.0.1", "2026-02-01"},
 			err:      nil,
 			expected: `["ok", ["0.0.1","2026-02-01"]]`,
 		},
 		{
 			name:     "success with simple string",
-			command:  ":INIT:",
+			command:  ":SYS:INIT:",
 			result:   "ok",
 			err:      nil,
 			expected: `["ok", "ok"]`,
 		},
 		{
 			name:     "success with path string",
-			command:  ":GETDIR:ARMA:",
+			command:  ":SYS:DIR:ARMA:",
 			result:   `C:\Program Files\Arma 3`,
 			err:      nil,
 			expected: `["ok", "C:\Program Files\Arma 3"]`,
@@ -46,7 +46,7 @@ func TestFormatDispatchResponse(t *testing.T) {
 		},
 		{
 			name:     "error response",
-			command:  ":LOG:",
+			command:  ":SYS:LOG:",
 			result:   nil,
 			err:      errors.New("no handler registered"),
 			expected: `["error", "no handler registered"]`,

--- a/pkg/core/events.go
+++ b/pkg/core/events.go
@@ -151,7 +151,7 @@ type TimeState struct {
 }
 
 // TelemetryEvent represents a unified telemetry snapshot from the game server.
-// Replaces the old :FPS: and :METRIC: commands with a single :TELEMETRY: call.
+// Replaces the old :FPS: and :METRIC: commands with a single :TELEMETRY:FRAME: call.
 type TelemetryEvent struct {
 	Time         time.Time
 	CaptureFrame Frame


### PR DESCRIPTION
## Summary

- Renames all extension command strings from inconsistent naming (overloaded `:NEW:`, mixed verb/noun ordering, bare nouns) to a consistent `:RESOURCE:ACTION:` pattern
- System commands namespaced under `:SYS:` (INIT, VERSION, LOG, DIR, TIMESTAMP)
- Entity commands use `:RESOURCE:CREATE/STATE:` (SOLDIER, VEHICLE, PLACED, MARKER)
- Event commands namespaced under `:EVENT:` (GENERAL, KILL, PROJECTILE, CHAT, RADIO)
- Mission commands flipped to `:MISSION:START/SAVE:`
- Callbacks aligned (`:EXT:READY:` → `:SYS:READY:`)

## Coordinated change

**Must be deployed together with the addon PR: OCAP2/addon#80**

## Test plan

- [x] `go test ./...` passes
- [x] Grep confirms zero leftover old command strings
- [ ] Integration test with addon using matching branch