### PR TITLE
refactor: move /api path prefix from config to code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ File: `ocap_recorder.cfg.json` (placed alongside DLL)
   "logsDir": "./ocaplogs",
   "defaultTag": "TvT",
   "api": {
-    "serverUrl": "http://127.0.0.1:5000/api",
+    "serverUrl": "http://127.0.0.1:5000",
     "apiKey": "secret"
   },
   "db": {

--- a/cmd/ocap_recorder/storage.go
+++ b/cmd/ocap_recorder/storage.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/OCAP2/extension/v5/internal/api"
 	"github.com/OCAP2/extension/v5/internal/config"
 	"github.com/OCAP2/extension/v5/internal/storage"
 	"github.com/OCAP2/extension/v5/internal/storage/memory"
@@ -76,7 +77,7 @@ func createStorageBackend(storageCfg config.StorageConfig) (storage.Backend, err
 		return backend, nil
 
 	case "websocket":
-		wsURL := httpToWS(viper.GetString("api.serverUrl")) + "/api/v1/stream"
+		wsURL := httpToWS(viper.GetString("api.serverUrl")) + api.PathPrefix + "/v1/stream"
 		secret := viper.GetString("api.apiKey")
 		Logger.Info("WebSocket storage backend initialized", "url", wsURL)
 		return wsstorage.New(wsstorage.Config{

--- a/cmd/ocap_recorder/storage.go
+++ b/cmd/ocap_recorder/storage.go
@@ -76,7 +76,7 @@ func createStorageBackend(storageCfg config.StorageConfig) (storage.Backend, err
 		return backend, nil
 
 	case "websocket":
-		wsURL := httpToWS(viper.GetString("api.serverUrl")) + "/v1/stream"
+		wsURL := httpToWS(viper.GetString("api.serverUrl")) + "/api/v1/stream"
 		secret := viper.GetString("api.apiKey")
 		Logger.Info("WebSocket storage backend initialized", "url", wsURL)
 		return wsstorage.New(wsstorage.Config{

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -14,6 +14,9 @@ import (
 	"github.com/OCAP2/extension/v5/pkg/core"
 )
 
+// PathPrefix is the API path prefix appended to the base server URL.
+const PathPrefix = "/api"
+
 // Client handles communication with the OCAP web frontend.
 type Client struct {
 	baseURL    string
@@ -24,7 +27,7 @@ type Client struct {
 // New creates a new API client.
 func New(baseURL, apiKey string) *Client {
 	return &Client{
-		baseURL:    strings.TrimRight(baseURL, "/") + "/api",
+		baseURL:    strings.TrimRight(baseURL, "/") + PathPrefix,
 		apiKey:     apiKey,
 		httpClient: &http.Client{Timeout: 30 * time.Second},
 	}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -24,7 +24,7 @@ type Client struct {
 // New creates a new API client.
 func New(baseURL, apiKey string) *Client {
 	return &Client{
-		baseURL:    strings.TrimRight(baseURL, "/"),
+		baseURL:    strings.TrimRight(baseURL, "/") + "/api",
 		apiKey:     apiKey,
 		httpClient: &http.Client{Timeout: 30 * time.Second},
 	}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -16,19 +16,19 @@ func TestNew(t *testing.T) {
 	c := New("http://localhost:5000", "secret123")
 
 	require.NotNil(t, c)
-	assert.Equal(t, "http://localhost:5000", c.baseURL)
+	assert.Equal(t, "http://localhost:5000/api", c.baseURL)
 	assert.Equal(t, "secret123", c.apiKey)
 	assert.NotNil(t, c.httpClient)
 }
 
 func TestNew_TrimsTrailingSlash(t *testing.T) {
 	c := New("http://localhost:5000/", "secret")
-	assert.Equal(t, "http://localhost:5000", c.baseURL)
+	assert.Equal(t, "http://localhost:5000/api", c.baseURL)
 }
 
 func TestHealthcheck_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/healthcheck", r.URL.Path)
+		assert.Equal(t, "/api/healthcheck", r.URL.Path)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -62,7 +62,7 @@ func TestUpload_Success(t *testing.T) {
 	var receivedFileContent []byte
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/v1/operations/add", r.URL.Path)
+		assert.Equal(t, "/api/v1/operations/add", r.URL.Path)
 		assert.Equal(t, http.MethodPost, r.Method)
 
 		err := r.ParseMultipartForm(10 << 20)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,7 @@ func Load(configDir string) error {
 	viper.SetDefault("defaultTag", "Op")
 	viper.SetDefault("logsDir", "./ocaplogs")
 
-	viper.SetDefault("api.serverUrl", "http://localhost:5000/api")
+	viper.SetDefault("api.serverUrl", "http://localhost:5000")
 	viper.SetDefault("api.apiKey", "")
 
 	viper.SetDefault("db.host", "localhost")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -43,7 +43,7 @@ func TestLoad_DefaultValues(t *testing.T) {
 	assert.Equal(t, "info", viper.GetString("logLevel"))
 	assert.Equal(t, "Op", viper.GetString("defaultTag"))
 	assert.Equal(t, "./ocaplogs", viper.GetString("logsDir"))
-	assert.Equal(t, "http://localhost:5000/api", viper.GetString("api.serverUrl"))
+	assert.Equal(t, "http://localhost:5000", viper.GetString("api.serverUrl"))
 	assert.Equal(t, "", viper.GetString("api.apiKey"))
 	assert.Equal(t, "localhost", viper.GetString("db.host"))
 	assert.Equal(t, "5432", viper.GetString("db.port"))

--- a/ocap_recorder.cfg.json.example
+++ b/ocap_recorder.cfg.json.example
@@ -3,7 +3,7 @@
   "logsDir": "./ocaplogs",
   "defaultTag": "TvT",
   "api": {
-    "serverUrl": "http://127.0.0.1:5000/api",
+    "serverUrl": "http://127.0.0.1:5000",
     "apiKey": "same-secret"
   },
   "db": {


### PR DESCRIPTION
## Summary
- `api.serverUrl` config now expects the base website URL (e.g. `http://127.0.0.1:5000`) without the `/api` suffix
- The `/api` prefix is appended internally by the API client constructor and the websocket storage backend
- Updated defaults, example config, docs, and tests accordingly

## Test plan
- [x] All existing config and API client tests pass with updated expectations