### PR TITLE
feat: track all marker property updates in :MARKER:STATE:

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ All commands follow a `:RESOURCE:ACTION:` naming convention. New commands must u
 | Command | Buffer | Purpose |
 |---------|--------|---------|
 | `:MARKER:CREATE:` | Sync | Create map marker (needs immediate DB ID) |
-| `:MARKER:STATE:` | 1,000 | Update marker position/appearance |
+| `:MARKER:STATE:` | 1,000 | Update marker position/appearance (pos, dir, alpha, text, color, size, type, brush, shape) |
 | `:MARKER:DELETE:` | 500 | Delete marker |
 
 ### Placed Object Commands

--- a/internal/model/convert/to_gorm.go
+++ b/internal/model/convert/to_gorm.go
@@ -174,6 +174,12 @@ func CoreToMarkerState(s core.MarkerState) model.MarkerState {
 		Position:     position3DToPoint(s.Position),
 		Direction:    s.Direction,
 		Alpha:        s.Alpha,
+		Text:         s.Text,
+		Color:        s.Color,
+		Size:         s.Size,
+		MarkerType:   s.MarkerType,
+		Brush:        s.Brush,
+		Shape:        s.Shape,
 	}
 }
 

--- a/internal/model/convert/to_gorm_test.go
+++ b/internal/model/convert/to_gorm_test.go
@@ -265,6 +265,12 @@ func TestCoreToMarkerState(t *testing.T) {
 		Position:     core.Position3D{X: 150.0, Y: 250.0, Z: 0.0},
 		Direction:    90.0,
 		Alpha:        0.5,
+		Text:         "Sector Alpha",
+		Color:        "#FF0000",
+		Size:         "[200,200]",
+		MarkerType:   "hd_objective",
+		Brush:        "grid",
+		Shape:        "ELLIPSE",
 	}
 
 	result := CoreToMarkerState(input)
@@ -275,6 +281,12 @@ func TestCoreToMarkerState(t *testing.T) {
 	assert.Equal(t, uint(100), result.CaptureFrame)
 	assert.Equal(t, float32(90.0), result.Direction)
 	assert.Equal(t, float32(0.5), result.Alpha)
+	assert.Equal(t, "Sector Alpha", result.Text)
+	assert.Equal(t, "#FF0000", result.Color)
+	assert.Equal(t, "[200,200]", result.Size)
+	assert.Equal(t, "hd_objective", result.MarkerType)
+	assert.Equal(t, "grid", result.Brush)
+	assert.Equal(t, "ELLIPSE", result.Shape)
 }
 
 func TestCoreToGeneralEvent(t *testing.T) {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -649,7 +649,7 @@ func (*PlacedObjectEvent) TableName() string {
 // MarkerState tracks marker position/property changes over time
 //
 // SQF Command: :MARKER:STATE:
-// Args: [markerName, frameNo, position, direction, alpha]
+// Args: [markerName, frameNo, position, direction, alpha, text, color, size, type, brush, shape]
 type MarkerState struct {
 	ID           uint      `json:"id" gorm:"primarykey;autoIncrement;"`
 	Time         time.Time `json:"time" gorm:"type:timestamptz;"`                               // Server time when state recorded
@@ -659,9 +659,15 @@ type MarkerState struct {
 	Marker       Marker    `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;foreignkey:MarkerID;"`
 	CaptureFrame uint      `json:"captureFrame" gorm:"index:idx_markerstate_capture_frame;"`    // Frame number when state recorded
 
-	Position  geom.Point `json:"position"`  // Current marker position ASL
-	Direction float32    `json:"direction"` // Current marker rotation (0-360 degrees)
-	Alpha     float32    `json:"alpha"`     // Current marker opacity (0.0-1.0, 0 = deleted)
+	Position   geom.Point `json:"position"`   // Current marker position ASL
+	Direction  float32    `json:"direction"`  // Current marker rotation (0-360 degrees)
+	Alpha      float32    `json:"alpha"`      // Current marker opacity (0.0-1.0, 0 = deleted)
+	Text       string     `json:"text" gorm:"size:512"`
+	Color      string     `json:"color" gorm:"size:32"`
+	Size       string     `json:"size" gorm:"size:32"`
+	MarkerType string     `json:"markerType" gorm:"size:128"`
+	Brush      string     `json:"brush" gorm:"size:64"`
+	Shape      string     `json:"shape" gorm:"size:32"`
 }
 
 func (*MarkerState) TableName() string {

--- a/internal/parser/parse_marker.go
+++ b/internal/parser/parse_marker.go
@@ -106,6 +106,10 @@ func (p *Parser) ParseMarkerCreate(data []string) (core.Marker, error) {
 func (p *Parser) ParseMarkerMove(data []string) (MarkerMove, error) {
 	var result MarkerMove
 
+	if len(data) < 11 {
+		return result, fmt.Errorf("insufficient data fields: got %d, need 11", len(data))
+	}
+
 	// fix received data
 	for i, v := range data {
 		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))

--- a/internal/parser/parse_marker.go
+++ b/internal/parser/parse_marker.go
@@ -147,6 +147,24 @@ func (p *Parser) ParseMarkerMove(data []string) (MarkerMove, error) {
 	}
 	result.Alpha = float32(alpha)
 
+	// text
+	result.Text = data[5]
+
+	// color
+	result.Color = data[6]
+
+	// size
+	result.Size = data[7]
+
+	// type
+	result.MarkerType = data[8]
+
+	// brush
+	result.Brush = data[9]
+
+	// shape
+	result.Shape = data[10]
+
 	result.Time = time.Now()
 
 	return result, nil

--- a/internal/parser/parse_marker_test.go
+++ b/internal/parser/parse_marker_test.go
@@ -203,46 +203,58 @@ func TestParseMarkerMove(t *testing.T) {
 	}{
 		{
 			name:  "normal move",
-			input: []string{"markerName", "517", "6069.06,5627.81,17.81", "0", "1"},
+			input: []string{"markerName", "517", "6069.06,5627.81,17.81", "0", "1", "FPS: 45", "#00FF00", "[0.7,0.7]", "mil_start", "Solid", "ICON"},
 			check: func(t *testing.T, r MarkerMove) {
 				assert.Equal(t, "markerName", r.MarkerName)
 				assert.Equal(t, core.Frame(517), r.CaptureFrame)
 				assert.NotEqual(t, core.Position3D{}, r.Position)
 				assert.Equal(t, float32(0), r.Direction)
 				assert.Equal(t, float32(1), r.Alpha)
+				assert.Equal(t, "FPS: 45", r.Text)
+				assert.Equal(t, "#00FF00", r.Color)
+				assert.Equal(t, "[0.7,0.7]", r.Size)
+				assert.Equal(t, "mil_start", r.MarkerType)
+				assert.Equal(t, "Solid", r.Brush)
+				assert.Equal(t, "ICON", r.Shape)
 			},
 		},
 		{
 			name:  "with direction and alpha",
-			input: []string{"sector_1", "200", "5000.0,4000.0,0", "-40.08", "0.5"},
+			input: []string{"sector_1", "200", "5000.0,4000.0,0", "-40.08", "0.5", "Sector Alpha", "#FF0000", "[200,200]", "hd_objective", "grid", "ELLIPSE"},
 			check: func(t *testing.T, r MarkerMove) {
 				assert.Equal(t, "sector_1", r.MarkerName)
 				assert.InDelta(t, float32(-40.08), r.Direction, 0.01)
 				assert.InDelta(t, float32(0.5), r.Alpha, 0.01)
+				assert.Equal(t, "Sector Alpha", r.Text)
+				assert.Equal(t, "#FF0000", r.Color)
+				assert.Equal(t, "[200,200]", r.Size)
+				assert.Equal(t, "hd_objective", r.MarkerType)
+				assert.Equal(t, "grid", r.Brush)
+				assert.Equal(t, "ELLIPSE", r.Shape)
 			},
 		},
 		{
 			name:  "bad direction falls back to 0",
-			input: []string{"marker1", "100", "1000.0,2000.0,0", "not_float", "1"},
+			input: []string{"marker1", "100", "1000.0,2000.0,0", "not_float", "1", "text", "color", "size", "type", "brush", "shape"},
 			check: func(t *testing.T, r MarkerMove) {
 				assert.Equal(t, float32(0), r.Direction)
 			},
 		},
 		{
 			name:  "bad alpha falls back to 1.0",
-			input: []string{"marker1", "100", "1000.0,2000.0,0", "0", "not_float"},
+			input: []string{"marker1", "100", "1000.0,2000.0,0", "0", "not_float", "text", "color", "size", "type", "brush", "shape"},
 			check: func(t *testing.T, r MarkerMove) {
 				assert.Equal(t, float32(1.0), r.Alpha)
 			},
 		},
 		{
 			name:    "error: bad frame",
-			input:   []string{"marker1", "abc", "1000.0,2000.0,0", "0", "1"},
+			input:   []string{"marker1", "abc", "1000.0,2000.0,0", "0", "1", "text", "color", "size", "type", "brush", "shape"},
 			wantErr: true,
 		},
 		{
 			name:    "error: bad position",
-			input:   []string{"marker1", "100", "not_valid", "0", "1"},
+			input:   []string{"marker1", "100", "not_valid", "0", "1", "text", "color", "size", "type", "brush", "shape"},
 			wantErr: true,
 		},
 	}

--- a/internal/parser/parse_marker_test.go
+++ b/internal/parser/parse_marker_test.go
@@ -257,6 +257,11 @@ func TestParseMarkerMove(t *testing.T) {
 			input:   []string{"marker1", "100", "not_valid", "0", "1", "text", "color", "size", "type", "brush", "shape"},
 			wantErr: true,
 		},
+		{
+			name:    "error: insufficient fields",
+			input:   []string{"marker1", "100", "1000.0,2000.0,0", "0", "1"},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -56,5 +56,11 @@ type MarkerMove struct {
 	Position     core.Position3D
 	Direction    float32
 	Alpha        float32
+	Text         string
+	Color        string
+	Size         string
+	MarkerType   string
+	Brush        string
+	Shape        string
 	Time         time.Time
 }

--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -320,10 +320,15 @@ func Build(data *MissionData) Export {
 
 	// Convert markers
 	// Format: [type, text, startFrame, endFrame, playerId, color, sideIndex, positions, size, shape, brush]
-	// positions is always: [[frameNum, pos, direction, alpha], ...]
+	// positions is always: [[frameNum, pos, direction, alpha, text, color, size, type, brush, shape], ...]
 	// For POLYLINE: pos is [[x1,y1],[x2,y2],...] (array of coordinates)
 	// For other shapes: pos is [x, y] (single coordinate)
 	for _, record := range data.Markers {
+		// Strip "#" prefix from hex colors (e.g., "#800000" -> "800000") for URL compatibility
+		// The web UI constructs URLs like: /images/markers/${type}/${color}.png
+		// With "#" prefix, browsers interpret the fragment as an anchor, causing 404s
+		markerColor := strings.TrimPrefix(record.Marker.Color, "#")
+
 		posArray := make([][]any, 0)
 
 		if record.Marker.Shape == "POLYLINE" {
@@ -337,6 +342,12 @@ func Build(data *MissionData) Export {
 				coords, // [[x1,y1], [x2,y2], ...]
 				record.Marker.Direction,
 				record.Marker.Alpha,
+				record.Marker.Text,
+				markerColor,
+				parseMarkerSize(record.Marker.Size),
+				record.Marker.MarkerType,
+				record.Marker.Brush,
+				record.Marker.Shape,
 			})
 		} else {
 			// For other shapes: pos is a single coordinate
@@ -345,6 +356,12 @@ func Build(data *MissionData) Export {
 				[]float64{record.Marker.Position.X, record.Marker.Position.Y, record.Marker.Position.Z},
 				record.Marker.Direction,
 				record.Marker.Alpha,
+				record.Marker.Text,
+				markerColor,
+				parseMarkerSize(record.Marker.Size),
+				record.Marker.MarkerType,
+				record.Marker.Brush,
+				record.Marker.Shape,
 			})
 
 			// State changes
@@ -354,14 +371,15 @@ func Build(data *MissionData) Export {
 					[]float64{state.Position.X, state.Position.Y, state.Position.Z},
 					state.Direction,
 					state.Alpha,
+					state.Text,
+					strings.TrimPrefix(state.Color, "#"),
+					parseMarkerSize(state.Size),
+					state.MarkerType,
+					state.Brush,
+					state.Shape,
 				})
 			}
 		}
-
-		// Strip "#" prefix from hex colors (e.g., "#800000" -> "800000") for URL compatibility
-		// The web UI constructs URLs like: /images/markers/${type}/${color}.png
-		// With "#" prefix, browsers interpret the fragment as an anchor, causing 404s
-		markerColor := strings.TrimPrefix(record.Marker.Color, "#")
 
 		marker := []any{
 			record.Marker.MarkerType,               // [0] type

--- a/internal/storage/memory/export/v1/builder_test.go
+++ b/internal/storage/memory/export/v1/builder_test.go
@@ -528,7 +528,8 @@ func TestBuildWithMarker(t *testing.T) {
 					CaptureFrame: 1, Position: core.Position3D{X: 5000, Y: 6000}, Direction: 45, Alpha: 1.0,
 				},
 				States: []core.MarkerState{
-					{MarkerID: 1, CaptureFrame: 50, Position: core.Position3D{X: 5100, Y: 6100}, Direction: 90, Alpha: 0.8},
+					{MarkerID: 1, CaptureFrame: 50, Position: core.Position3D{X: 5100, Y: 6100}, Direction: 90, Alpha: 0.8,
+						Text: "Objective Updated", Color: "#900000", Size: "[3.0,4.0]", MarkerType: "mil_objective", Brush: "Solid", Shape: "ICON"},
 				},
 			},
 		},
@@ -550,8 +551,24 @@ func TestBuildWithMarker(t *testing.T) {
 	// Positions
 	positions := marker[7].([][]any)
 	require.Len(t, positions, 2)
+
+	// Initial position entry
 	assert.Equal(t, 0, positions[0][0])          // initial frame (internal 1 → v1 0)
+	assert.Equal(t, "Objective", positions[0][4])           // text
+	assert.Equal(t, "800000", positions[0][5])              // color (# stripped)
+	assert.Equal(t, []float64{2.0, 3.0}, positions[0][6])  // size
+	assert.Equal(t, "mil_objective", positions[0][7])       // type
+	assert.Equal(t, "Solid", positions[0][8])               // brush
+	assert.Equal(t, "ICON", positions[0][9])                // shape
+
+	// State change position entry
 	assert.Equal(t, 49, positions[1][0])         // state change frame (internal 50 → v1 49)
+	assert.Equal(t, "Objective Updated", positions[1][4])   // text
+	assert.Equal(t, "900000", positions[1][5])              // color (# stripped)
+	assert.Equal(t, []float64{3.0, 4.0}, positions[1][6])  // size
+	assert.Equal(t, "mil_objective", positions[1][7])       // type
+	assert.Equal(t, "Solid", positions[1][8])               // brush
+	assert.Equal(t, "ICON", positions[1][9])                // shape
 
 	assert.Equal(t, []float64{2.0, 3.0}, marker[8]) // size
 	assert.Equal(t, "ICON", marker[9])              // shape

--- a/internal/worker/dispatch.go
+++ b/internal/worker/dispatch.go
@@ -399,6 +399,12 @@ func (m *Manager) handleMarkerMove(e dispatcher.Event) (any, error) {
 		Position:     parsed.Position,
 		Direction:    parsed.Direction,
 		Alpha:        parsed.Alpha,
+		Text:         parsed.Text,
+		Color:        parsed.Color,
+		Size:         parsed.Size,
+		MarkerType:   parsed.MarkerType,
+		Brush:        parsed.Brush,
+		Shape:        parsed.Shape,
 		Time:         parsed.Time,
 	}
 

--- a/internal/worker/dispatch_test.go
+++ b/internal/worker/dispatch_test.go
@@ -922,6 +922,12 @@ func TestHandleMarkerMove_ResolvesMarkerName(t *testing.T) {
 		markerMove: parser.MarkerMove{
 			CaptureFrame: 100,
 			MarkerName:   "marker_alpha",
+			Text:         "Objective Alpha",
+			Color:        "#FF0000",
+			Size:         "[200,200]",
+			MarkerType:   "hd_objective",
+			Brush:        "grid",
+			Shape:        "ELLIPSE",
 		},
 	}
 
@@ -957,6 +963,12 @@ func TestHandleMarkerMove_ResolvesMarkerName(t *testing.T) {
 	defer backend.mu.Unlock()
 	require.Equal(t, 1, len(backend.markerStates))
 	assert.Equal(t, uint(42), backend.markerStates[0].MarkerID)
+	assert.Equal(t, "Objective Alpha", backend.markerStates[0].Text)
+	assert.Equal(t, "#FF0000", backend.markerStates[0].Color)
+	assert.Equal(t, "[200,200]", backend.markerStates[0].Size)
+	assert.Equal(t, "hd_objective", backend.markerStates[0].MarkerType)
+	assert.Equal(t, "grid", backend.markerStates[0].Brush)
+	assert.Equal(t, "ELLIPSE", backend.markerStates[0].Shape)
 }
 
 func TestHandleChatEvent_ValidatesSender(t *testing.T) {

--- a/pkg/core/marker.go
+++ b/pkg/core/marker.go
@@ -40,4 +40,10 @@ type MarkerState struct {
 	Position     Position3D
 	Direction    float32
 	Alpha        float32
+	Text         string
+	Color        string
+	Size         string
+	MarkerType   string
+	Brush        string
+	Shape        string
 }


### PR DESCRIPTION
## Summary
- Extends `:MARKER:STATE:` payload from 5 fields (name, frame, pos, dir, alpha) to 11 fields (+text, color, size, type, brush, shape)
- Adds new fields to `MarkerState` core type, parser, DB model, converter, worker handler, and v1 export builder
- Position entries in export now include all marker properties for each state change frame

## Context
Communities use markers that dynamically update text/color during gameplay (e.g., FPS display markers). Previously OCAP only captured position/direction/alpha on updates — text, color, and other property changes were lost.

Companion addon PR: OCAP2/addon#new

## Test plan
- [x] `go test ./...` — all 20 packages pass
- [x] Parser tests cover all 6 new fields + error fallbacks
- [x] Converter test verifies core→model mapping for new fields
- [x] Worker test verifies fields flow from parser through to backend
- [x] Export builder test verifies position entries include properties