### PR TITLE
feat: script-side focus range for mission uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,4 +162,6 @@ All commands follow a `:RESOURCE:ACTION:` naming convention. New commands must u
 | `:STORAGE:INIT:` | Initialize storage backend, ungate buffered handlers |
 | `:MISSION:START:` | Start recording mission |
 | `:MISSION:SAVE:` | End recording, flush data, upload if configured |
+| `:MISSION:FOCUS_START:` | Set playback focus start frame |
+| `:MISSION:FOCUS_END:` | Set playback focus end frame |
 | `:SYS:VERSION:` | Get extension version |

--- a/cmd/ocap_recorder/main.go
+++ b/cmd/ocap_recorder/main.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -28,6 +30,7 @@ import (
 	"github.com/OCAP2/extension/v5/internal/util"
 	"github.com/OCAP2/extension/v5/internal/worker"
 	"github.com/OCAP2/extension/v5/pkg/a3interface"
+	"github.com/OCAP2/extension/v5/pkg/core"
 
 	"github.com/spf13/viper"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
@@ -83,6 +86,10 @@ var (
 	SessionStartTime time.Time = time.Now()
 
 	addonVersion string = "unknown"
+
+	// Focus range: set by :MISSION:FOCUS_START: / :MISSION:FOCUS_END:, cleared on new mission
+	focusStart *core.Frame
+	focusEnd   *core.Frame
 
 	// storageReady is closed when storage (DB or memory) is initialized and ready
 	storageReady     = make(chan struct{})
@@ -302,6 +309,8 @@ func handleNewMission(e dispatcher.Event) (any, error) {
 	// 2. Reset caches
 	MarkerCache.Reset()
 	EntityCache.Reset()
+	focusStart = nil
+	focusEnd = nil
 
 	// 3. Start backend (handles DB ops for GORM/SQLite backends, stores missionID internally)
 	if storageBackend != nil {
@@ -374,6 +383,34 @@ func registerLifecycleHandlers(d *dispatcher.Dispatcher) {
 
 	d.Register(":MISSION:START:", handleNewMission, dispatcher.Buffered(1), dispatcher.Blocking(), dispatcher.Gated(storageReady))
 
+	d.Register(":MISSION:FOCUS_START:", func(e dispatcher.Event) (any, error) {
+		if len(e.Args) < 1 {
+			return nil, fmt.Errorf("MISSION:FOCUS_START requires 1 arg (frame)")
+		}
+		v, err := strconv.ParseUint(strings.TrimSpace(util.TrimQuotes(e.Args[0])), 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid focus start frame: %w", err)
+		}
+		f := core.Frame(v)
+		focusStart = &f
+		Logger.Info("Focus start set", "frame", f)
+		return nil, nil
+	})
+
+	d.Register(":MISSION:FOCUS_END:", func(e dispatcher.Event) (any, error) {
+		if len(e.Args) < 1 {
+			return nil, fmt.Errorf("MISSION:FOCUS_END requires 1 arg (frame)")
+		}
+		v, err := strconv.ParseUint(strings.TrimSpace(util.TrimQuotes(e.Args[0])), 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid focus end frame: %w", err)
+		}
+		f := core.Frame(v)
+		focusEnd = &f
+		Logger.Info("Focus end set", "frame", f)
+		return nil, nil
+	})
+
 	d.Register(":MISSION:SAVE:", func(e dispatcher.Event) (any, error) {
 		Logger.Info("Received :MISSION:SAVE: command, ending mission recording")
 		if storageBackend != nil {
@@ -387,6 +424,19 @@ func registerLifecycleHandlers(d *dispatcher.Dispatcher) {
 			if u, ok := storageBackend.(storage.Uploadable); ok && apiClient != nil {
 				if path := u.GetExportedFilePath(); path != "" {
 					meta := u.GetExportMetadata()
+					if focusStart != nil || focusEnd != nil {
+						if focusStart != nil {
+							meta.FocusStart = focusStart
+						} else {
+							f := core.Frame(0)
+							meta.FocusStart = &f
+						}
+						if focusEnd != nil {
+							meta.FocusEnd = focusEnd
+						} else {
+							meta.FocusEnd = &meta.EndFrame
+						}
+					}
 					if err := apiClient.Upload(path, meta); err != nil {
 						Logger.Error("Failed to upload to OCAP web", "error", err, "path", path)
 						// Don't return error - file is saved locally

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -72,6 +73,12 @@ func (c *Client) Upload(filePath string, meta core.UploadMetadata) error {
 		_ = writer.WriteField("missionName", meta.MissionName)
 		_ = writer.WriteField("missionDuration", fmt.Sprintf("%f", meta.MissionDuration))
 		_ = writer.WriteField("tag", meta.Tag)
+		if meta.FocusStart != nil {
+			_ = writer.WriteField("focusStart", strconv.FormatUint(uint64(*meta.FocusStart), 10))
+		}
+		if meta.FocusEnd != nil {
+			_ = writer.WriteField("focusEnd", strconv.FormatUint(uint64(*meta.FocusEnd), 10))
+		}
 
 		// File
 		part, err := writer.CreateFormFile("file", filepath.Base(filePath))

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -441,6 +441,7 @@ func (b *Backend) computeExportMetadata() core.UploadMetadata {
 		MissionName:     b.mission.MissionName,
 		MissionDuration: duration,
 		Tag:             b.mission.Tag,
+		EndFrame:        endFrame,
 	}
 }
 

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -57,4 +57,7 @@ type UploadMetadata struct {
 	MissionName     string
 	MissionDuration float64
 	Tag             string
+	EndFrame        Frame
+	FocusStart      *Frame
+	FocusEnd        *Frame
 }


### PR DESCRIPTION
## Summary

- Adds `:MISSION:FOCUS_START:` and `:MISSION:FOCUS_END:` lifecycle commands
- Extension stores focus frame numbers and resolves incomplete pairs at save time (missing start → 0, missing end → last frame)
- Includes `focusStart`/`focusEnd` form fields in the web upload — no web changes needed

## Usage (from SQF)

```sqf
// Trim prep phase (end auto-filled at save time)
["OCAP_setFocusStart"] call CBA_fnc_serverEvent;

// Explicit frame numbers
["OCAP_setFocusStart", [120]] call CBA_fnc_serverEvent;
["OCAP_setFocusEnd", [850]] call CBA_fnc_serverEvent;
```

## Companion PR

- Addon: OCAP2/addon#93