### PR TITLE
feat: add :SOLDIER:DELETE: and :VEHICLE:DELETE: commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,11 @@ All commands follow a `:RESOURCE:ACTION:` naming convention. New commands must u
 | Command | Buffer | Purpose |
 |---------|--------|---------|
 | `:SOLDIER:CREATE:` | Sync | Register new unit |
-| `:VEHICLE:CREATE:` | Sync | Register new vehicle |
 | `:SOLDIER:STATE:` | 10,000 | Update unit position/state |
+| `:SOLDIER:DELETE:` | 500 | Mark unit as removed (disconnect, respawn corpse) |
+| `:VEHICLE:CREATE:` | Sync | Register new vehicle |
 | `:VEHICLE:STATE:` | 10,000 | Update vehicle position/state |
+| `:VEHICLE:DELETE:` | 500 | Mark vehicle as removed |
 
 ### Combat Commands
 

--- a/internal/parser/parse_soldier.go
+++ b/internal/parser/parse_soldier.go
@@ -56,6 +56,30 @@ func (p *Parser) ParseSoldier(data []string) (core.Soldier, error) {
 	return soldier, nil
 }
 
+// ParseSoldierDelete parses a soldier delete command.
+// Args: [entityId, frameNo]
+func (p *Parser) ParseSoldierDelete(data []string) (uint16, core.Frame, error) {
+	if len(data) < 2 {
+		return 0, 0, fmt.Errorf("expected 2 args, got %d", len(data))
+	}
+
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	id, err := parseUintFromFloat(data[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("error converting entityId: %w", err)
+	}
+
+	frame, err := strconv.ParseFloat(data[1], 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("error converting frameNo: %w", err)
+	}
+
+	return uint16(id), core.Frame(frame), nil
+}
+
 // ParseSoldierState parses soldier state data and returns a core SoldierState.
 // Sets SoldierID directly from the parsed ocapID (no cache lookup).
 // If groupID/side fields are not in the data (len < 17), they are left empty

--- a/internal/parser/parse_soldier_test.go
+++ b/internal/parser/parse_soldier_test.go
@@ -154,6 +154,64 @@ func TestParseSoldier(t *testing.T) {
 	}
 }
 
+func TestParseSoldierDelete(t *testing.T) {
+	p := newTestParser()
+
+	tests := []struct {
+		name      string
+		input     []string
+		wantID    uint16
+		wantFrame core.Frame
+		wantErr   bool
+	}{
+		{
+			name:      "valid delete",
+			input:     []string{"42", "500"},
+			wantID:    42,
+			wantFrame: 500,
+		},
+		{
+			name:      "float values from ArmA",
+			input:     []string{"42.00", "500.00"},
+			wantID:    42,
+			wantFrame: 500,
+		},
+		{
+			name:    "too few args",
+			input:   []string{"42"},
+			wantErr: true,
+		},
+		{
+			name:    "empty args",
+			input:   []string{},
+			wantErr: true,
+		},
+		{
+			name:    "bad entity ID",
+			input:   []string{"abc", "500"},
+			wantErr: true,
+		},
+		{
+			name:    "bad frame",
+			input:   []string{"42", "abc"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, frame, err := p.ParseSoldierDelete(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantID, id)
+			assert.Equal(t, tt.wantFrame, frame)
+		})
+	}
+}
+
 func TestParseSoldierState_ScoresParsingPanic(t *testing.T) {
 	p := newTestParser()
 

--- a/internal/parser/parse_vehicle.go
+++ b/internal/parser/parse_vehicle.go
@@ -44,6 +44,30 @@ func (p *Parser) ParseVehicle(data []string) (core.Vehicle, error) {
 	return vehicle, nil
 }
 
+// ParseVehicleDelete parses a vehicle delete command.
+// Args: [entityId, frameNo]
+func (p *Parser) ParseVehicleDelete(data []string) (uint16, core.Frame, error) {
+	if len(data) < 2 {
+		return 0, 0, fmt.Errorf("expected 2 args, got %d", len(data))
+	}
+
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	id, err := parseUintFromFloat(data[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("error converting entityId: %w", err)
+	}
+
+	frame, err := strconv.ParseFloat(data[1], 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("error converting frameNo: %w", err)
+	}
+
+	return uint16(id), core.Frame(frame), nil
+}
+
 // ParseVehicleState parses vehicle state data and returns a core VehicleState.
 // Sets VehicleID directly from the parsed ocapID (no cache lookup).
 func (p *Parser) ParseVehicleState(data []string) (core.VehicleState, error) {

--- a/internal/parser/parse_vehicle_test.go
+++ b/internal/parser/parse_vehicle_test.go
@@ -109,6 +109,64 @@ func TestParseVehicle(t *testing.T) {
 	}
 }
 
+func TestParseVehicleDelete(t *testing.T) {
+	p := newTestParser()
+
+	tests := []struct {
+		name      string
+		input     []string
+		wantID    uint16
+		wantFrame core.Frame
+		wantErr   bool
+	}{
+		{
+			name:      "valid delete",
+			input:     []string{"33", "1000"},
+			wantID:    33,
+			wantFrame: 1000,
+		},
+		{
+			name:      "float values from ArmA",
+			input:     []string{"33.00", "1000.00"},
+			wantID:    33,
+			wantFrame: 1000,
+		},
+		{
+			name:    "too few args",
+			input:   []string{"33"},
+			wantErr: true,
+		},
+		{
+			name:    "empty args",
+			input:   []string{},
+			wantErr: true,
+		},
+		{
+			name:    "bad entity ID",
+			input:   []string{"abc", "1000"},
+			wantErr: true,
+		},
+		{
+			name:    "bad frame",
+			input:   []string{"33", "abc"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, frame, err := p.ParseVehicleDelete(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantID, id)
+			assert.Equal(t, tt.wantFrame, frame)
+		})
+	}
+}
+
 func TestParseVehicleState_CrewPreservesBrackets(t *testing.T) {
 	p := newTestParser()
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -69,6 +69,8 @@ type Service interface {
 	ParseMarkerCreate(args []string) (core.Marker, error)
 	ParseMarkerMove(args []string) (MarkerMove, error)
 	ParseMarkerDelete(args []string) (*core.DeleteMarker, error)
+	ParseSoldierDelete(args []string) (uint16, core.Frame, error)
+	ParseVehicleDelete(args []string) (uint16, core.Frame, error)
 	ParseTelemetryEvent(args []string) (core.TelemetryEvent, error)
 	ParsePlacedObject(args []string) (core.PlacedObject, error)
 	ParsePlacedObjectEvent(args []string) (core.PlacedObjectEvent, error)

--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -175,7 +175,12 @@ func Build(data *MissionData) Export {
 			if i+1 < len(record.States) {
 				endF = frameToV1(record.States[i+1].CaptureFrame) - 1
 			} else {
-				endF = frameToV1(maxFrame)
+				// Last state: extend to entity's delete frame (or maxFrame if still active)
+				if record.Soldier.DeleteFrame > 0 {
+					endF = frameToV1(record.Soldier.DeleteFrame)
+				} else {
+					endF = frameToV1(maxFrame)
+				}
 			}
 			for f := startF; f <= endF; f++ {
 				entity.Positions = append(entity.Positions, pos)
@@ -223,13 +228,18 @@ func Build(data *MissionData) Export {
 				crew = []any{}
 			}
 
-			// Gap-fill: extend frame range to next state change (or maxFrame)
+			// Gap-fill: extend frame range to next state change (or entity end)
 			startF := frameToV1(state.CaptureFrame)
 			var endF int
 			if i+1 < len(record.States) {
 				endF = frameToV1(record.States[i+1].CaptureFrame) - 1
 			} else {
-				endF = frameToV1(maxFrame)
+				// Last state: extend to entity's delete frame (or maxFrame if still active)
+				if record.Vehicle.DeleteFrame > 0 {
+					endF = frameToV1(record.Vehicle.DeleteFrame)
+				} else {
+					endF = frameToV1(maxFrame)
+				}
 			}
 
 			pos := []any{

--- a/internal/storage/memory/export/v1/builder_test.go
+++ b/internal/storage/memory/export/v1/builder_test.go
@@ -1301,3 +1301,92 @@ func TestBuildWithPlacedObjectHitEvents(t *testing.T) {
 	// Distance: sqrt((1000-1003)^2 + (2000-2004)^2) = sqrt(9+16) = 5.0
 	assert.InDelta(t, 5.0, float64(evt[4].(float32)), 0.01)
 }
+
+func TestBuildWithSoldierDeleteFrame(t *testing.T) {
+	// Soldier with DeleteFrame should stop gap-filling at the delete frame
+	// instead of extending to maxFrame.
+	data := &MissionData{
+		Mission: &core.Mission{MissionName: "Test"},
+		World:   &core.World{WorldName: "Altis"},
+		Soldiers: map[uint16]*SoldierRecord{
+			0: {
+				Soldier: core.Soldier{
+					ID: 0, UnitName: "Disconnected", Side: "WEST", JoinFrame: 1,
+					DeleteFrame: 6, // removed at frame 6
+				},
+				States: []core.SoldierState{
+					{SoldierID: 0, CaptureFrame: 1, Position: core.Position3D{X: 100, Y: 200}, Lifestate: 1, Side: "WEST"},
+				},
+			},
+			1: {
+				Soldier: core.Soldier{
+					ID: 1, UnitName: "StillAlive", Side: "WEST", JoinFrame: 1,
+				},
+				States: []core.SoldierState{
+					{SoldierID: 1, CaptureFrame: 1, Position: core.Position3D{X: 300, Y: 400}, Lifestate: 1, Side: "WEST"},
+					{SoldierID: 1, CaptureFrame: 11, Position: core.Position3D{X: 310, Y: 410}, Lifestate: 1, Side: "WEST"},
+				},
+			},
+		},
+		Vehicles: make(map[uint16]*VehicleRecord),
+		Markers:  make(map[string]*MarkerRecord),
+	}
+
+	export := Build(data)
+
+	// Entity 0 with DeleteFrame=6:
+	// Single state at frame 1, last state extends to deleteFrame=6.
+	// v1: startF=0 (frameToV1(1)=0), endF=5 (frameToV1(6)=5)
+	// Gap-fill: frames 0-5 = 6 positions
+	entity0 := export.Entities[0]
+	assert.Len(t, entity0.Positions, 6)
+
+	// Entity 1 without DeleteFrame:
+	// State at frame 1 extends to frame 10 (next state - 1), state at frame 11 extends to maxFrame=11.
+	// v1: first state fills frames 0-9, second state fills frame 10 = 11 total
+	entity1 := export.Entities[1]
+	assert.Len(t, entity1.Positions, 11)
+}
+
+func TestBuildWithVehicleDeleteFrame(t *testing.T) {
+	// Vehicle with DeleteFrame should use delete frame as gap-fill boundary
+	// instead of maxFrame.
+	data := &MissionData{
+		Mission:  &core.Mission{MissionName: "Test"},
+		World:    &core.World{WorldName: "Altis"},
+		Soldiers: map[uint16]*SoldierRecord{
+			0: {
+				Soldier: core.Soldier{ID: 0, JoinFrame: 1},
+				States: []core.SoldierState{
+					{SoldierID: 0, CaptureFrame: 1, Lifestate: 1},
+					{SoldierID: 0, CaptureFrame: 21, Lifestate: 1},
+				},
+			},
+		},
+		Vehicles: map[uint16]*VehicleRecord{
+			1: {
+				Vehicle: core.Vehicle{
+					ID: 1, OcapType: "car", JoinFrame: 1,
+					DeleteFrame: 11, // removed at frame 11
+				},
+				States: []core.VehicleState{
+					{VehicleID: 1, CaptureFrame: 1, IsAlive: true, Crew: "[]"},
+				},
+			},
+		},
+		Markers: make(map[string]*MarkerRecord),
+	}
+
+	export := Build(data)
+
+	// Vehicle with DeleteFrame=11:
+	// Single state at frame 1, extends to deleteFrame=11.
+	// v1: startF=0 (frameToV1(1)=0), endF=10 (frameToV1(11)=10)
+	// Range entry: [0, 10]
+	entity := export.Entities[1]
+	require.Len(t, entity.Positions, 1)
+	frameRange := entity.Positions[0][4].([]int)
+	assert.Equal(t, []int{0, 10}, frameRange)
+
+	// Without DeleteFrame it would extend to maxFrame=21 → v1 [0, 20]
+}

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -196,6 +196,28 @@ func (b *Backend) AddMarker(m *core.Marker) (uint, error) {
 	return id, nil
 }
 
+// DeleteSoldier sets the delete frame for a soldier, marking it as excluded at that frame.
+func (b *Backend) DeleteSoldier(id uint16, frame core.Frame) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if record, ok := b.soldiers[id]; ok {
+		record.Soldier.DeleteFrame = frame
+	}
+	return nil
+}
+
+// DeleteVehicle sets the delete frame for a vehicle, marking it as excluded at that frame.
+func (b *Backend) DeleteVehicle(id uint16, frame core.Frame) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if record, ok := b.vehicles[id]; ok {
+		record.Vehicle.DeleteFrame = frame
+	}
+	return nil
+}
+
 // RecordSoldierState records a soldier state update.
 // SoldierID must be set to the soldier's ObjectID.
 func (b *Backend) RecordSoldierState(s *core.SoldierState) error {

--- a/internal/storage/memory/memory_test.go
+++ b/internal/storage/memory/memory_test.go
@@ -247,6 +247,38 @@ func TestDeleteMarker(t *testing.T) {
 	require.NoError(t, b.DeleteMarker(&core.DeleteMarker{Name: "nonexistent", EndFrame: 50}))
 }
 
+func TestDeleteSoldier(t *testing.T) {
+	b := New(config.MemoryConfig{})
+
+	s := &core.Soldier{ID: 1, UnitName: "Test"}
+	require.NoError(t, b.AddSoldier(s))
+
+	// Delete soldier at frame 500
+	require.NoError(t, b.DeleteSoldier(1, 500))
+
+	record := b.soldiers[1]
+	assert.Equal(t, core.Frame(500), record.Soldier.DeleteFrame)
+
+	// Deleting non-existent soldier should not panic
+	require.NoError(t, b.DeleteSoldier(999, 100))
+}
+
+func TestDeleteVehicle(t *testing.T) {
+	b := New(config.MemoryConfig{})
+
+	v := &core.Vehicle{ID: 10, ClassName: "B_MRAP_01_F"}
+	require.NoError(t, b.AddVehicle(v))
+
+	// Delete vehicle at frame 750
+	require.NoError(t, b.DeleteVehicle(10, 750))
+
+	record := b.vehicles[10]
+	assert.Equal(t, core.Frame(750), record.Vehicle.DeleteFrame)
+
+	// Deleting non-existent vehicle should not panic
+	require.NoError(t, b.DeleteVehicle(999, 100))
+}
+
 func TestRecordFiredEvent(t *testing.T) {
 	b := New(config.MemoryConfig{})
 

--- a/internal/storage/postgres/postgres.go
+++ b/internal/storage/postgres/postgres.go
@@ -245,6 +245,16 @@ func (b *Backend) AddMarker(m *core.Marker) (uint, error) {
 	return 0, nil
 }
 
+// DeleteSoldier is a no-op — postgres tracks all states, export logic differs.
+func (b *Backend) DeleteSoldier(id uint16, frame core.Frame) error {
+	return nil
+}
+
+// DeleteVehicle is a no-op — postgres tracks all states, export logic differs.
+func (b *Backend) DeleteVehicle(id uint16, frame core.Frame) error {
+	return nil
+}
+
 // RecordSoldierState converts and queues a soldier state.
 func (b *Backend) RecordSoldierState(s *core.SoldierState) error {
 	gormObj := convert.CoreToSoldierState(*s)

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -446,6 +446,24 @@ func TestEndMission_IsNoOp(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDeleteSoldier_IsNoOp(t *testing.T) {
+	b := newTestBackend()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
+
+	err := b.DeleteSoldier(42, 500)
+	require.NoError(t, err)
+}
+
+func TestDeleteVehicle_IsNoOp(t *testing.T) {
+	b := newTestBackend()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
+
+	err := b.DeleteVehicle(10, 750)
+	require.NoError(t, err)
+}
+
 func TestDeleteMarker_PushesAlphaZeroState(t *testing.T) {
 	b := newTestBackend()
 	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -19,6 +19,8 @@ type Backend interface {
 	AddMarker(m *core.Marker) (uint, error)
 
 	// State recording
+	DeleteSoldier(id uint16, frame core.Frame) error
+	DeleteVehicle(id uint16, frame core.Frame) error
 	RecordSoldierState(s *core.SoldierState) error
 	RecordVehicleState(v *core.VehicleState) error
 	RecordMarkerState(s *core.MarkerState) error

--- a/internal/storage/websocket/websocket.go
+++ b/internal/storage/websocket/websocket.go
@@ -121,6 +121,14 @@ func (b *Backend) AddMarker(m *core.Marker) (uint, error) {
 	return id, b.sendEnvelope(streaming.TypeAddMarker, &markerCopy)
 }
 
+func (b *Backend) DeleteSoldier(id uint16, frame core.Frame) error {
+	return b.sendEnvelope(streaming.TypeDeleteSoldier, map[string]any{"id": id, "frame": frame})
+}
+
+func (b *Backend) DeleteVehicle(id uint16, frame core.Frame) error {
+	return b.sendEnvelope(streaming.TypeDeleteVehicle, map[string]any{"id": id, "frame": frame})
+}
+
 func (b *Backend) RecordSoldierState(s *core.SoldierState) error {
 	return b.sendEnvelope(streaming.TypeSoldierState, s)
 }

--- a/internal/storage/websocket/websocket_test.go
+++ b/internal/storage/websocket/websocket_test.go
@@ -149,6 +149,8 @@ func TestAllMessageTypes(t *testing.T) {
 	require.NoError(t, b.RecordVehicleState(&core.VehicleState{VehicleID: 100, CaptureFrame: 1}))
 	require.NoError(t, b.RecordMarkerState(&core.MarkerState{MarkerID: 1, CaptureFrame: 1}))
 	require.NoError(t, b.DeleteMarker(&core.DeleteMarker{Name: "m1", EndFrame: 10}))
+	require.NoError(t, b.DeleteSoldier(1, 50))
+	require.NoError(t, b.DeleteVehicle(100, 60))
 
 	// Events
 	require.NoError(t, b.RecordFiredEvent(&core.FiredEvent{SoldierID: 1, Weapon: "arifle_MX_F"}))

--- a/internal/worker/dispatch.go
+++ b/internal/worker/dispatch.go
@@ -39,6 +39,10 @@ func (m *Manager) RegisterHandlers(d *dispatcher.Dispatcher) {
 	d.Register(":PLACED:CREATE:", m.handleNewPlaced, dispatcher.Logged())
 	d.Register(":PLACED:EVENT:", m.handlePlacedEvent, dispatcher.Buffered(1000), dispatcher.Logged())
 
+	// Entity removal - buffered
+	d.Register(":SOLDIER:DELETE:", m.handleSoldierDelete, dispatcher.Buffered(500), dispatcher.Logged())
+	d.Register(":VEHICLE:DELETE:", m.handleVehicleDelete, dispatcher.Buffered(500), dispatcher.Logged())
+
 	// Marker creation - sync (need to cache before states arrive)
 	d.Register(":MARKER:CREATE:", m.handleMarkerCreate, dispatcher.Logged())
 	// Marker updates - buffered
@@ -363,6 +367,22 @@ func (m *Manager) handleAce3UnconsciousEvent(e dispatcher.Event) (any, error) {
 		return nil, fmt.Errorf("record ace3 unconscious event: %w", err)
 	}
 	return nil, nil
+}
+
+func (m *Manager) handleSoldierDelete(e dispatcher.Event) (any, error) {
+	id, frame, err := m.deps.ParserService.ParseSoldierDelete(e.Args)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse soldier delete: %w", err)
+	}
+	return nil, m.backend.DeleteSoldier(id, frame)
+}
+
+func (m *Manager) handleVehicleDelete(e dispatcher.Event) (any, error) {
+	id, frame, err := m.deps.ParserService.ParseVehicleDelete(e.Args)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse vehicle delete: %w", err)
+	}
+	return nil, m.backend.DeleteVehicle(id, frame)
 }
 
 func (m *Manager) handleMarkerCreate(e dispatcher.Event) (any, error) {

--- a/internal/worker/dispatch_test.go
+++ b/internal/worker/dispatch_test.go
@@ -119,6 +119,14 @@ func (b *mockBackend) AddMarker(m *core.Marker) (uint, error) {
 	return id, nil
 }
 
+func (b *mockBackend) DeleteSoldier(id uint16, frame core.Frame) error {
+	return nil
+}
+
+func (b *mockBackend) DeleteVehicle(id uint16, frame core.Frame) error {
+	return nil
+}
+
 func (b *mockBackend) RecordSoldierState(s *core.SoldierState) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -414,6 +422,26 @@ func (h *mockParserService) ParseAce3UnconsciousEvent(args []string) (core.Ace3U
 	return h.ace3Uncon, nil
 }
 
+func (h *mockParserService) ParseSoldierDelete(args []string) (uint16, core.Frame, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.calls = append(h.calls, "ParseSoldierDelete")
+	if h.returnError {
+		return 0, 0, errors.New(h.errorMsg)
+	}
+	return 0, 0, nil
+}
+
+func (h *mockParserService) ParseVehicleDelete(args []string) (uint16, core.Frame, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.calls = append(h.calls, "ParseVehicleDelete")
+	if h.returnError {
+		return 0, 0, errors.New(h.errorMsg)
+	}
+	return 0, 0, nil
+}
+
 func (h *mockParserService) ParseMarkerCreate(args []string) (core.Marker, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -527,6 +555,8 @@ func TestRegisterHandlers_RegistersAllCommands(t *testing.T) {
 		":TELEMETRY:FRAME:",
 		":ACE3:DEATH:",
 		":ACE3:UNCONSCIOUS:",
+		":SOLDIER:DELETE:",
+		":VEHICLE:DELETE:",
 		":PLACED:CREATE:",
 		":PLACED:EVENT:",
 		":MARKER:CREATE:",

--- a/internal/worker/dispatch_test.go
+++ b/internal/worker/dispatch_test.go
@@ -39,6 +39,16 @@ func (l *mockLogger) Error(msg string, keysAndValues ...any) {
 	l.messages = append(l.messages, msg)
 }
 
+type soldierDeleteCall struct {
+	id    uint16
+	frame core.Frame
+}
+
+type vehicleDeleteCall struct {
+	id    uint16
+	frame core.Frame
+}
+
 // mockBackend implements storage.Backend for testing
 type mockBackend struct {
 	mu sync.Mutex
@@ -63,6 +73,8 @@ type mockBackend struct {
 	deletedMarkers    []*core.DeleteMarker
 	placedObjects     []*core.PlacedObject
 	placedEvents      []*core.PlacedObjectEvent
+	deletedSoldiers   []soldierDeleteCall
+	deletedVehicles   []vehicleDeleteCall
 	initCalled     bool
 	closeCalled    bool
 	missionStarted bool
@@ -120,10 +132,16 @@ func (b *mockBackend) AddMarker(m *core.Marker) (uint, error) {
 }
 
 func (b *mockBackend) DeleteSoldier(id uint16, frame core.Frame) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.deletedSoldiers = append(b.deletedSoldiers, soldierDeleteCall{id, frame})
 	return nil
 }
 
 func (b *mockBackend) DeleteVehicle(id uint16, frame core.Frame) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.deletedVehicles = append(b.deletedVehicles, vehicleDeleteCall{id, frame})
 	return nil
 }
 
@@ -271,8 +289,12 @@ type mockParserService struct {
 	marker        core.Marker
 	markerMove    parser.MarkerMove
 	deleteMarker *core.DeleteMarker
-	placedObject  core.PlacedObject
-	placedEvent   core.PlacedObjectEvent
+	placedObject       core.PlacedObject
+	placedEvent        core.PlacedObjectEvent
+	soldierDeleteID    uint16
+	soldierDeleteFrame core.Frame
+	vehicleDeleteID    uint16
+	vehicleDeleteFrame core.Frame
 
 	// Error simulation
 	returnError bool
@@ -429,7 +451,7 @@ func (h *mockParserService) ParseSoldierDelete(args []string) (uint16, core.Fram
 	if h.returnError {
 		return 0, 0, errors.New(h.errorMsg)
 	}
-	return 0, 0, nil
+	return h.soldierDeleteID, h.soldierDeleteFrame, nil
 }
 
 func (h *mockParserService) ParseVehicleDelete(args []string) (uint16, core.Frame, error) {
@@ -439,7 +461,7 @@ func (h *mockParserService) ParseVehicleDelete(args []string) (uint16, core.Fram
 	if h.returnError {
 		return 0, 0, errors.New(h.errorMsg)
 	}
-	return 0, 0, nil
+	return h.vehicleDeleteID, h.vehicleDeleteFrame, nil
 }
 
 func (h *mockParserService) ParseMarkerCreate(args []string) (core.Marker, error) {
@@ -1056,6 +1078,120 @@ func TestHandleMarkerDelete_WithBackend(t *testing.T) {
 	require.Len(t, backend.deletedMarkers, 1)
 	assert.Equal(t, "Projectile#123", backend.deletedMarkers[0].Name)
 	assert.Equal(t, core.Frame(500), backend.deletedMarkers[0].EndFrame)
+}
+
+func TestHandleSoldierDelete_WithBackend(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{
+		soldierDeleteID:    42,
+		soldierDeleteFrame: 500,
+	}
+
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":SOLDIER:DELETE:", Args: []string{"42", "500"}})
+	require.NoError(t, err)
+
+	waitFor(t, func() bool {
+		backend.mu.Lock()
+		n := len(backend.deletedSoldiers)
+		backend.mu.Unlock()
+		return n > 0
+	}, "timed out waiting for soldier delete")
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	require.Len(t, backend.deletedSoldiers, 1)
+	assert.Equal(t, uint16(42), backend.deletedSoldiers[0].id)
+	assert.Equal(t, core.Frame(500), backend.deletedSoldiers[0].frame)
+}
+
+func TestHandleSoldierDelete_ParseError(t *testing.T) {
+	d, logger := newTestDispatcher(t)
+
+	parserService := &mockParserService{
+		returnError: true,
+		errorMsg:    "bad soldier delete",
+	}
+
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":SOLDIER:DELETE:", Args: []string{}})
+	require.NoError(t, err) // buffered dispatch doesn't return handler errors
+
+	waitForLogMsg(t, logger, "event failed")
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.deletedSoldiers)
+}
+
+func TestHandleVehicleDelete_WithBackend(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{
+		vehicleDeleteID:    99,
+		vehicleDeleteFrame: 750,
+	}
+
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":VEHICLE:DELETE:", Args: []string{"99", "750"}})
+	require.NoError(t, err)
+
+	waitFor(t, func() bool {
+		backend.mu.Lock()
+		n := len(backend.deletedVehicles)
+		backend.mu.Unlock()
+		return n > 0
+	}, "timed out waiting for vehicle delete")
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	require.Len(t, backend.deletedVehicles, 1)
+	assert.Equal(t, uint16(99), backend.deletedVehicles[0].id)
+	assert.Equal(t, core.Frame(750), backend.deletedVehicles[0].frame)
+}
+
+func TestHandleVehicleDelete_ParseError(t *testing.T) {
+	d, logger := newTestDispatcher(t)
+
+	parserService := &mockParserService{
+		returnError: true,
+		errorMsg:    "bad vehicle delete",
+	}
+
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":VEHICLE:DELETE:", Args: []string{}})
+	require.NoError(t, err) // buffered dispatch doesn't return handler errors
+
+	waitForLogMsg(t, logger, "event failed")
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.deletedVehicles)
 }
 
 func TestHandleVehicleState_HappyPath(t *testing.T) {

--- a/pkg/core/soldier.go
+++ b/pkg/core/soldier.go
@@ -19,6 +19,7 @@ type Soldier struct {
 	DisplayName     string
 	PlayerUID       string
 	SquadParams     []any
+	DeleteFrame     Frame // Frame when entity was excluded (0 = active until end)
 }
 
 // SoldierState represents soldier state at a point in time.

--- a/pkg/core/vehicle.go
+++ b/pkg/core/vehicle.go
@@ -14,6 +14,7 @@ type Vehicle struct {
 	DisplayName   string
 	Customization string
 	Side          string // Config side: WEST, EAST, GUER, CIV (from "str side vehicle")
+	DeleteFrame   Frame  // Frame when entity was excluded (0 = active until end)
 }
 
 // VehicleState represents vehicle state at a point in time.

--- a/pkg/streaming/messages.go
+++ b/pkg/streaming/messages.go
@@ -17,6 +17,8 @@ const (
 	TypeVehicleState    = "vehicle_state"
 	TypeMarkerState     = "marker_state"
 	TypeDeleteMarker    = "delete_marker"
+	TypeDeleteSoldier   = "delete_soldier"
+	TypeDeleteVehicle   = "delete_vehicle"
 	TypeFiredEvent      = "fired_event"
 	TypeProjectileEvent = "projectile_event"
 	TypeGeneralEvent    = "general_event"
@@ -36,7 +38,7 @@ const (
 var AllMessageTypes = []string{
 	TypeStartMission, TypeEndMission,
 	TypeAddSoldier, TypeAddVehicle, TypeAddMarker,
-	TypeSoldierState, TypeVehicleState, TypeMarkerState, TypeDeleteMarker,
+	TypeSoldierState, TypeVehicleState, TypeMarkerState, TypeDeleteMarker, TypeDeleteSoldier, TypeDeleteVehicle,
 	TypeFiredEvent, TypeProjectileEvent, TypeGeneralEvent,
 	TypeHitEvent, TypeKillEvent, TypeChatEvent, TypeRadioEvent,
 	TypeTelemetry, TypeTimeState, TypeAce3Death, TypeAce3Unconscious,


### PR DESCRIPTION
## Summary

- Add `:SOLDIER:DELETE:` and `:VEHICLE:DELETE:` commands so the addon can report entity removal (disconnect, respawn corpse)
- Extension stores a `DeleteFrame` on the entity and uses it as the gap-fill boundary in the v1 builder instead of `maxFrame`
- Entities that are excluded mid-recording now stop at their delete frame instead of persisting as frozen markers until the end

## Changes

- **Core types**: `DeleteFrame` field on `Soldier` and `Vehicle`
- **Parser**: `ParseSoldierDelete` / `ParseVehicleDelete`
- **Storage interface**: `DeleteSoldier` / `DeleteVehicle` on `Backend`
- **Memory backend**: Sets `DeleteFrame` on the record
- **Postgres backend**: No-op stubs (postgres handles export differently)
- **WebSocket backend**: Forwards via `sendEnvelope`
- **Worker dispatch**: Registered handlers with buffer size 500
- **Builder**: Uses `DeleteFrame` as gap-fill boundary for last state (falls back to `maxFrame` when 0)

## Test plan

- [x] `go test ./...` passes
- [x] Test mission: disconnect → unit disappears at disconnect frame
- [x] Test mission: respawn → corpse disappears at death frame
- [x] Normal kill (no respawn) → dead body persists (DeleteFrame defaults to 0)
- [x] Old recordings unaffected (DeleteFrame=0 → maxFrame fallback)