### PR TITLE
feat: focus range commands and typed event arg parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,4 +162,6 @@ All commands follow a `:RESOURCE:ACTION:` naming convention. New commands must u
 | `:STORAGE:INIT:` | Initialize storage backend, ungate buffered handlers |
 | `:MISSION:START:` | Start recording mission |
 | `:MISSION:SAVE:` | End recording, flush data, upload if configured |
+| `:MISSION:FOCUS_START:` | Set playback focus start frame |
+| `:MISSION:FOCUS_END:` | Set playback focus end frame |
 | `:SYS:VERSION:` | Get extension version |

--- a/cmd/ocap_recorder/storage.go
+++ b/cmd/ocap_recorder/storage.go
@@ -87,7 +87,7 @@ func createStorageBackend(storageCfg config.StorageConfig) (storage.Backend, err
 
 	default:
 		Logger.Info("Memory storage backend initialized")
-		return memory.New(storageCfg.Memory), nil
+		return memory.New(storageCfg.Memory, Logger), nil
 	}
 }
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -72,6 +73,12 @@ func (c *Client) Upload(filePath string, meta core.UploadMetadata) error {
 		_ = writer.WriteField("missionName", meta.MissionName)
 		_ = writer.WriteField("missionDuration", fmt.Sprintf("%f", meta.MissionDuration))
 		_ = writer.WriteField("tag", meta.Tag)
+		if meta.FocusStart != nil {
+			_ = writer.WriteField("focusStart", strconv.FormatUint(uint64(*meta.FocusStart), 10))
+		}
+		if meta.FocusEnd != nil {
+			_ = writer.WriteField("focusEnd", strconv.FormatUint(uint64(*meta.FocusEnd), 10))
+		}
 
 		// File
 		part, err := writer.CreateFormFile("file", filepath.Base(filePath))

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -73,11 +73,10 @@ func (c *Client) Upload(filePath string, meta core.UploadMetadata) error {
 		_ = writer.WriteField("missionName", meta.MissionName)
 		_ = writer.WriteField("missionDuration", fmt.Sprintf("%f", meta.MissionDuration))
 		_ = writer.WriteField("tag", meta.Tag)
-		if meta.FocusStart != nil {
-			_ = writer.WriteField("focusStart", strconv.FormatUint(uint64(*meta.FocusStart), 10))
-		}
-		if meta.FocusEnd != nil {
-			_ = writer.WriteField("focusEnd", strconv.FormatUint(uint64(*meta.FocusEnd), 10))
+		if len(meta.FocusRanges) > 0 {
+			first := meta.FocusRanges[0]
+			_ = writer.WriteField("focusStart", strconv.FormatUint(uint64(first.Start), 10))
+			_ = writer.WriteField("focusEnd", strconv.FormatUint(uint64(first.End), 10))
 		}
 
 		// File

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -112,6 +112,42 @@ func TestUpload_Success(t *testing.T) {
 	assert.Equal(t, "test content", string(receivedFileContent))
 }
 
+func TestUpload_WithFocusRanges(t *testing.T) {
+	var receivedFocusStart, receivedFocusEnd string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := r.ParseMultipartForm(10 << 20)
+		require.NoError(t, err)
+
+		receivedFocusStart = r.FormValue("focusStart")
+		receivedFocusEnd = r.FormValue("focusEnd")
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	testFile := tmpDir + "/test_mission.json.gz"
+	err := writeTestFile(testFile, []byte("test content"))
+	require.NoError(t, err)
+
+	c := New(server.URL, "mysecret")
+	meta := core.UploadMetadata{
+		WorldName:   "Altis",
+		MissionName: "Focus Test",
+		FocusRanges: []core.FocusRange{
+			{Start: 50, End: 150},
+			{Start: 200, End: 400}, // only first range should be sent
+		},
+	}
+
+	err = c.Upload(testFile, meta)
+	require.NoError(t, err)
+
+	assert.Equal(t, "50", receivedFocusStart)
+	assert.Equal(t, "150", receivedFocusEnd)
+}
+
 func TestUpload_FileNotFound(t *testing.T) {
 	c := New("http://localhost:5000", "secret")
 	err := c.Upload("/nonexistent/file.json.gz", core.UploadMetadata{})

--- a/internal/parser/parse_events.go
+++ b/internal/parser/parse_events.go
@@ -224,12 +224,7 @@ func (p *Parser) ParseGeneralEvent(data []string) (core.GeneralEvent, error) {
 
 // jsonString returns a JSON-encoded string value (with quotes and escaping).
 func jsonString(s string) string {
-	b, err := json.Marshal(s)
-	if err != nil {
-		// Fallback: manually quote the string
-		return `"` + s + `"`
-	}
-	return string(b)
+	return strconv.Quote(s)
 }
 
 // ParseKillEvent parses kill event data into a KillEvent.

--- a/internal/parser/parse_events.go
+++ b/internal/parser/parse_events.go
@@ -179,9 +179,12 @@ func (p *Parser) ParseGeneralEvent(data []string) (core.GeneralEvent, error) {
 			objectType := data[2]
 			unitName := data[3]
 			if len(data) >= 7 {
-				posX, _ := strconv.ParseFloat(data[4], 64)
-				posY, _ := strconv.ParseFloat(data[5], 64)
-				posZ, _ := strconv.ParseFloat(data[6], 64)
+				posX, errX := strconv.ParseFloat(data[4], 64)
+				posY, errY := strconv.ParseFloat(data[5], 64)
+				posZ, errZ := strconv.ParseFloat(data[6], 64)
+				if errX != nil || errY != nil || errZ != nil {
+					return thisEvent, fmt.Errorf("invalid position data for event %q", data[1])
+				}
 				thisEvent.Message = fmt.Sprintf("[%s,%s,[%g,%g,%g]]",
 					jsonString(objectType), jsonString(unitName), posX, posY, posZ)
 			} else {
@@ -189,11 +192,8 @@ func (p *Parser) ParseGeneralEvent(data []string) (core.GeneralEvent, error) {
 					jsonString(objectType), jsonString(unitName))
 			}
 		} else if len(data) >= 3 {
-			// Legacy format: [frame, type, "name,objectType", extraDataJSON?]
+			// Legacy format: [frame, type, "name,objectType"]
 			thisEvent.Message = data[2]
-			if len(data) > 3 {
-				_ = json.Unmarshal([]byte(data[3]), &thisEvent.ExtraData)
-			}
 		}
 
 	case "endMission":
@@ -224,7 +224,11 @@ func (p *Parser) ParseGeneralEvent(data []string) (core.GeneralEvent, error) {
 
 // jsonString returns a JSON-encoded string value (with quotes and escaping).
 func jsonString(s string) string {
-	b, _ := json.Marshal(s)
+	b, err := json.Marshal(s)
+	if err != nil {
+		// Fallback: manually quote the string
+		return `"` + s + `"`
+	}
 	return string(b)
 }
 

--- a/internal/parser/parse_events.go
+++ b/internal/parser/parse_events.go
@@ -158,6 +158,10 @@ func (p *Parser) ParseGeneralEvent(data []string) (core.GeneralEvent, error) {
 		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
 	}
 
+	if len(data) < 2 {
+		return thisEvent, fmt.Errorf("insufficient data fields: got %d, need at least 2", len(data))
+	}
+
 	// get frame
 	capframe, err := strconv.ParseFloat(data[0], 64)
 	if err != nil {
@@ -167,17 +171,65 @@ func (p *Parser) ParseGeneralEvent(data []string) (core.GeneralEvent, error) {
 	thisEvent.Time = time.Now()
 	thisEvent.CaptureFrame = core.Frame(capframe)
 	thisEvent.Name = data[1]
-	thisEvent.Message = data[2]
 
-	// get extra event data
-	if len(data) > 3 {
-		err = json.Unmarshal([]byte(data[3]), &thisEvent.ExtraData)
-		if err != nil {
-			return thisEvent, fmt.Errorf("error unmarshalling extra data: %w", err)
+	switch data[1] {
+	case "captured", "contested", "capturedFlag":
+		// Typed args: [frame, type, objectType, unitName, posX?, posY?, posZ?]
+		if len(data) >= 4 {
+			objectType := data[2]
+			unitName := data[3]
+			if len(data) >= 7 {
+				posX, _ := strconv.ParseFloat(data[4], 64)
+				posY, _ := strconv.ParseFloat(data[5], 64)
+				posZ, _ := strconv.ParseFloat(data[6], 64)
+				thisEvent.Message = fmt.Sprintf("[%s,%s,[%g,%g,%g]]",
+					jsonString(objectType), jsonString(unitName), posX, posY, posZ)
+			} else {
+				thisEvent.Message = fmt.Sprintf("[%s,%s]",
+					jsonString(objectType), jsonString(unitName))
+			}
+		} else if len(data) >= 3 {
+			// Legacy format: [frame, type, "name,objectType", extraDataJSON?]
+			thisEvent.Message = data[2]
+			if len(data) > 3 {
+				_ = json.Unmarshal([]byte(data[3]), &thisEvent.ExtraData)
+			}
+		}
+
+	case "endMission":
+		if len(data) >= 4 && data[2] == "" {
+			// Legacy format: [frame, "endMission", "", extraDataJSON]
+			thisEvent.Message = data[2]
+			_ = json.Unmarshal([]byte(data[3]), &thisEvent.ExtraData)
+		} else if len(data) >= 4 {
+			// Typed args: [frame, "endMission", side, message]
+			side := data[2]
+			message := data[3]
+			thisEvent.Message = fmt.Sprintf("[%s,%s]", jsonString(side), jsonString(message))
+		} else if len(data) >= 3 {
+			thisEvent.Message = data[2]
+		}
+
+	default:
+		// connected, disconnected, generalEvent, respawnTickets, counterInit,
+		// counterSet, terminalHack* — all use: [frame, type, message, extraData?]
+		if len(data) >= 3 {
+			thisEvent.Message = data[2]
+		}
+		if len(data) > 3 {
+			if err := json.Unmarshal([]byte(data[3]), &thisEvent.ExtraData); err != nil {
+				return thisEvent, fmt.Errorf("error unmarshalling extra data: %w", err)
+			}
 		}
 	}
 
 	return thisEvent, nil
+}
+
+// jsonString returns a JSON-encoded string value (with quotes and escaping).
+func jsonString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
 }
 
 // ParseKillEvent parses kill event data into a KillEvent.

--- a/internal/parser/parse_events.go
+++ b/internal/parser/parse_events.go
@@ -186,10 +186,10 @@ func (p *Parser) ParseGeneralEvent(data []string) (core.GeneralEvent, error) {
 					return thisEvent, fmt.Errorf("invalid position data for event %q", data[1])
 				}
 				thisEvent.Message = fmt.Sprintf("[%s,%s,[%g,%g,%g]]",
-					jsonString(objectType), jsonString(unitName), posX, posY, posZ)
+					strconv.Quote(objectType), strconv.Quote(unitName), posX, posY, posZ)
 			} else {
 				thisEvent.Message = fmt.Sprintf("[%s,%s]",
-					jsonString(objectType), jsonString(unitName))
+					strconv.Quote(objectType), strconv.Quote(unitName))
 			}
 		} else if len(data) >= 3 {
 			// Legacy format: [frame, type, "name,objectType"]
@@ -201,7 +201,7 @@ func (p *Parser) ParseGeneralEvent(data []string) (core.GeneralEvent, error) {
 		if len(data) >= 4 {
 			side := data[2]
 			message := data[3]
-			thisEvent.Message = fmt.Sprintf("[%s,%s]", jsonString(side), jsonString(message))
+			thisEvent.Message = fmt.Sprintf("[%s,%s]", strconv.Quote(side), strconv.Quote(message))
 		} else if len(data) >= 3 {
 			thisEvent.Message = data[2]
 		}
@@ -222,10 +222,6 @@ func (p *Parser) ParseGeneralEvent(data []string) (core.GeneralEvent, error) {
 	return thisEvent, nil
 }
 
-// jsonString returns a JSON-encoded string value (with quotes and escaping).
-func jsonString(s string) string {
-	return strconv.Quote(s)
-}
 
 // ParseKillEvent parses kill event data into a KillEvent.
 // Raw victim/killer IDs are returned for the worker to classify as soldier vs vehicle.

--- a/internal/parser/parse_events.go
+++ b/internal/parser/parse_events.go
@@ -197,12 +197,8 @@ func (p *Parser) ParseGeneralEvent(data []string) (core.GeneralEvent, error) {
 		}
 
 	case "endMission":
-		if len(data) >= 4 && data[2] == "" {
-			// Legacy format: [frame, "endMission", "", extraDataJSON]
-			thisEvent.Message = data[2]
-			_ = json.Unmarshal([]byte(data[3]), &thisEvent.ExtraData)
-		} else if len(data) >= 4 {
-			// Typed args: [frame, "endMission", side, message]
+		// Typed args: [frame, "endMission", side, message]
+		if len(data) >= 4 {
 			side := data[2]
 			message := data[3]
 			thisEvent.Message = fmt.Sprintf("[%s,%s]", jsonString(side), jsonString(message))

--- a/internal/parser/parse_events_test.go
+++ b/internal/parser/parse_events_test.go
@@ -501,6 +501,61 @@ func TestParseGeneralEvent(t *testing.T) {
 			},
 		},
 		{
+			name:  "captured with typed args",
+			input: []string{"200", "captured", "sector", "Sector Alpha", "100.5", "200.3", "0"},
+			check: func(t *testing.T, e core.GeneralEvent) {
+				assert.Equal(t, core.Frame(200), e.CaptureFrame)
+				assert.Equal(t, "captured", e.Name)
+				assert.Equal(t, `["sector","Sector Alpha",[100.5,200.3,0]]`, e.Message)
+			},
+		},
+		{
+			name:  "contested with typed args and commas in name",
+			input: []string{"300", "contested", "sector", "Sector,With,Commas", "50", "60", "0"},
+			check: func(t *testing.T, e core.GeneralEvent) {
+				assert.Equal(t, "contested", e.Name)
+				assert.Equal(t, `["sector","Sector,With,Commas",[50,60,0]]`, e.Message)
+			},
+		},
+		{
+			name:  "capturedFlag with typed args",
+			input: []string{"150", "capturedFlag", "flag", "Player One", "300", "400", "5"},
+			check: func(t *testing.T, e core.GeneralEvent) {
+				assert.Equal(t, "capturedFlag", e.Name)
+				assert.Equal(t, `["flag","Player One",[300,400,5]]`, e.Message)
+			},
+		},
+		{
+			name:  "captured with typed args no position",
+			input: []string{"200", "captured", "sector", "Sector Alpha"},
+			check: func(t *testing.T, e core.GeneralEvent) {
+				assert.Equal(t, `["sector","Sector Alpha"]`, e.Message)
+			},
+		},
+		{
+			name:  "endMission with typed args",
+			input: []string{"1043", "endMission", "WEST", "BLUFOR wins"},
+			check: func(t *testing.T, e core.GeneralEvent) {
+				assert.Equal(t, "endMission", e.Name)
+				assert.Equal(t, `["WEST","BLUFOR wins"]`, e.Message)
+			},
+		},
+		{
+			name:  "endMission with comma in message",
+			input: []string{"500", "endMission", "EAST", "OPFOR wins, decisively"},
+			check: func(t *testing.T, e core.GeneralEvent) {
+				assert.Equal(t, `["EAST","OPFOR wins, decisively"]`, e.Message)
+			},
+		},
+		{
+			name:  "terminalHackStarted with typed args",
+			input: []string{"400", "terminalHackStarted", "Player One"},
+			check: func(t *testing.T, e core.GeneralEvent) {
+				assert.Equal(t, "terminalHackStarted", e.Name)
+				assert.Equal(t, "Player One", e.Message)
+			},
+		},
+		{
 			name:    "error: bad frame",
 			input:   []string{"abc", "evt", "msg", "{}"},
 			wantErr: true,

--- a/internal/parser/parse_events_test.go
+++ b/internal/parser/parse_events_test.go
@@ -554,6 +554,19 @@ func TestParseGeneralEvent(t *testing.T) {
 			},
 		},
 		{
+			name:  "endMission with side only (3 fields)",
+			input: []string{"500", "endMission", "WEST"},
+			check: func(t *testing.T, e core.GeneralEvent) {
+				assert.Equal(t, "endMission", e.Name)
+				assert.Equal(t, "WEST", e.Message)
+			},
+		},
+		{
+			name:    "error: insufficient data",
+			input:   []string{"0"},
+			wantErr: true,
+		},
+		{
 			name:    "error: bad frame",
 			input:   []string{"abc", "evt", "msg", "{}"},
 			wantErr: true,

--- a/internal/parser/parse_events_test.go
+++ b/internal/parser/parse_events_test.go
@@ -481,14 +481,12 @@ func TestParseGeneralEvent(t *testing.T) {
 			},
 		},
 		{
-			name:  "end mission with extraData",
-			input: []string{"1043", "endMission", "", `{"message":"BLUFOR wins","winner":"WEST"}`},
+			name:  "endMission with empty side",
+			input: []string{"1043", "endMission", "", "Recording ended due to server being empty"},
 			check: func(t *testing.T, e core.GeneralEvent) {
 				assert.Equal(t, core.Frame(1043), e.CaptureFrame)
 				assert.Equal(t, "endMission", e.Name)
-				assert.Equal(t, "", e.Message)
-				assert.Equal(t, "BLUFOR wins", e.ExtraData["message"])
-				assert.Equal(t, "WEST", e.ExtraData["winner"])
+				assert.Equal(t, `["","Recording ended due to server being empty"]`, e.Message)
 			},
 		},
 		{

--- a/internal/parser/parse_events_test.go
+++ b/internal/parser/parse_events_test.go
@@ -563,6 +563,18 @@ func TestParseGeneralEvent(t *testing.T) {
 			input:   []string{"0", "evt", "msg", "not_json"},
 			wantErr: true,
 		},
+		{
+			name:    "error: bad position data in captured event",
+			input:   []string{"200", "captured", "sector", "Alpha", "not_a_number", "200", "0"},
+			wantErr: true,
+		},
+		{
+			name:  "captured with legacy 3-field format",
+			input: []string{"200", "captured", "Alpha,sector"},
+			check: func(t *testing.T, e core.GeneralEvent) {
+				assert.Equal(t, "Alpha,sector", e.Message)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/parser/parse_focus.go
+++ b/internal/parser/parse_focus.go
@@ -1,0 +1,37 @@
+package parser
+
+import (
+	"fmt"
+
+	"github.com/OCAP2/extension/v5/internal/util"
+	"github.com/OCAP2/extension/v5/pkg/core"
+)
+
+// parseFocusFrame parses a single frame number from args.
+// Args: [frameNo]
+func (p *Parser) parseFocusFrame(data []string) (core.Frame, error) {
+	if len(data) < 1 {
+		return 0, fmt.Errorf("expected 1 arg, got %d", len(data))
+	}
+
+	cleaned := util.FixEscapeQuotes(util.TrimQuotes(data[0]))
+
+	frame, err := parseUintFromFloat(cleaned)
+	if err != nil {
+		return 0, fmt.Errorf("error converting frame: %w", err)
+	}
+
+	return core.Frame(frame), nil
+}
+
+// ParseFocusStart parses a focus start command.
+// Args: [frameNo]
+func (p *Parser) ParseFocusStart(data []string) (core.Frame, error) {
+	return p.parseFocusFrame(data)
+}
+
+// ParseFocusEnd parses a focus end command.
+// Args: [frameNo]
+func (p *Parser) ParseFocusEnd(data []string) (core.Frame, error) {
+	return p.parseFocusFrame(data)
+}

--- a/internal/parser/parse_focus_test.go
+++ b/internal/parser/parse_focus_test.go
@@ -1,0 +1,66 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/OCAP2/extension/v5/pkg/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFocusStart(t *testing.T) {
+	p := newTestParser()
+
+	tests := []struct {
+		name    string
+		input   []string
+		want    core.Frame
+		wantErr bool
+	}{
+		{
+			name:  "integer frame",
+			input: []string{"150"},
+			want:  core.Frame(150),
+		},
+		{
+			name:  "float frame",
+			input: []string{"150.00"},
+			want:  core.Frame(150),
+		},
+		{
+			name:  "quoted frame",
+			input: []string{`"300"`},
+			want:  core.Frame(300),
+		},
+		{
+			name:    "no args",
+			input:   []string{},
+			wantErr: true,
+		},
+		{
+			name:    "invalid value",
+			input:   []string{"abc"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := p.ParseFocusStart(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseFocusEnd(t *testing.T) {
+	p := newTestParser()
+
+	frame, err := p.ParseFocusEnd([]string{"850"})
+	require.NoError(t, err)
+	assert.Equal(t, core.Frame(850), frame)
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -74,6 +74,8 @@ type Service interface {
 	ParseTelemetryEvent(args []string) (core.TelemetryEvent, error)
 	ParsePlacedObject(args []string) (core.PlacedObject, error)
 	ParsePlacedObjectEvent(args []string) (core.PlacedObjectEvent, error)
+	ParseFocusStart(args []string) (core.Frame, error)
+	ParseFocusEnd(args []string) (core.Frame, error)
 }
 
 var _ Service = (*Parser)(nil)

--- a/internal/storage/memory/export/v1/builder_test.go
+++ b/internal/storage/memory/export/v1/builder_test.go
@@ -445,6 +445,43 @@ func TestBuildWithGeneralEvents(t *testing.T) {
 	assert.Equal(t, "[1,2,3", export.Events[3][2])
 }
 
+func TestBuildWithCapturedEventJSONArray(t *testing.T) {
+	data := &MissionData{
+		Mission:  &core.Mission{MissionName: "Test"},
+		World:    &core.World{WorldName: "Altis"},
+		Soldiers: make(map[uint16]*SoldierRecord),
+		Vehicles: make(map[uint16]*VehicleRecord),
+		Markers:  make(map[string]*MarkerRecord),
+		GeneralEvents: []core.GeneralEvent{
+			{CaptureFrame: 15, Name: "captured", Message: `["sector","Sector Alpha",[100.5,200.3,0]]`},
+		},
+	}
+
+	export := Build(data)
+
+	require.Len(t, export.Events, 1)
+
+	evt := export.Events[0]
+	assert.Equal(t, 14, evt[0])          // internal frame 15 → v1 frame 14
+	assert.Equal(t, "captured", evt[1])  // event name
+
+	// Message must be a parsed JSON array, not a raw string
+	arr, ok := evt[2].([]any)
+	require.True(t, ok, "expected evt[2] to be []any (parsed JSON array), got %T", evt[2])
+	require.Len(t, arr, 3)
+
+	assert.Equal(t, "sector", arr[0])
+	assert.Equal(t, "Sector Alpha", arr[1])
+
+	// Nested array: JSON numbers decode as float64
+	nested, ok := arr[2].([]any)
+	require.True(t, ok, "expected arr[2] to be []any (nested array), got %T", arr[2])
+	require.Len(t, nested, 3)
+	assert.Equal(t, 100.5, nested[0])
+	assert.Equal(t, 200.3, nested[1])
+	assert.Equal(t, float64(0), nested[2])
+}
+
 func TestBuildWithHitEvents(t *testing.T) {
 	soldierVictim := uint(5)
 	soldierShooter := uint(10)

--- a/internal/storage/memory/export_test.go
+++ b/internal/storage/memory/export_test.go
@@ -24,7 +24,7 @@ func TestIntegrationFullExport(t *testing.T) {
 	b := New(config.MemoryConfig{
 		OutputDir:      tempDir,
 		CompressOutput: false,
-	})
+	}, nil)
 
 	mission := &core.Mission{
 		MissionName:      "Test Mission",
@@ -175,7 +175,7 @@ func TestExportJSON(t *testing.T) {
 	b := New(config.MemoryConfig{
 		OutputDir:      tempDir,
 		CompressOutput: false,
-	})
+	}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{
 		MissionName: "Export Test", Author: "Author", StartTime: time.Date(2024, 3, 15, 14, 30, 0, 0, time.UTC),
@@ -198,7 +198,7 @@ func TestExportJSON(t *testing.T) {
 func TestExportGzipJSON(t *testing.T) {
 	tempDir := t.TempDir()
 
-	b := New(config.MemoryConfig{OutputDir: tempDir, CompressOutput: true})
+	b := New(config.MemoryConfig{OutputDir: tempDir, CompressOutput: true}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{
 		MissionName: "Gzip Test", Author: "Author", StartTime: time.Date(2024, 3, 15, 14, 30, 0, 0, time.UTC),
@@ -238,7 +238,7 @@ func TestFilenameGeneration(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		b := New(config.MemoryConfig{OutputDir: tempDir, CompressOutput: tt.compress})
+		b := New(config.MemoryConfig{OutputDir: tempDir, CompressOutput: tt.compress}, nil)
 
 		require.NoError(t, b.StartMission(&core.Mission{MissionName: tt.missionName, StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 		require.NoError(t, b.EndMission())
@@ -260,7 +260,7 @@ func TestExportCreatesOutputDir(t *testing.T) {
 	b := New(config.MemoryConfig{
 		OutputDir:      nonExistentDir,
 		CompressOutput: false,
-	})
+	}, nil)
 
 	mission := &core.Mission{
 		MissionName: "Nested Dir Test",
@@ -281,7 +281,7 @@ func TestExportCreatesOutputDir(t *testing.T) {
 }
 
 func TestSoldierPositionFormat(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Player1", IsPlayer: true, JoinFrame: 1}))
@@ -315,7 +315,7 @@ func TestSoldierPositionFormat(t *testing.T) {
 }
 
 func TestVehiclePositionFormat(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 	require.NoError(t, b.AddVehicle(&core.Vehicle{ID: 10, DisplayName: "Hunter", OcapType: "car", JoinFrame: 1}))
@@ -348,7 +348,7 @@ func TestVehiclePositionFormat(t *testing.T) {
 }
 
 func TestFiredEventFormat(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 1, JoinFrame: 1}))
@@ -377,7 +377,7 @@ func TestFiredEventFormat(t *testing.T) {
 }
 
 func TestMarkerPositionFormat(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 	testMarker := &core.Marker{
@@ -410,7 +410,7 @@ func TestMarkerPositionFormat(t *testing.T) {
 
 func TestEmptyExport(t *testing.T) {
 	tempDir := t.TempDir()
-	b := New(config.MemoryConfig{OutputDir: tempDir, CompressOutput: false})
+	b := New(config.MemoryConfig{OutputDir: tempDir, CompressOutput: false}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Empty Mission", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 	require.NoError(t, b.EndMission())
@@ -431,7 +431,7 @@ func TestEmptyExport(t *testing.T) {
 }
 
 func TestMaxFrameCalculation(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 1, JoinFrame: 1}))
@@ -446,7 +446,7 @@ func TestMaxFrameCalculation(t *testing.T) {
 }
 
 func TestSoldierWithoutVehicle(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Infantry", IsPlayer: false, JoinFrame: 1}))
@@ -468,7 +468,7 @@ func TestSoldierWithoutVehicle(t *testing.T) {
 }
 
 func TestDeadVehicle(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 	require.NoError(t, b.AddVehicle(&core.Vehicle{ID: 5, DisplayName: "Destroyed Tank", OcapType: "tank", ClassName: "B_MBT_01_cannon_F", JoinFrame: 1}))
@@ -488,7 +488,7 @@ func TestDeadVehicle(t *testing.T) {
 }
 
 func TestMultipleEntitiesExport(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Alpha1", GroupID: "Alpha", Side: "WEST", IsPlayer: true, JoinFrame: 1}))
@@ -522,7 +522,7 @@ func TestMultipleEntitiesExport(t *testing.T) {
 }
 
 func TestEventWithoutExtraData(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 	require.NoError(t, b.RecordGeneralEvent(&core.GeneralEvent{CaptureFrame: 100, Name: "endMission", Message: "Mission ended", ExtraData: nil}))
@@ -575,7 +575,7 @@ func TestGeneralEventJSONMessageParsing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := New(config.MemoryConfig{})
+			b := New(config.MemoryConfig{}, nil)
 			require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 			require.NoError(t, b.RecordGeneralEvent(&core.GeneralEvent{
 				CaptureFrame: 10,
@@ -592,7 +592,7 @@ func TestGeneralEventJSONMessageParsing(t *testing.T) {
 }
 
 func TestMultipleMarkersExport(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 	// Each marker needs a unique ID so RecordMarkerState can find the correct one
@@ -637,7 +637,7 @@ func TestMultipleMarkersExport(t *testing.T) {
 }
 
 func TestMultipleFiredEvents(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 1, UnitName: "Shooter", JoinFrame: 1}))
@@ -673,7 +673,7 @@ func TestMultipleFiredEvents(t *testing.T) {
 }
 
 func TestVehicleWithJoinFrame(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 	require.NoError(t, b.AddVehicle(&core.Vehicle{
@@ -697,7 +697,7 @@ func TestVehicleWithJoinFrame(t *testing.T) {
 // TestJSONFormatValidation validates that JSON output matches the old C++ extension format
 func TestJSONFormatValidation(t *testing.T) {
 	tempDir := t.TempDir()
-	b := New(config.MemoryConfig{OutputDir: tempDir, CompressOutput: false})
+	b := New(config.MemoryConfig{OutputDir: tempDir, CompressOutput: false}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{
 		MissionName: "Format Test", Author: "Author", StartTime: time.Now(),
@@ -829,7 +829,7 @@ func ptrUint16(v uint16) *uint16 {
 }
 
 func TestMarkerColorHashPrefixIsStripped(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 
@@ -873,7 +873,7 @@ func TestMarkerColorHashPrefixIsStripped(t *testing.T) {
 }
 
 func TestMarkerOwnerIDExport(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 
@@ -919,7 +919,7 @@ func TestMarkerOwnerIDExport(t *testing.T) {
 }
 
 func TestMarkerSizeAndBrushExport(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 
@@ -968,7 +968,7 @@ func TestMarkerSizeAndBrushExport(t *testing.T) {
 }
 
 func TestExtensionBuildExport(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{
 		MissionName:    "Test",
@@ -982,7 +982,7 @@ func TestExtensionBuildExport(t *testing.T) {
 }
 
 func TestTagsExport(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{
 		MissionName: "Test",
@@ -996,7 +996,7 @@ func TestTagsExport(t *testing.T) {
 }
 
 func TestTimesExport(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{
 		MissionName: "Test",
@@ -1039,7 +1039,7 @@ func TestTimesExport(t *testing.T) {
 }
 
 func TestTimesExportEmpty(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{
 		MissionName: "Test",
@@ -1055,7 +1055,7 @@ func TestTimesExportEmpty(t *testing.T) {
 
 func TestTimesExportJSON(t *testing.T) {
 	tempDir := t.TempDir()
-	b := New(config.MemoryConfig{OutputDir: tempDir, CompressOutput: false})
+	b := New(config.MemoryConfig{OutputDir: tempDir, CompressOutput: false}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{
 		MissionName:    "Times Test",
@@ -1105,7 +1105,7 @@ func TestTimesExportJSON(t *testing.T) {
 }
 
 func TestPolylineMarkerExport(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 
@@ -1161,7 +1161,7 @@ func TestPolylineMarkerExport(t *testing.T) {
 func TestVehicleCrewExportIntegration(t *testing.T) {
 	tempDir := t.TempDir()
 
-	b := New(config.MemoryConfig{OutputDir: tempDir, CompressOutput: false})
+	b := New(config.MemoryConfig{OutputDir: tempDir, CompressOutput: false}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{
 		MissionName: "Crew Test", Author: "Test", StartTime: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -1226,7 +1226,7 @@ func TestVehicleCrewExportIntegration(t *testing.T) {
 }
 
 func TestPlayerTakeoverUpdatesEntityMetadata(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 
@@ -1283,7 +1283,7 @@ func TestExportJSON_MkdirAllError(t *testing.T) {
 	b := New(config.MemoryConfig{
 		OutputDir:      "/dev/null/subdir",
 		CompressOutput: false,
-	})
+	}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 
@@ -1316,7 +1316,7 @@ func TestEndMission_ExportError(t *testing.T) {
 	b := New(config.MemoryConfig{
 		OutputDir:      "/dev/null/subdir",
 		CompressOutput: true,
-	})
+	}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 
@@ -1326,7 +1326,7 @@ func TestEndMission_ExportError(t *testing.T) {
 }
 
 func TestPlacedObjectExport(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 
@@ -1379,7 +1379,7 @@ func TestPlacedObjectExport(t *testing.T) {
 
 func TestMarkerSideValues(t *testing.T) {
 	// Test that sideToIndex correctly handles side string values
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 
 	// Add markers with string side values
@@ -1427,7 +1427,7 @@ func TestMarkerSideValues(t *testing.T) {
 }
 
 func TestPlacedObjectHitEventExport(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
 

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -62,6 +62,9 @@ type Backend struct {
 	ace3UnconsciousEvents []core.Ace3UnconsciousEvent
 	projectileEvents      []core.ProjectileEvent
 
+	focusStart *core.Frame
+	focusEnd   *core.Frame
+
 	mu sync.RWMutex
 }
 
@@ -144,6 +147,8 @@ func (b *Backend) resetCollections() {
 	b.ace3DeathEvents = nil
 	b.ace3UnconsciousEvents = nil
 	b.projectileEvents = nil
+	b.focusStart = nil
+	b.focusEnd = nil
 }
 
 // AddSoldier registers a new soldier.
@@ -384,6 +389,22 @@ func (b *Backend) RecordPlacedObjectEvent(e *core.PlacedObjectEvent) error {
 	return nil
 }
 
+// SetFocusStart sets the playback focus start frame.
+func (b *Backend) SetFocusStart(frame core.Frame) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.focusStart = &frame
+	return nil
+}
+
+// SetFocusEnd sets the playback focus end frame.
+func (b *Backend) SetFocusEnd(frame core.Frame) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.focusEnd = &frame
+	return nil
+}
+
 // GetExportedFilePath returns the path to the last exported file.
 func (b *Backend) GetExportedFilePath() string {
 	b.mu.RLock()
@@ -436,12 +457,33 @@ func (b *Backend) computeExportMetadata() core.UploadMetadata {
 
 	duration := float64(endFrame) * float64(b.mission.CaptureDelay) / 1000.0
 
-	return core.UploadMetadata{
+	meta := core.UploadMetadata{
 		WorldName:       b.world.WorldName,
 		MissionName:     b.mission.MissionName,
 		MissionDuration: duration,
 		Tag:             b.mission.Tag,
+		EndFrame:        endFrame,
 	}
+
+	// Resolve focus: if either is set, default the missing one
+	if b.focusStart != nil || b.focusEnd != nil {
+		if b.focusStart != nil {
+			fs := *b.focusStart
+			meta.FocusStart = &fs
+		} else {
+			fs := core.Frame(0)
+			meta.FocusStart = &fs
+		}
+		if b.focusEnd != nil {
+			fe := *b.focusEnd
+			meta.FocusEnd = &fe
+		} else {
+			fe := endFrame
+			meta.FocusEnd = &fe
+		}
+	}
+
+	return meta
 }
 
 // BuildExport creates a v1 export from the current mission data.

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -395,25 +395,41 @@ func (b *Backend) RecordPlacedObjectEvent(e *core.PlacedObjectEvent) error {
 	return nil
 }
 
-// SetFocusStart opens a new focus range. If a range is already open, logs a warning and ignores.
+// SetFocusStart opens a new focus range.
+// Returns an error if a range is already open or if the start frame is invalid.
 func (b *Backend) SetFocusStart(frame core.Frame) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	if frame == core.FrameForever {
+		return fmt.Errorf("focus start frame must be > 0")
+	}
 	if b.focusOpenStart != nil {
 		b.logger.Warn("SetFocusStart called while a focus range is already open, ignoring", "openStart", *b.focusOpenStart, "newStart", frame)
 		return nil
+	}
+	if len(b.focusRanges) > 0 {
+		lastEnd := b.focusRanges[len(b.focusRanges)-1].End
+		if frame < lastEnd {
+			return fmt.Errorf("focus start frame %d must be >= end of previous range %d", frame, lastEnd)
+		}
 	}
 	b.focusOpenStart = &frame
 	return nil
 }
 
-// SetFocusEnd closes the currently open focus range. If no range is open, logs a warning and ignores.
+// SetFocusEnd closes the currently open focus range.
+// Returns an error if no range is open or if the end frame is invalid.
 func (b *Backend) SetFocusEnd(frame core.Frame) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
 	if b.focusOpenStart == nil {
 		b.logger.Warn("SetFocusEnd called without an open focus range, ignoring", "frame", frame)
 		return nil
+	}
+	if frame <= *b.focusOpenStart {
+		return fmt.Errorf("focus end frame %d must be > start frame %d", frame, *b.focusOpenStart)
 	}
 	b.focusRanges = append(b.focusRanges, core.FocusRange{Start: *b.focusOpenStart, End: frame})
 	b.focusOpenStart = nil

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -3,6 +3,7 @@ package memory
 
 import (
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"github.com/OCAP2/extension/v5/internal/config"
@@ -62,14 +63,18 @@ type Backend struct {
 	ace3UnconsciousEvents []core.Ace3UnconsciousEvent
 	projectileEvents      []core.ProjectileEvent
 
-	focusStart *core.Frame
-	focusEnd   *core.Frame
+	focusRanges    []core.FocusRange // completed ranges
+	focusOpenStart *core.Frame       // currently open range (start set, end not yet)
 
-	mu sync.RWMutex
+	logger *slog.Logger
+	mu     sync.RWMutex
 }
 
 // New creates a new memory backend
-func New(cfg config.MemoryConfig) *Backend {
+func New(cfg config.MemoryConfig, logger *slog.Logger) *Backend {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	return &Backend{
 		cfg:         cfg,
 		soldiers:    make(map[uint16]*SoldierRecord),
@@ -77,6 +82,7 @@ func New(cfg config.MemoryConfig) *Backend {
 		markers:     make(map[string]*MarkerRecord),
 		markersByID: make(map[uint]*MarkerRecord),
 		placed:      make(map[uint16]*PlacedObjectRecord),
+		logger:      logger,
 	}
 }
 
@@ -147,8 +153,8 @@ func (b *Backend) resetCollections() {
 	b.ace3DeathEvents = nil
 	b.ace3UnconsciousEvents = nil
 	b.projectileEvents = nil
-	b.focusStart = nil
-	b.focusEnd = nil
+	b.focusRanges = nil
+	b.focusOpenStart = nil
 }
 
 // AddSoldier registers a new soldier.
@@ -389,19 +395,28 @@ func (b *Backend) RecordPlacedObjectEvent(e *core.PlacedObjectEvent) error {
 	return nil
 }
 
-// SetFocusStart sets the playback focus start frame.
+// SetFocusStart opens a new focus range. If a range is already open, logs a warning and ignores.
 func (b *Backend) SetFocusStart(frame core.Frame) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.focusStart = &frame
+	if b.focusOpenStart != nil {
+		b.logger.Warn("SetFocusStart called while a focus range is already open, ignoring", "openStart", *b.focusOpenStart, "newStart", frame)
+		return nil
+	}
+	b.focusOpenStart = &frame
 	return nil
 }
 
-// SetFocusEnd sets the playback focus end frame.
+// SetFocusEnd closes the currently open focus range. If no range is open, logs a warning and ignores.
 func (b *Backend) SetFocusEnd(frame core.Frame) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.focusEnd = &frame
+	if b.focusOpenStart == nil {
+		b.logger.Warn("SetFocusEnd called without an open focus range, ignoring", "frame", frame)
+		return nil
+	}
+	b.focusRanges = append(b.focusRanges, core.FocusRange{Start: *b.focusOpenStart, End: frame})
+	b.focusOpenStart = nil
 	return nil
 }
 
@@ -465,22 +480,17 @@ func (b *Backend) computeExportMetadata() core.UploadMetadata {
 		EndFrame:        endFrame,
 	}
 
-	// Resolve focus: if either is set, default the missing one
-	if b.focusStart != nil || b.focusEnd != nil {
-		if b.focusStart != nil {
-			fs := *b.focusStart
-			meta.FocusStart = &fs
-		} else {
-			fs := core.Frame(0)
-			meta.FocusStart = &fs
-		}
-		if b.focusEnd != nil {
-			fe := *b.focusEnd
-			meta.FocusEnd = &fe
-		} else {
-			fe := endFrame
-			meta.FocusEnd = &fe
-		}
+	// Resolve focus ranges for upload
+	allRanges := make([]core.FocusRange, len(b.focusRanges))
+	copy(allRanges, b.focusRanges)
+
+	// Auto-close any open range with endFrame
+	if b.focusOpenStart != nil {
+		allRanges = append(allRanges, core.FocusRange{Start: *b.focusOpenStart, End: endFrame})
+	}
+
+	if len(allRanges) > 0 {
+		meta.FocusRanges = allRanges
 	}
 
 	return meta

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -500,8 +500,8 @@ func (b *Backend) computeExportMetadata() core.UploadMetadata {
 	allRanges := make([]core.FocusRange, len(b.focusRanges))
 	copy(allRanges, b.focusRanges)
 
-	// Auto-close any open range with endFrame
-	if b.focusOpenStart != nil {
+	// Auto-close any open range with endFrame (only if endFrame > start)
+	if b.focusOpenStart != nil && endFrame > *b.focusOpenStart {
 		allRanges = append(allRanges, core.FocusRange{Start: *b.focusOpenStart, End: endFrame})
 	}
 

--- a/internal/storage/memory/memory_test.go
+++ b/internal/storage/memory/memory_test.go
@@ -985,3 +985,103 @@ func TestFocusRange_ResetOnNewMission(t *testing.T) {
 	assert.Nil(t, b.focusOpenStart)
 	assert.Len(t, b.focusRanges, 0)
 }
+
+func TestFocusRange_StartFrameZero(t *testing.T) {
+	b := New(config.MemoryConfig{}, nil)
+
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Focus", CaptureDelay: 1.0}, &core.World{WorldName: "Altis"}))
+
+	// Frame 0 (FrameForever) is invalid for focus start
+	err := b.SetFocusStart(core.Frame(0))
+	assert.Error(t, err)
+	assert.Nil(t, b.focusOpenStart)
+}
+
+func TestFocusRange_EndBeforeStart(t *testing.T) {
+	b := New(config.MemoryConfig{}, nil)
+
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Focus", CaptureDelay: 1.0}, &core.World{WorldName: "Altis"}))
+
+	// start(45), end(1) — end must be > start
+	require.NoError(t, b.SetFocusStart(core.Frame(45)))
+	err := b.SetFocusEnd(core.Frame(1))
+	assert.Error(t, err)
+
+	// Range should NOT have been added, but the open start should still be there
+	assert.Len(t, b.focusRanges, 0)
+	assert.NotNil(t, b.focusOpenStart)
+	assert.Equal(t, core.Frame(45), *b.focusOpenStart)
+}
+
+func TestFocusRange_EndEqualToStart(t *testing.T) {
+	b := New(config.MemoryConfig{}, nil)
+
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Focus", CaptureDelay: 1.0}, &core.World{WorldName: "Altis"}))
+
+	// start(50), end(50) — end must be strictly greater
+	require.NoError(t, b.SetFocusStart(core.Frame(50)))
+	err := b.SetFocusEnd(core.Frame(50))
+	assert.Error(t, err)
+	assert.Len(t, b.focusRanges, 0)
+}
+
+func TestFocusRange_OverlappingStart(t *testing.T) {
+	b := New(config.MemoryConfig{}, nil)
+
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Focus", CaptureDelay: 1.0}, &core.World{WorldName: "Altis"}))
+
+	// First range: start(1), end(10) — valid
+	require.NoError(t, b.SetFocusStart(core.Frame(1)))
+	require.NoError(t, b.SetFocusEnd(core.Frame(10)))
+
+	// Second start before previous end: start(5) — must be >= 10
+	err := b.SetFocusStart(core.Frame(5))
+	assert.Error(t, err)
+	assert.Nil(t, b.focusOpenStart)
+	assert.Len(t, b.focusRanges, 1)
+}
+
+func TestFocusRange_UserScenario(t *testing.T) {
+	// User's exact scenario: start(1), end(10), start(45), end(1), start(10), end(100)
+	b := New(config.MemoryConfig{}, nil)
+
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Focus", CaptureDelay: 1.0}, &core.World{WorldName: "Altis"}))
+
+	s := &core.Soldier{ID: 1}
+	require.NoError(t, b.AddSoldier(s))
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{SoldierID: 1, CaptureFrame: 500}))
+
+	// start(1), end(10) — valid first range
+	require.NoError(t, b.SetFocusStart(core.Frame(1)))
+	require.NoError(t, b.SetFocusEnd(core.Frame(10)))
+	assert.Len(t, b.focusRanges, 1)
+
+	// start(45), end(1) — start is valid (45 >= 10), but end(1) < start(45) = error
+	require.NoError(t, b.SetFocusStart(core.Frame(45)))
+	err := b.SetFocusEnd(core.Frame(1))
+	assert.Error(t, err)
+	// Range still open at 45
+	assert.Len(t, b.focusRanges, 1)
+	assert.NotNil(t, b.focusOpenStart)
+
+	// Close the open range properly, then start a new one
+	require.NoError(t, b.SetFocusEnd(core.Frame(50)))
+	assert.Len(t, b.focusRanges, 2)
+
+	// start(10) — must be >= 50 (end of last range), so this fails
+	err = b.SetFocusStart(core.Frame(10))
+	assert.Error(t, err)
+
+	// start(100), end(200) — valid third range
+	require.NoError(t, b.SetFocusStart(core.Frame(100)))
+	require.NoError(t, b.SetFocusEnd(core.Frame(200)))
+
+	meta := b.GetExportMetadata()
+	require.Len(t, meta.FocusRanges, 3)
+	assert.Equal(t, core.Frame(1), meta.FocusRanges[0].Start)
+	assert.Equal(t, core.Frame(10), meta.FocusRanges[0].End)
+	assert.Equal(t, core.Frame(45), meta.FocusRanges[1].Start)
+	assert.Equal(t, core.Frame(50), meta.FocusRanges[1].End)
+	assert.Equal(t, core.Frame(100), meta.FocusRanges[2].Start)
+	assert.Equal(t, core.Frame(200), meta.FocusRanges[2].End)
+}

--- a/internal/storage/memory/memory_test.go
+++ b/internal/storage/memory/memory_test.go
@@ -25,7 +25,7 @@ func TestNew(t *testing.T) {
 		OutputDir:      "/tmp/test",
 		CompressOutput: true,
 	}
-	b := New(cfg)
+	b := New(cfg, nil)
 
 	require.NotNil(t, b)
 	assert.Equal(t, "/tmp/test", b.cfg.OutputDir)
@@ -36,14 +36,14 @@ func TestNew(t *testing.T) {
 }
 
 func TestInitAndClose(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	assert.NoError(t, b.Init())
 	assert.NoError(t, b.Close())
 }
 
 func TestStartMission(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	mission := &core.Mission{
 		MissionName: "Test Mission",
@@ -68,7 +68,7 @@ func TestStartMission(t *testing.T) {
 }
 
 func TestAddSoldier(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	s1 := &core.Soldier{
 		ID:       1,
@@ -97,7 +97,7 @@ func TestAddSoldier(t *testing.T) {
 }
 
 func TestAddVehicle(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	v1 := &core.Vehicle{
 		ID:          10,
@@ -121,7 +121,7 @@ func TestAddVehicle(t *testing.T) {
 }
 
 func TestAddMarker(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	m1 := &core.Marker{
 		MarkerName: "marker_1",
@@ -149,7 +149,7 @@ func TestAddMarker(t *testing.T) {
 }
 
 func TestRecordSoldierState(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	s := &core.Soldier{ID: 1, UnitName: "Test"}
 	require.NoError(t, b.AddSoldier(s))
@@ -183,7 +183,7 @@ func TestRecordSoldierState(t *testing.T) {
 }
 
 func TestRecordVehicleState(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	v := &core.Vehicle{ID: 10, ClassName: "Car"}
 	require.NoError(t, b.AddVehicle(v))
@@ -206,7 +206,7 @@ func TestRecordVehicleState(t *testing.T) {
 }
 
 func TestRecordMarkerState(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	m := &core.Marker{MarkerName: "test_marker"}
 	id, err := b.AddMarker(m)
@@ -231,7 +231,7 @@ func TestRecordMarkerState(t *testing.T) {
 }
 
 func TestDeleteMarker(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	m := &core.Marker{MarkerName: "grenade_1", EndFrame: core.FrameForever}
 	_, err := b.AddMarker(m)
@@ -248,7 +248,7 @@ func TestDeleteMarker(t *testing.T) {
 }
 
 func TestDeleteSoldier(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	s := &core.Soldier{ID: 1, UnitName: "Test"}
 	require.NoError(t, b.AddSoldier(s))
@@ -264,7 +264,7 @@ func TestDeleteSoldier(t *testing.T) {
 }
 
 func TestDeleteVehicle(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	v := &core.Vehicle{ID: 10, ClassName: "B_MRAP_01_F"}
 	require.NoError(t, b.AddVehicle(v))
@@ -280,7 +280,7 @@ func TestDeleteVehicle(t *testing.T) {
 }
 
 func TestRecordFiredEvent(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	s := &core.Soldier{ID: 1}
 	require.NoError(t, b.AddSoldier(s))
@@ -307,7 +307,7 @@ func TestRecordFiredEvent(t *testing.T) {
 }
 
 func TestRecordGeneralEvent(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	evt := &core.GeneralEvent{
 		CaptureFrame: 50,
@@ -323,7 +323,7 @@ func TestRecordGeneralEvent(t *testing.T) {
 }
 
 func TestRecordHitEvent(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	victimID := uint(1)
 	shooterID := uint(2)
@@ -341,7 +341,7 @@ func TestRecordHitEvent(t *testing.T) {
 }
 
 func TestRecordKillEvent(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	victimID := uint(1)
 	killerID := uint(2)
@@ -359,7 +359,7 @@ func TestRecordKillEvent(t *testing.T) {
 }
 
 func TestRecordChatEvent(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	soldierID := uint(1)
 	evt := &core.ChatEvent{
@@ -376,7 +376,7 @@ func TestRecordChatEvent(t *testing.T) {
 }
 
 func TestRecordRadioEvent(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	soldierID := uint(1)
 	evt := &core.RadioEvent{
@@ -395,7 +395,7 @@ func TestRecordRadioEvent(t *testing.T) {
 }
 
 func TestRecordTelemetryEvent(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	evt := &core.TelemetryEvent{
 		CaptureFrame: 100,
@@ -410,7 +410,7 @@ func TestRecordTelemetryEvent(t *testing.T) {
 }
 
 func TestRecordTimeState(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	now := time.Now()
 	state := &core.TimeState{
@@ -430,7 +430,7 @@ func TestRecordTimeState(t *testing.T) {
 }
 
 func TestRecordAce3DeathEvent(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	damageSource := uint(2)
 	evt := &core.Ace3DeathEvent{
@@ -446,7 +446,7 @@ func TestRecordAce3DeathEvent(t *testing.T) {
 }
 
 func TestRecordAce3UnconsciousEvent(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	evt := &core.Ace3UnconsciousEvent{
 		SoldierID:     1,
@@ -460,7 +460,7 @@ func TestRecordAce3UnconsciousEvent(t *testing.T) {
 }
 
 func TestRecordProjectileEvent(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	evt := &core.ProjectileEvent{
 		CaptureFrame:   100,
@@ -481,7 +481,7 @@ func TestRecordProjectileEvent(t *testing.T) {
 }
 
 func TestAddPlacedObject(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	p1 := &core.PlacedObject{
 		ID:          100,
@@ -513,7 +513,7 @@ func TestAddPlacedObject(t *testing.T) {
 }
 
 func TestRecordPlacedObjectEvent(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	p := &core.PlacedObject{ID: 100, DisplayName: "Mine"}
 	require.NoError(t, b.AddPlacedObject(p))
@@ -537,7 +537,7 @@ func TestRecordPlacedObjectEvent(t *testing.T) {
 }
 
 func TestConcurrentAccess(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	var wg sync.WaitGroup
 	numGoroutines := 10
@@ -576,7 +576,7 @@ func TestConcurrentAccess(t *testing.T) {
 }
 
 func TestIDsPreserved(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	// IDs are ObjectIDs set by caller, not auto-assigned
 	s := &core.Soldier{ID: 1}
@@ -597,7 +597,7 @@ func TestIDsPreserved(t *testing.T) {
 }
 
 func TestStartMissionResetsEverything(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	// Populate with data
 	require.NoError(t, b.AddSoldier(&core.Soldier{ID: 1}))
@@ -642,7 +642,7 @@ func TestGetExportedFilePath(t *testing.T) {
 	b := New(config.MemoryConfig{
 		OutputDir:      t.TempDir(),
 		CompressOutput: true,
-	})
+	}, nil)
 
 	// Before export, should return empty
 	assert.Empty(t, b.GetExportedFilePath())
@@ -653,7 +653,7 @@ func TestGetExportedFilePath_AfterExport(t *testing.T) {
 	b := New(config.MemoryConfig{
 		OutputDir:      tmpDir,
 		CompressOutput: true,
-	})
+	}, nil)
 
 	mission := &core.Mission{
 		MissionName: "Test",
@@ -675,7 +675,7 @@ func TestGetExportedFilePath_UncompressedExport(t *testing.T) {
 	b := New(config.MemoryConfig{
 		OutputDir:      tmpDir,
 		CompressOutput: false,
-	})
+	}, nil)
 
 	mission := &core.Mission{
 		MissionName: "Test",
@@ -693,7 +693,7 @@ func TestGetExportedFilePath_UncompressedExport(t *testing.T) {
 }
 
 func TestGetExportMetadata(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	mission := &core.Mission{
 		MissionName:  "Test Mission",
@@ -724,7 +724,7 @@ func TestGetExportMetadata(t *testing.T) {
 }
 
 func TestGetExportMetadata_VehicleEndFrame(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	mission := &core.Mission{
 		MissionName:  "Vehicle Test",
@@ -758,7 +758,7 @@ func TestGetExportMetadata_VehicleEndFrame(t *testing.T) {
 }
 
 func TestGetExportMetadata_EmptyMission(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	mission := &core.Mission{
 		MissionName:  "Empty Mission",
@@ -783,7 +783,7 @@ func TestStartMissionResetsExportPath(t *testing.T) {
 	b := New(config.MemoryConfig{
 		OutputDir:      t.TempDir(),
 		CompressOutput: true,
-	})
+	}, nil)
 
 	mission := &core.Mission{
 		MissionName: "First",
@@ -804,7 +804,7 @@ func TestStartMissionResetsExportPath(t *testing.T) {
 }
 
 func TestEndMissionWithoutStartMission(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	// EndMission without StartMission should return an error, not panic
 	err := b.EndMission()
@@ -813,7 +813,7 @@ func TestEndMissionWithoutStartMission(t *testing.T) {
 }
 
 func TestGetExportMetadataWithoutStartMission(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	// GetExportMetadata without StartMission should return empty metadata, not panic
 	meta := b.GetExportMetadata()
@@ -825,7 +825,7 @@ func TestGetExportMetadataWithoutStartMission(t *testing.T) {
 }
 
 func TestGetExportMetadata_PlacedEventEndFrame(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	mission := &core.Mission{
 		MissionName:  "Placed Test",
@@ -859,7 +859,7 @@ func TestGetExportMetadata_PlacedEventEndFrame(t *testing.T) {
 }
 
 func TestComputeExportMetadata_NilMission(t *testing.T) {
-	b := New(config.MemoryConfig{})
+	b := New(config.MemoryConfig{}, nil)
 
 	// Directly call computeExportMetadata with nil mission/world
 	meta := b.computeExportMetadata()
@@ -867,4 +867,121 @@ func TestComputeExportMetadata_NilMission(t *testing.T) {
 	assert.Empty(t, meta.WorldName)
 	assert.Empty(t, meta.MissionName)
 	assert.Equal(t, 0.0, meta.MissionDuration)
+}
+
+func TestFocusRange_SingleRange(t *testing.T) {
+	b := New(config.MemoryConfig{}, nil)
+
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Focus", CaptureDelay: 1.0}, &core.World{WorldName: "Altis"}))
+
+	s := &core.Soldier{ID: 1}
+	require.NoError(t, b.AddSoldier(s))
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{SoldierID: 1, CaptureFrame: 200}))
+
+	require.NoError(t, b.SetFocusStart(core.Frame(50)))
+	require.NoError(t, b.SetFocusEnd(core.Frame(150)))
+
+	meta := b.GetExportMetadata()
+
+	require.Len(t, meta.FocusRanges, 1)
+	assert.Equal(t, core.Frame(50), meta.FocusRanges[0].Start)
+	assert.Equal(t, core.Frame(150), meta.FocusRanges[0].End)
+}
+
+func TestFocusRange_MultipleRanges(t *testing.T) {
+	b := New(config.MemoryConfig{}, nil)
+
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Focus", CaptureDelay: 1.0}, &core.World{WorldName: "Altis"}))
+
+	s := &core.Soldier{ID: 1}
+	require.NoError(t, b.AddSoldier(s))
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{SoldierID: 1, CaptureFrame: 500}))
+
+	// First range
+	require.NoError(t, b.SetFocusStart(core.Frame(10)))
+	require.NoError(t, b.SetFocusEnd(core.Frame(100)))
+
+	// Second range
+	require.NoError(t, b.SetFocusStart(core.Frame(200)))
+	require.NoError(t, b.SetFocusEnd(core.Frame(400)))
+
+	meta := b.GetExportMetadata()
+
+	require.Len(t, meta.FocusRanges, 2)
+	assert.Equal(t, core.Frame(10), meta.FocusRanges[0].Start)
+	assert.Equal(t, core.Frame(100), meta.FocusRanges[0].End)
+	assert.Equal(t, core.Frame(200), meta.FocusRanges[1].Start)
+	assert.Equal(t, core.Frame(400), meta.FocusRanges[1].End)
+}
+
+func TestFocusRange_DoubleStart(t *testing.T) {
+	b := New(config.MemoryConfig{}, nil)
+
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Focus", CaptureDelay: 1.0}, &core.World{WorldName: "Altis"}))
+
+	// First start opens a range
+	require.NoError(t, b.SetFocusStart(core.Frame(10)))
+
+	// Second start should be ignored (warning logged)
+	require.NoError(t, b.SetFocusStart(core.Frame(50)))
+
+	// The open range should still be at frame 10
+	assert.Equal(t, core.Frame(10), *b.focusOpenStart)
+	assert.Len(t, b.focusRanges, 0)
+}
+
+func TestFocusRange_DoubleEnd(t *testing.T) {
+	b := New(config.MemoryConfig{}, nil)
+
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Focus", CaptureDelay: 1.0}, &core.World{WorldName: "Altis"}))
+
+	// End without start should be ignored (warning logged)
+	require.NoError(t, b.SetFocusEnd(core.Frame(100)))
+
+	assert.Nil(t, b.focusOpenStart)
+	assert.Len(t, b.focusRanges, 0)
+}
+
+func TestFocusRange_AutoClose(t *testing.T) {
+	b := New(config.MemoryConfig{}, nil)
+
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Focus", CaptureDelay: 1.0}, &core.World{WorldName: "Altis"}))
+
+	s := &core.Soldier{ID: 1}
+	require.NoError(t, b.AddSoldier(s))
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{SoldierID: 1, CaptureFrame: 300}))
+
+	// Start a range but never close it
+	require.NoError(t, b.SetFocusStart(core.Frame(50)))
+
+	meta := b.GetExportMetadata()
+
+	// Should auto-close with endFrame (300)
+	require.Len(t, meta.FocusRanges, 1)
+	assert.Equal(t, core.Frame(50), meta.FocusRanges[0].Start)
+	assert.Equal(t, core.Frame(300), meta.FocusRanges[0].End)
+}
+
+func TestFocusRange_NoRanges(t *testing.T) {
+	b := New(config.MemoryConfig{}, nil)
+
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Focus", CaptureDelay: 1.0}, &core.World{WorldName: "Altis"}))
+
+	meta := b.GetExportMetadata()
+
+	assert.Nil(t, meta.FocusRanges)
+}
+
+func TestFocusRange_ResetOnNewMission(t *testing.T) {
+	b := New(config.MemoryConfig{}, nil)
+
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "First", CaptureDelay: 1.0}, &core.World{WorldName: "Altis"}))
+	require.NoError(t, b.SetFocusStart(core.Frame(10)))
+	require.NoError(t, b.SetFocusEnd(core.Frame(100)))
+
+	// Start new mission should reset focus ranges
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Second", CaptureDelay: 1.0}, &core.World{WorldName: "Altis"}))
+
+	assert.Nil(t, b.focusOpenStart)
+	assert.Len(t, b.focusRanges, 0)
 }

--- a/internal/storage/postgres/postgres.go
+++ b/internal/storage/postgres/postgres.go
@@ -380,6 +380,12 @@ func (b *Backend) AddPlacedObject(p *core.PlacedObject) error {
 	return nil
 }
 
+// SetFocusStart is a no-op — focus metadata is only used by memory backend export.
+func (b *Backend) SetFocusStart(frame core.Frame) error { return nil }
+
+// SetFocusEnd is a no-op — focus metadata is only used by memory backend export.
+func (b *Backend) SetFocusEnd(frame core.Frame) error { return nil }
+
 // RecordPlacedObjectEvent converts and queues a placed object event.
 func (b *Backend) RecordPlacedObjectEvent(e *core.PlacedObjectEvent) error {
 	gormObj := convert.CoreToPlacedObjectEvent(*e)

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -464,6 +464,24 @@ func TestDeleteVehicle_IsNoOp(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSetFocusStart_IsNoOp(t *testing.T) {
+	b := newTestBackend()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
+
+	err := b.SetFocusStart(100)
+	require.NoError(t, err)
+}
+
+func TestSetFocusEnd_IsNoOp(t *testing.T) {
+	b := newTestBackend()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
+
+	err := b.SetFocusEnd(500)
+	require.NoError(t, err)
+}
+
 func TestDeleteMarker_PushesAlphaZeroState(t *testing.T) {
 	b := newTestBackend()
 	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -42,6 +42,10 @@ type Backend interface {
 	// Placed objects
 	AddPlacedObject(p *core.PlacedObject) error
 	RecordPlacedObjectEvent(e *core.PlacedObjectEvent) error
+
+	// Mission focus
+	SetFocusStart(frame core.Frame) error
+	SetFocusEnd(frame core.Frame) error
 }
 
 // Uploadable is an optional interface for storage backends that produce

--- a/internal/storage/websocket/websocket.go
+++ b/internal/storage/websocket/websocket.go
@@ -189,6 +189,14 @@ func (b *Backend) RecordAce3UnconsciousEvent(e *core.Ace3UnconsciousEvent) error
 	return b.sendEnvelope(streaming.TypeAce3Unconscious, e)
 }
 
+func (b *Backend) SetFocusStart(frame core.Frame) error {
+	return b.sendEnvelope(streaming.TypeMissionFocusStart, map[string]any{"frame": frame})
+}
+
+func (b *Backend) SetFocusEnd(frame core.Frame) error {
+	return b.sendEnvelope(streaming.TypeMissionFocusEnd, map[string]any{"frame": frame})
+}
+
 func (b *Backend) AddPlacedObject(p *core.PlacedObject) error {
 	return b.sendEnvelope(streaming.TypeAddPlaced, p)
 }

--- a/internal/storage/websocket/websocket_test.go
+++ b/internal/storage/websocket/websocket_test.go
@@ -166,6 +166,8 @@ func TestAllMessageTypes(t *testing.T) {
 	require.NoError(t, b.RecordAce3UnconsciousEvent(&core.Ace3UnconsciousEvent{SoldierID: 1, IsUnconscious: true}))
 	require.NoError(t, b.AddPlacedObject(&core.PlacedObject{ID: 200, ClassName: "APERSMine"}))
 	require.NoError(t, b.RecordPlacedObjectEvent(&core.PlacedObjectEvent{PlacedID: 200, EventType: "detonated"}))
+	require.NoError(t, b.SetFocusStart(core.Frame(100)))
+	require.NoError(t, b.SetFocusEnd(core.Frame(200)))
 
 	require.NoError(t, b.EndMission())
 

--- a/internal/worker/dispatch.go
+++ b/internal/worker/dispatch.go
@@ -48,6 +48,10 @@ func (m *Manager) RegisterHandlers(d *dispatcher.Dispatcher) {
 	// Marker updates - buffered
 	d.Register(":MARKER:STATE:", m.handleMarkerMove, dispatcher.Buffered(1000), dispatcher.Logged())
 	d.Register(":MARKER:DELETE:", m.handleMarkerDelete, dispatcher.Buffered(500), dispatcher.Logged())
+
+	// Mission focus - sync (low volume, metadata)
+	d.Register(":MISSION:FOCUS_START:", m.handleFocusStart, dispatcher.Logged())
+	d.Register(":MISSION:FOCUS_END:", m.handleFocusEnd, dispatcher.Logged())
 }
 
 func (m *Manager) handleNewSoldier(e dispatcher.Event) (any, error) {
@@ -444,4 +448,20 @@ func (m *Manager) handleMarkerDelete(e dispatcher.Event) (any, error) {
 		return nil, fmt.Errorf("delete marker: %w", err)
 	}
 	return nil, nil
+}
+
+func (m *Manager) handleFocusStart(e dispatcher.Event) (any, error) {
+	frame, err := m.deps.ParserService.ParseFocusStart(e.Args)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse focus start: %w", err)
+	}
+	return nil, m.backend.SetFocusStart(frame)
+}
+
+func (m *Manager) handleFocusEnd(e dispatcher.Event) (any, error) {
+	frame, err := m.deps.ParserService.ParseFocusEnd(e.Args)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse focus end: %w", err)
+	}
+	return nil, m.backend.SetFocusEnd(frame)
 }

--- a/internal/worker/dispatch_test.go
+++ b/internal/worker/dispatch_test.go
@@ -75,6 +75,8 @@ type mockBackend struct {
 	placedEvents      []*core.PlacedObjectEvent
 	deletedSoldiers   []soldierDeleteCall
 	deletedVehicles   []vehicleDeleteCall
+	focusStarts       []core.Frame
+	focusEnds         []core.Frame
 	initCalled     bool
 	closeCalled    bool
 	missionStarted bool
@@ -264,6 +266,20 @@ func (b *mockBackend) RecordPlacedObjectEvent(e *core.PlacedObjectEvent) error {
 	return nil
 }
 
+func (b *mockBackend) SetFocusStart(frame core.Frame) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.focusStarts = append(b.focusStarts, frame)
+	return nil
+}
+
+func (b *mockBackend) SetFocusEnd(frame core.Frame) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.focusEnds = append(b.focusEnds, frame)
+	return nil
+}
+
 // errorBackend is a mockBackend that returns an error from AddMarker.
 
 // mockParserService provides a minimal implementation for testing
@@ -295,6 +311,8 @@ type mockParserService struct {
 	soldierDeleteFrame core.Frame
 	vehicleDeleteID    uint16
 	vehicleDeleteFrame core.Frame
+	focusStartFrame    core.Frame
+	focusEndFrame      core.Frame
 
 	// Error simulation
 	returnError bool
@@ -514,6 +532,26 @@ func (h *mockParserService) ParsePlacedObjectEvent(args []string) (core.PlacedOb
 	return h.placedEvent, nil
 }
 
+func (h *mockParserService) ParseFocusStart(args []string) (core.Frame, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.calls = append(h.calls, "ParseFocusStart")
+	if h.returnError {
+		return 0, errors.New(h.errorMsg)
+	}
+	return h.focusStartFrame, nil
+}
+
+func (h *mockParserService) ParseFocusEnd(args []string) (core.Frame, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.calls = append(h.calls, "ParseFocusEnd")
+	if h.returnError {
+		return 0, errors.New(h.errorMsg)
+	}
+	return h.focusEndFrame, nil
+}
+
 // waitFor polls until check returns true or times out after 2s.
 func waitFor(t *testing.T, check func() bool, msg string) {
 	t.Helper()
@@ -584,6 +622,8 @@ func TestRegisterHandlers_RegistersAllCommands(t *testing.T) {
 		":MARKER:CREATE:",
 		":MARKER:STATE:",
 		":MARKER:DELETE:",
+		":MISSION:FOCUS_START:",
+		":MISSION:FOCUS_END:",
 	}
 
 	for _, cmd := range expectedCommands {

--- a/internal/worker/dispatch_test.go
+++ b/internal/worker/dispatch_test.go
@@ -2390,6 +2390,20 @@ func (b *configurableErrorBackend) RecordPlacedObjectEvent(e *core.PlacedObjectE
 	return b.mockBackend.RecordPlacedObjectEvent(e)
 }
 
+func (b *configurableErrorBackend) SetFocusStart(frame core.Frame) error {
+	if e := b.fail("SetFocusStart"); e != nil {
+		return e
+	}
+	return b.mockBackend.SetFocusStart(frame)
+}
+
+func (b *configurableErrorBackend) SetFocusEnd(frame core.Frame) error {
+	if e := b.fail("SetFocusEnd"); e != nil {
+		return e
+	}
+	return b.mockBackend.SetFocusEnd(frame)
+}
+
 // --- Backend Record* error tests ---
 
 func TestHandleSoldierState_BackendError(t *testing.T) {
@@ -2823,4 +2837,120 @@ func TestHandleMarkerDelete_BackendError(t *testing.T) {
 	_, err := d.Dispatch(dispatcher.Event{Command: ":MARKER:DELETE:", Args: []string{}})
 	require.NoError(t, err)
 	waitForLogMsg(t, logger, "event failed")
+}
+
+// --- Focus handler tests ---
+
+func TestHandleFocusStart(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{
+		focusStartFrame: core.Frame(100),
+	}
+
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":MISSION:FOCUS_START:", Args: []string{"100"}})
+	require.NoError(t, err)
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	require.Len(t, backend.focusStarts, 1)
+	assert.Equal(t, core.Frame(100), backend.focusStarts[0])
+}
+
+func TestHandleFocusEnd(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{
+		focusEndFrame: core.Frame(500),
+	}
+
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":MISSION:FOCUS_END:", Args: []string{"500"}})
+	require.NoError(t, err)
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	require.Len(t, backend.focusEnds, 1)
+	assert.Equal(t, core.Frame(500), backend.focusEnds[0])
+}
+
+func TestHandleFocusStart_ParserError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{returnError: true, errorMsg: "bad focus start"}
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":MISSION:FOCUS_START:", Args: []string{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse focus start")
+	assert.Empty(t, backend.focusStarts)
+}
+
+func TestHandleFocusEnd_ParserError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{returnError: true, errorMsg: "bad focus end"}
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":MISSION:FOCUS_END:", Args: []string{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse focus end")
+	assert.Empty(t, backend.focusEnds)
+}
+
+func TestHandleFocusStart_BackendError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{
+		focusStartFrame: core.Frame(100),
+	}
+
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, &configurableErrorBackend{failOn: map[string]error{"SetFocusStart": errInjected}})
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":MISSION:FOCUS_START:", Args: []string{"100"}})
+	require.Error(t, err)
+}
+
+func TestHandleFocusEnd_BackendError(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{
+		focusEndFrame: core.Frame(500),
+	}
+
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, &configurableErrorBackend{failOn: map[string]error{"SetFocusEnd": errInjected}})
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":MISSION:FOCUS_END:", Args: []string{"500"}})
+	require.Error(t, err)
 }

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -51,6 +51,12 @@ type SideFriendly struct {
 	WestIndependent bool `json:"westIndependent"`
 }
 
+// FocusRange represents a focus range in the recording timeline.
+type FocusRange struct {
+	Start Frame
+	End   Frame
+}
+
 // UploadMetadata contains mission information needed for upload.
 type UploadMetadata struct {
 	WorldName       string
@@ -58,6 +64,5 @@ type UploadMetadata struct {
 	MissionDuration float64
 	Tag             string
 	EndFrame        Frame
-	FocusStart      *Frame
-	FocusEnd        *Frame
+	FocusRanges     []FocusRange
 }

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -57,4 +57,7 @@ type UploadMetadata struct {
 	MissionName     string
 	MissionDuration float64
 	Tag             string
+	EndFrame        Frame
+	FocusStart      *Frame
+	FocusEnd        *Frame
 }

--- a/pkg/streaming/messages.go
+++ b/pkg/streaming/messages.go
@@ -30,8 +30,10 @@ const (
 	TypeTimeState       = "time_state"
 	TypeAce3Death       = "ace3_death"
 	TypeAce3Unconscious = "ace3_unconscious"
-	TypeAddPlaced       = "add_placed"
-	TypePlacedEvent     = "placed_event"
+	TypeAddPlaced          = "add_placed"
+	TypePlacedEvent        = "placed_event"
+	TypeMissionFocusStart  = "mission_focus_start"
+	TypeMissionFocusEnd    = "mission_focus_end"
 )
 
 // AllMessageTypes lists every streaming message type.
@@ -43,6 +45,7 @@ var AllMessageTypes = []string{
 	TypeHitEvent, TypeKillEvent, TypeChatEvent, TypeRadioEvent,
 	TypeTelemetry, TypeTimeState, TypeAce3Death, TypeAce3Unconscious,
 	TypeAddPlaced, TypePlacedEvent,
+	TypeMissionFocusStart, TypeMissionFocusEnd,
 }
 
 // Envelope wraps all messages sent over the WebSocket.


### PR DESCRIPTION
## Summary

### Focus Range Commands
- Add `:MISSION:FOCUS_START:` and `:MISSION:FOCUS_END:` commands for marking key time ranges during recording
- Parser, storage (memory/postgres/websocket), and dispatch handler support
- V1 upload sends the first focus range to the web API
- Auto-close open ranges on mission save

### Typed Event Arg Parsing
- `ParseGeneralEvent` now switches on event type to parse typed positional args
- `captured`/`contested`/`capturedFlag`: parses `[frame, type, objectType, unitName, posX, posY, posZ]` and stores as JSON array in Message — eliminates comma-delimited string parsing that broke when names contained commas
- `endMission`: parses `[frame, type, side, message]` as typed args — fixes data loss where side/message were stored in ExtraData which the v1 export ignored
- All other event types (connected, generalEvent, respawnTickets, etc.) unchanged
- V1 export works with zero changes — already JSON-parses Message when it starts with `[`

## Test plan
- [x] Parser tests for all typed event formats (captured, contested, capturedFlag, endMission with/without side, commas in names)
- [x] V1 export test verifying JSON-array Message is correctly emitted as native array
- [x] Focus range parser, storage, dispatch, and auto-close tests
- [x] Full test suite passes (`go test ./...`)
- [x] Deploy with updated addon and verify sector capture events appear correctly in web playback