### PR TITLE
fix: gap-fill sparse position data in v1 export

### DIFF
--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -86,7 +86,22 @@ func Build(data *MissionData) Export {
 		})
 	}
 
+	// Pre-compute maxFrame across all entities (needed for gap-filling sparse states)
 	var maxFrame core.Frame = 0
+	for _, record := range data.Soldiers {
+		if n := len(record.States); n > 0 {
+			if f := record.States[n-1].CaptureFrame; f > maxFrame {
+				maxFrame = f
+			}
+		}
+	}
+	for _, record := range data.Vehicles {
+		if n := len(record.States); n > 0 {
+			if f := record.States[n-1].CaptureFrame; f > maxFrame {
+				maxFrame = f
+			}
+		}
+	}
 
 	// Find max entity ID to size the entities array correctly
 	// The JS frontend uses entities[id] to look up entities, so array index must equal entity ID
@@ -135,7 +150,7 @@ func Build(data *MissionData) Export {
 			FramesFired:   make([][]any, 0, len(record.FiredEvents)),
 		}
 
-		for _, state := range record.States {
+		for i, state := range record.States {
 			// Convert nil InVehicleObjectID to 0 (old C++ extension uses 0 for "not in vehicle")
 			var inVehicleID any = 0
 			if state.InVehicleObjectID != nil {
@@ -153,9 +168,17 @@ func Build(data *MissionData) Export {
 				state.GroupID,
 				state.Side,
 			}
-			entity.Positions = append(entity.Positions, pos)
-			if state.CaptureFrame > maxFrame {
-				maxFrame = state.CaptureFrame
+
+			// Gap-fill: emit one position entry per frame (dense output)
+			startF := frameToV1(state.CaptureFrame)
+			var endF int
+			if i+1 < len(record.States) {
+				endF = frameToV1(record.States[i+1].CaptureFrame) - 1
+			} else {
+				endF = frameToV1(maxFrame)
+			}
+			for f := startF; f <= endF; f++ {
+				entity.Positions = append(entity.Positions, pos)
 			}
 		}
 
@@ -189,7 +212,7 @@ func Build(data *MissionData) Export {
 			FramesFired:   [][]any{},
 		}
 
-		for _, state := range record.States {
+		for i, state := range record.States {
 			// Parse crew JSON string into actual JSON array
 			var crew any
 			if state.Crew != "" {
@@ -200,17 +223,23 @@ func Build(data *MissionData) Export {
 				crew = []any{}
 			}
 
+			// Gap-fill: extend frame range to next state change (or maxFrame)
+			startF := frameToV1(state.CaptureFrame)
+			var endF int
+			if i+1 < len(record.States) {
+				endF = frameToV1(record.States[i+1].CaptureFrame) - 1
+			} else {
+				endF = frameToV1(maxFrame)
+			}
+
 			pos := []any{
 				[]float64{state.Position.X, state.Position.Y, state.Position.Z},
 				state.Bearing,
 				boolToInt(state.IsAlive),
 				crew,
-				[]int{frameToV1(state.CaptureFrame), frameToV1(state.CaptureFrame)},
+				[]int{startF, endF},
 			}
 			entity.Positions = append(entity.Positions, pos)
-			if state.CaptureFrame > maxFrame {
-				maxFrame = state.CaptureFrame
-			}
 		}
 
 		export.Entities[record.Vehicle.ID] = entity

--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -89,16 +89,16 @@ func Build(data *MissionData) Export {
 	// Pre-compute maxFrame across all entities (needed for gap-filling sparse states)
 	var maxFrame core.Frame = 0
 	for _, record := range data.Soldiers {
-		if n := len(record.States); n > 0 {
-			if f := record.States[n-1].CaptureFrame; f > maxFrame {
-				maxFrame = f
+		for _, state := range record.States {
+			if state.CaptureFrame > maxFrame {
+				maxFrame = state.CaptureFrame
 			}
 		}
 	}
 	for _, record := range data.Vehicles {
-		if n := len(record.States); n > 0 {
-			if f := record.States[n-1].CaptureFrame; f > maxFrame {
-				maxFrame = f
+		for _, state := range record.States {
+			if state.CaptureFrame > maxFrame {
+				maxFrame = state.CaptureFrame
 			}
 		}
 	}

--- a/internal/storage/memory/export/v1/builder_test.go
+++ b/internal/storage/memory/export/v1/builder_test.go
@@ -184,8 +184,8 @@ func TestBuildWithSoldier(t *testing.T) {
 	assert.Equal(t, "Rifleman", entity.Role)
 	assert.Equal(t, 9, entity.StartFrameNum) // internal 10 → v1 9
 
-	// Check positions
-	require.Len(t, entity.Positions, 2)
+	// Check positions — dense gap-fill: state@10 covers v1 frames 9-18 (10 entries), state@20 covers v1 frame 19 (1 entry)
+	require.Len(t, entity.Positions, 11)
 	pos := entity.Positions[0]
 	coords := pos[0].([]float64)
 	require.Len(t, coords, 3)
@@ -201,8 +201,8 @@ func TestBuildWithSoldier(t *testing.T) {
 	assert.Equal(t, "Alpha", pos[7])    // groupID
 	assert.Equal(t, "WEST", pos[8])     // side
 
-	// Second position has different group
-	pos2 := entity.Positions[1]
+	// Last position has different group (from second state)
+	pos2 := entity.Positions[10]
 	assert.Equal(t, "Bravo", pos2[7])   // groupID changed mid-mission
 
 	// Check fired events - v1 format: [frameNum, [x, y, z]]
@@ -294,9 +294,9 @@ func TestBuildWithVehicle(t *testing.T) {
 	crewEntry := crew[0].([]any)
 	assert.Equal(t, float64(1), crewEntry[0])
 
-	// Frame range (internal 5 → v1 4)
+	// Frame range — gap-filled to next state (internal 5-14 → v1 4-13)
 	frameRange := pos[4].([]int)
-	assert.Equal(t, []int{4, 4}, frameRange)
+	assert.Equal(t, []int{4, 13}, frameRange)
 
 	assert.Equal(t, 14, export.EndFrame) // internal 15 → v1 14
 }

--- a/internal/storage/memory/export_test.go
+++ b/internal/storage/memory/export_test.go
@@ -124,7 +124,7 @@ func TestIntegrationFullExport(t *testing.T) {
 	assert.Equal(t, "Alpha", soldierEntity.Group)
 	assert.Equal(t, "WEST", soldierEntity.Side)
 	assert.Equal(t, 1, soldierEntity.IsPlayer)
-	require.Len(t, soldierEntity.Positions, 2)
+	require.Len(t, soldierEntity.Positions, 10) // dense gap-fill: state@1 covers v1 0-8 (9), state@10 covers v1 9 (1)
 	require.Len(t, soldierEntity.FramesFired, 1)
 
 	// Verify soldier position coordinates after JSON round-trip
@@ -1268,14 +1268,14 @@ func TestPlayerTakeoverUpdatesEntityMetadata(t *testing.T) {
 	assert.Equal(t, 1, entity.IsPlayer, "entity should be marked as player after takeover")
 	assert.Equal(t, "zigster", entity.Name, "entity name should be the player's name")
 
-	// Per-frame data should still be correct
-	require.Len(t, entity.Positions, 4)
-	// Frame 0: AI
+	// Per-frame data should still be correct (dense gap-fill: 30 entries total)
+	require.Len(t, entity.Positions, 30)
+	// Frame 0: AI (state@1, covers v1 0-8)
 	assert.Equal(t, "Habibzai", entity.Positions[0][4])
 	assert.Equal(t, 0, entity.Positions[0][5])
-	// Frame 20: player took over
-	assert.Equal(t, "zigster", entity.Positions[2][4])
-	assert.Equal(t, 1, entity.Positions[2][5])
+	// Frame 19: player took over (state@20, covers v1 19-28)
+	assert.Equal(t, "zigster", entity.Positions[19][4])
+	assert.Equal(t, 1, entity.Positions[19][5])
 }
 
 func TestExportJSON_MkdirAllError(t *testing.T) {


### PR DESCRIPTION
## Summary

- The addon's dedup optimization (ocap2-addon commits 88eabe7, 424bed3) only sends `:SOLDIER:STATE:` / `:VEHICLE:STATE:` when entity data changes between frames, producing sparse position data
- The web player's JSON decoder treats soldier positions as dense (one per frame), computing `endFrame = startFrame + positions.length - 1` — so entities vanish early (e.g., a unit with 1079 states disappears at frame 1079 instead of frame 7936)
- Vehicles have the same bug via their `[N, N]` single-frame ranges

## Fix

Gap-fill at export time in `builder.go`:

- **Soldiers**: expand sparse states into dense output (one 9-field position entry per frame, repeating until next state change)
- **Vehicles**: change frame ranges from `[N, N]` to `[N, M]`, where M extends to the frame before the next state change (or maxFrame for the last state)

`maxFrame` is pre-computed across all entities before processing, so the last state of each entity extends to the recording's final frame.

## Backward compatibility

Fully backward compatible — no v1 schema or web player changes:

| Input | Soldier output | Vehicle output |
|-------|---------------|----------------|
| Dense (pre-dedup addon) | Identical — consecutive frames make gap-fill a no-op | Identical — ranges stay `[N, N]` |
| Sparse (dedup addon) | Gap-filled to dense (one pos per frame) | Ranges expanded to `[N, M]` |

## Test plan

- [x] Existing unit tests updated and passing
- [x] Build extension and run a test mission with dedup addon
- [x] Verify soldier position count ≈ endFrame - startFrame + 1 in exported JSON
- [x] Verify vehicle frame ranges are `[N, M]` not `[N, N]`
- [x] Load old (pre-dedup) recording in web player — should work identically