### PR TITLE
feat: dedicated :EVENT:SECTOR: and :EVENT:ENDMISSION: commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ All commands follow a `:RESOURCE:ACTION:` naming convention. New commands must u
 | Command | Buffer | Purpose |
 |---------|--------|---------|
 | `:EVENT:GENERAL:` | 1,000 | General gameplay event |
+| `:EVENT:SECTOR:` | 1,000 | Sector state change (captured/contested/capturedFlag) |
+| `:EVENT:ENDMISSION:` | 100 | End-of-mission event with side and message |
 | `:EVENT:CHAT:` | 1,000 | Chat message |
 | `:EVENT:RADIO:` | 1,000 | Radio transmission |
 | `:TELEMETRY:FRAME:` | 100 | Server telemetry (FPS, entity counts, weather, player network stats) |

--- a/internal/parser/parse_events.go
+++ b/internal/parser/parse_events.go
@@ -149,77 +149,107 @@ func (p *Parser) ParseProjectileEvent(data []string) (ProjectileEvent, error) {
 	return result, nil
 }
 
-// ParseGeneralEvent parses general event data and returns a core GeneralEvent
+// ParseGeneralEvent parses general event data and returns a core GeneralEvent.
+// Handles: connected, disconnected, generalEvent, respawnTickets, counterInit,
+// counterSet, terminalHackStarted, terminalHackCanceled.
+// Args: [frame, type, message, extraDataJSON?]
 func (p *Parser) ParseGeneralEvent(data []string) (core.GeneralEvent, error) {
 	var thisEvent core.GeneralEvent
 
-	// fix received data
 	for i, v := range data {
 		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
 	}
 
-	if len(data) < 2 {
-		return thisEvent, fmt.Errorf("insufficient data fields: got %d, need at least 2", len(data))
+	if len(data) < 3 {
+		return thisEvent, fmt.Errorf("insufficient data fields: got %d, need at least 3", len(data))
 	}
 
-	// get frame
 	capframe, err := strconv.ParseFloat(data[0], 64)
 	if err != nil {
-		return thisEvent, fmt.Errorf("error converting capture frame to int: %w", err)
+		return thisEvent, fmt.Errorf("error converting capture frame: %w", err)
 	}
 
 	thisEvent.Time = time.Now()
 	thisEvent.CaptureFrame = core.Frame(capframe)
 	thisEvent.Name = data[1]
+	thisEvent.Message = data[2]
 
-	switch data[1] {
-	case "captured", "contested", "capturedFlag":
-		// Typed args: [frame, type, objectType, unitName, posX?, posY?, posZ?]
-		if len(data) >= 4 {
-			objectType := data[2]
-			unitName := data[3]
-			if len(data) >= 7 {
-				posX, errX := strconv.ParseFloat(data[4], 64)
-				posY, errY := strconv.ParseFloat(data[5], 64)
-				posZ, errZ := strconv.ParseFloat(data[6], 64)
-				if errX != nil || errY != nil || errZ != nil {
-					return thisEvent, fmt.Errorf("invalid position data for event %q", data[1])
-				}
-				thisEvent.Message = fmt.Sprintf("[%s,%s,[%g,%g,%g]]",
-					strconv.Quote(objectType), strconv.Quote(unitName), posX, posY, posZ)
-			} else {
-				thisEvent.Message = fmt.Sprintf("[%s,%s]",
-					strconv.Quote(objectType), strconv.Quote(unitName))
-			}
-		} else if len(data) >= 3 {
-			// Legacy format: [frame, type, "name,objectType"]
-			thisEvent.Message = data[2]
-		}
-
-	case "endMission":
-		// Typed args: [frame, "endMission", side, message]
-		if len(data) >= 4 {
-			side := data[2]
-			message := data[3]
-			thisEvent.Message = fmt.Sprintf("[%s,%s]", strconv.Quote(side), strconv.Quote(message))
-		} else if len(data) >= 3 {
-			thisEvent.Message = data[2]
-		}
-
-	default:
-		// connected, disconnected, generalEvent, respawnTickets, counterInit,
-		// counterSet, terminalHack* — all use: [frame, type, message, extraData?]
-		if len(data) >= 3 {
-			thisEvent.Message = data[2]
-		}
-		if len(data) > 3 {
-			if err := json.Unmarshal([]byte(data[3]), &thisEvent.ExtraData); err != nil {
-				return thisEvent, fmt.Errorf("error unmarshalling extra data: %w", err)
-			}
+	if len(data) > 3 {
+		if err := json.Unmarshal([]byte(data[3]), &thisEvent.ExtraData); err != nil {
+			return thisEvent, fmt.Errorf("error unmarshalling extra data: %w", err)
 		}
 	}
 
 	return thisEvent, nil
+}
+
+// ParseSectorEvent parses sector state change events.
+// Handles: captured, contested, capturedFlag.
+// Args: [frame, type, objectType, unitName, posX?, posY?, posZ?]
+func (p *Parser) ParseSectorEvent(data []string) (core.SectorEvent, error) {
+	var event core.SectorEvent
+
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	if len(data) < 4 {
+		return event, fmt.Errorf("insufficient data for sector event: got %d, need at least 4", len(data))
+	}
+
+	capframe, err := strconv.ParseFloat(data[0], 64)
+	if err != nil {
+		return event, fmt.Errorf("error converting capture frame: %w", err)
+	}
+
+	event.Time = time.Now()
+	event.CaptureFrame = core.Frame(capframe)
+	event.Name = data[1]
+	event.ObjectType = data[2]
+	event.UnitName = data[3]
+
+	if len(data) >= 7 {
+		event.PosX, err = strconv.ParseFloat(data[4], 64)
+		if err != nil {
+			return event, fmt.Errorf("invalid position X for sector event: %w", err)
+		}
+		event.PosY, err = strconv.ParseFloat(data[5], 64)
+		if err != nil {
+			return event, fmt.Errorf("invalid position Y for sector event: %w", err)
+		}
+		event.PosZ, err = strconv.ParseFloat(data[6], 64)
+		if err != nil {
+			return event, fmt.Errorf("invalid position Z for sector event: %w", err)
+		}
+	}
+
+	return event, nil
+}
+
+// ParseEndMissionEvent parses end-of-mission events.
+// Args: [frame, side, message]
+func (p *Parser) ParseEndMissionEvent(data []string) (core.EndMissionEvent, error) {
+	var event core.EndMissionEvent
+
+	for i, v := range data {
+		data[i] = util.FixEscapeQuotes(util.TrimQuotes(v))
+	}
+
+	if len(data) < 3 {
+		return event, fmt.Errorf("insufficient data for end mission event: got %d, need at least 3", len(data))
+	}
+
+	capframe, err := strconv.ParseFloat(data[0], 64)
+	if err != nil {
+		return event, fmt.Errorf("error converting capture frame: %w", err)
+	}
+
+	event.Time = time.Now()
+	event.CaptureFrame = core.Frame(capframe)
+	event.Side = data[1]
+	event.Message = data[2]
+
+	return event, nil
 }
 
 

--- a/internal/parser/parse_events_test.go
+++ b/internal/parser/parse_events_test.go
@@ -481,15 +481,6 @@ func TestParseGeneralEvent(t *testing.T) {
 			},
 		},
 		{
-			name:  "endMission with empty side",
-			input: []string{"1043", "endMission", "", "Recording ended due to server being empty"},
-			check: func(t *testing.T, e core.GeneralEvent) {
-				assert.Equal(t, core.Frame(1043), e.CaptureFrame)
-				assert.Equal(t, "endMission", e.Name)
-				assert.Equal(t, `["","Recording ended due to server being empty"]`, e.Message)
-			},
-		},
-		{
 			name:  "no extraData (3 fields)",
 			input: []string{"0", "respawnTickets", "[-1,-1,-1,-1]"},
 			check: func(t *testing.T, e core.GeneralEvent) {
@@ -499,66 +490,11 @@ func TestParseGeneralEvent(t *testing.T) {
 			},
 		},
 		{
-			name:  "captured with typed args",
-			input: []string{"200", "captured", "sector", "Sector Alpha", "100.5", "200.3", "0"},
-			check: func(t *testing.T, e core.GeneralEvent) {
-				assert.Equal(t, core.Frame(200), e.CaptureFrame)
-				assert.Equal(t, "captured", e.Name)
-				assert.Equal(t, `["sector","Sector Alpha",[100.5,200.3,0]]`, e.Message)
-			},
-		},
-		{
-			name:  "contested with typed args and commas in name",
-			input: []string{"300", "contested", "sector", "Sector,With,Commas", "50", "60", "0"},
-			check: func(t *testing.T, e core.GeneralEvent) {
-				assert.Equal(t, "contested", e.Name)
-				assert.Equal(t, `["sector","Sector,With,Commas",[50,60,0]]`, e.Message)
-			},
-		},
-		{
-			name:  "capturedFlag with typed args",
-			input: []string{"150", "capturedFlag", "flag", "Player One", "300", "400", "5"},
-			check: func(t *testing.T, e core.GeneralEvent) {
-				assert.Equal(t, "capturedFlag", e.Name)
-				assert.Equal(t, `["flag","Player One",[300,400,5]]`, e.Message)
-			},
-		},
-		{
-			name:  "captured with typed args no position",
-			input: []string{"200", "captured", "sector", "Sector Alpha"},
-			check: func(t *testing.T, e core.GeneralEvent) {
-				assert.Equal(t, `["sector","Sector Alpha"]`, e.Message)
-			},
-		},
-		{
-			name:  "endMission with typed args",
-			input: []string{"1043", "endMission", "WEST", "BLUFOR wins"},
-			check: func(t *testing.T, e core.GeneralEvent) {
-				assert.Equal(t, "endMission", e.Name)
-				assert.Equal(t, `["WEST","BLUFOR wins"]`, e.Message)
-			},
-		},
-		{
-			name:  "endMission with comma in message",
-			input: []string{"500", "endMission", "EAST", "OPFOR wins, decisively"},
-			check: func(t *testing.T, e core.GeneralEvent) {
-				assert.Equal(t, `["EAST","OPFOR wins, decisively"]`, e.Message)
-			},
-		},
-		{
-			name:  "terminalHackStarted with typed args",
+			name:  "terminalHackStarted",
 			input: []string{"400", "terminalHackStarted", "Player One"},
 			check: func(t *testing.T, e core.GeneralEvent) {
 				assert.Equal(t, "terminalHackStarted", e.Name)
 				assert.Equal(t, "Player One", e.Message)
-			},
-		},
-		{
-			name:  "endMission with side only (3 fields)",
-			input: []string{"500", "endMission", "WEST"},
-			check: func(t *testing.T, e core.GeneralEvent) {
-				assert.Equal(t, "endMission", e.Name)
-				assert.Equal(t, "WEST", e.Message)
 			},
 		},
 		{
@@ -576,23 +512,164 @@ func TestParseGeneralEvent(t *testing.T) {
 			input:   []string{"0", "evt", "msg", "not_json"},
 			wantErr: true,
 		},
-		{
-			name:    "error: bad position data in captured event",
-			input:   []string{"200", "captured", "sector", "Alpha", "not_a_number", "200", "0"},
-			wantErr: true,
-		},
-		{
-			name:  "captured with legacy 3-field format",
-			input: []string{"200", "captured", "Alpha,sector"},
-			check: func(t *testing.T, e core.GeneralEvent) {
-				assert.Equal(t, "Alpha,sector", e.Message)
-			},
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := p.ParseGeneralEvent(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			tt.check(t, result)
+		})
+	}
+}
+
+func TestParseSectorEvent(t *testing.T) {
+	p := newTestParser()
+
+	tests := []struct {
+		name    string
+		input   []string
+		check   func(t *testing.T, e core.SectorEvent)
+		wantErr bool
+	}{
+		{
+			name:  "captured with position",
+			input: []string{"200", "captured", "sector", "Sector Alpha", "100.5", "200.3", "0"},
+			check: func(t *testing.T, e core.SectorEvent) {
+				assert.Equal(t, core.Frame(200), e.CaptureFrame)
+				assert.Equal(t, "captured", e.Name)
+				assert.Equal(t, "sector", e.ObjectType)
+				assert.Equal(t, "Sector Alpha", e.UnitName)
+				assert.InDelta(t, 100.5, e.PosX, 0.001)
+				assert.InDelta(t, 200.3, e.PosY, 0.001)
+				assert.InDelta(t, 0.0, e.PosZ, 0.001)
+			},
+		},
+		{
+			name:  "contested",
+			input: []string{"300", "contested", "sector", "Sector,With,Commas", "50", "60", "0"},
+			check: func(t *testing.T, e core.SectorEvent) {
+				assert.Equal(t, "contested", e.Name)
+				assert.Equal(t, "Sector,With,Commas", e.UnitName)
+			},
+		},
+		{
+			name:  "capturedFlag",
+			input: []string{"150", "capturedFlag", "flag", "Player One", "300", "400", "5"},
+			check: func(t *testing.T, e core.SectorEvent) {
+				assert.Equal(t, "capturedFlag", e.Name)
+				assert.Equal(t, "flag", e.ObjectType)
+				assert.Equal(t, "Player One", e.UnitName)
+				assert.InDelta(t, 300.0, e.PosX, 0.001)
+				assert.InDelta(t, 400.0, e.PosY, 0.001)
+				assert.InDelta(t, 5.0, e.PosZ, 0.001)
+			},
+		},
+		{
+			name:  "captured without position",
+			input: []string{"200", "captured", "sector", "Sector Alpha"},
+			check: func(t *testing.T, e core.SectorEvent) {
+				assert.Equal(t, "captured", e.Name)
+				assert.Equal(t, "Sector Alpha", e.UnitName)
+				assert.Equal(t, 0.0, e.PosX)
+				assert.Equal(t, 0.0, e.PosY)
+				assert.Equal(t, 0.0, e.PosZ)
+			},
+		},
+		{
+			name:    "error: insufficient data",
+			input:   []string{"200", "captured", "sector"},
+			wantErr: true,
+		},
+		{
+			name:    "error: bad frame",
+			input:   []string{"abc", "captured", "sector", "Alpha"},
+			wantErr: true,
+		},
+		{
+			name:    "error: bad position X",
+			input:   []string{"200", "captured", "sector", "Alpha", "not_a_number", "200", "0"},
+			wantErr: true,
+		},
+		{
+			name:    "error: bad position Y",
+			input:   []string{"200", "captured", "sector", "Alpha", "100", "not_a_number", "0"},
+			wantErr: true,
+		},
+		{
+			name:    "error: bad position Z",
+			input:   []string{"200", "captured", "sector", "Alpha", "100", "200", "not_a_number"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := p.ParseSectorEvent(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			tt.check(t, result)
+		})
+	}
+}
+
+func TestParseEndMissionEvent(t *testing.T) {
+	p := newTestParser()
+
+	tests := []struct {
+		name    string
+		input   []string
+		check   func(t *testing.T, e core.EndMissionEvent)
+		wantErr bool
+	}{
+		{
+			name:  "normal",
+			input: []string{"1043", "WEST", "BLUFOR wins"},
+			check: func(t *testing.T, e core.EndMissionEvent) {
+				assert.Equal(t, core.Frame(1043), e.CaptureFrame)
+				assert.Equal(t, "WEST", e.Side)
+				assert.Equal(t, "BLUFOR wins", e.Message)
+			},
+		},
+		{
+			name:  "empty side",
+			input: []string{"1043", "", "Recording ended due to server being empty"},
+			check: func(t *testing.T, e core.EndMissionEvent) {
+				assert.Equal(t, core.Frame(1043), e.CaptureFrame)
+				assert.Equal(t, "", e.Side)
+				assert.Equal(t, "Recording ended due to server being empty", e.Message)
+			},
+		},
+		{
+			name:  "comma in message",
+			input: []string{"500", "EAST", "OPFOR wins, decisively"},
+			check: func(t *testing.T, e core.EndMissionEvent) {
+				assert.Equal(t, "EAST", e.Side)
+				assert.Equal(t, "OPFOR wins, decisively", e.Message)
+			},
+		},
+		{
+			name:    "error: insufficient data",
+			input:   []string{"500", "WEST"},
+			wantErr: true,
+		},
+		{
+			name:    "error: bad frame",
+			input:   []string{"abc", "WEST", "message"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := p.ParseEndMissionEvent(tt.input)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -60,6 +60,8 @@ type Service interface {
 	ParseVehicleState(args []string) (core.VehicleState, error)
 	ParseProjectileEvent(args []string) (ProjectileEvent, error)
 	ParseGeneralEvent(args []string) (core.GeneralEvent, error)
+	ParseSectorEvent(args []string) (core.SectorEvent, error)
+	ParseEndMissionEvent(args []string) (core.EndMissionEvent, error)
 	ParseKillEvent(args []string) (KillEvent, error)
 	ParseChatEvent(args []string) (core.ChatEvent, error)
 	ParseRadioEvent(args []string) (core.RadioEvent, error)

--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 
-	"github.com/OCAP2/extension/v5/pkg/core"
 	"github.com/OCAP2/extension/v5/internal/util"
+	"github.com/OCAP2/extension/v5/pkg/core"
 )
 
 // MissionData contains all the data needed to build an export
@@ -608,6 +609,11 @@ func Build(data *MissionData) Export {
 			}
 		}
 	}
+
+	// Sort events by frame number so consumers can rely on chronological order
+	sort.SliceStable(export.Events, func(i, j int) bool {
+		return export.Events[i][0].(int) < export.Events[j][0].(int)
+	})
 
 	return export
 }

--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -20,6 +20,8 @@ type MissionData struct {
 	PlacedObjects map[uint16]*PlacedObjectRecord
 
 	GeneralEvents    []core.GeneralEvent
+	SectorEvents     []core.SectorEvent
+	EndMissionEvents []core.EndMissionEvent
 	HitEvents        []core.HitEvent
 	KillEvents       []core.KillEvent
 	TimeStates       []core.TimeState
@@ -273,6 +275,27 @@ func Build(data *MissionData) Export {
 			frameToV1(evt.CaptureFrame),
 			evt.Name,
 			message,
+		})
+	}
+
+	// Convert sector events
+	// Format: [frameNum, "captured"|"contested"|"capturedFlag", [objectType, unitName, [x, y, z]]]
+	for _, evt := range data.SectorEvents {
+		export.Events = append(export.Events, []any{
+			frameToV1(evt.CaptureFrame),
+			evt.Name,
+			[]any{evt.ObjectType, evt.UnitName, []float64{evt.PosX, evt.PosY, evt.PosZ}},
+		})
+	}
+
+	// Convert end mission events
+	// Format: [frameNum, "endMission", side, message]
+	for _, evt := range data.EndMissionEvents {
+		export.Events = append(export.Events, []any{
+			frameToV1(evt.CaptureFrame),
+			"endMission",
+			evt.Side,
+			evt.Message,
 		})
 	}
 

--- a/internal/storage/memory/export/v1/builder_test.go
+++ b/internal/storage/memory/export/v1/builder_test.go
@@ -540,6 +540,40 @@ func TestBuildWithEndMissionEvents(t *testing.T) {
 	assert.Equal(t, "BLUFOR controlled all sectors!", evt[3])
 }
 
+func TestBuildEventsSortedByFrame(t *testing.T) {
+	soldierVictim := uint(5)
+	data := &MissionData{
+		Mission:  &core.Mission{MissionName: "Test"},
+		World:    &core.World{WorldName: "Altis"},
+		Soldiers: make(map[uint16]*SoldierRecord),
+		Vehicles: make(map[uint16]*VehicleRecord),
+		Markers:  make(map[string]*MarkerRecord),
+		GeneralEvents: []core.GeneralEvent{
+			{CaptureFrame: 50, Name: "connected", Message: "Player1"},
+		},
+		SectorEvents: []core.SectorEvent{
+			{CaptureFrame: 10, Name: "captured", ObjectType: "sector", UnitName: "Alpha"},
+		},
+		EndMissionEvents: []core.EndMissionEvent{
+			{CaptureFrame: 100, Side: "WEST", Message: "Win"},
+		},
+		KillEvents: []core.KillEvent{
+			{CaptureFrame: 30, VictimSoldierID: &soldierVictim, EventText: "rifle"},
+		},
+	}
+
+	export := Build(data)
+
+	require.Len(t, export.Events, 4)
+
+	// Events must be sorted by frame number regardless of type
+	frames := make([]int, len(export.Events))
+	for i, evt := range export.Events {
+		frames[i] = evt[0].(int)
+	}
+	assert.Equal(t, []int{9, 29, 49, 99}, frames)
+}
+
 func TestBuildWithHitEvents(t *testing.T) {
 	soldierVictim := uint(5)
 	soldierShooter := uint(10)

--- a/internal/storage/memory/export/v1/builder_test.go
+++ b/internal/storage/memory/export/v1/builder_test.go
@@ -482,6 +482,64 @@ func TestBuildWithCapturedEventJSONArray(t *testing.T) {
 	assert.Equal(t, float64(0), nested[2])
 }
 
+func TestBuildWithSectorEvents(t *testing.T) {
+	data := &MissionData{
+		Mission:  &core.Mission{MissionName: "Test"},
+		World:    &core.World{WorldName: "Altis"},
+		Soldiers: make(map[uint16]*SoldierRecord),
+		Vehicles: make(map[uint16]*VehicleRecord),
+		Markers:  make(map[string]*MarkerRecord),
+		SectorEvents: []core.SectorEvent{
+			{CaptureFrame: 15, Name: "captured", ObjectType: "sector", UnitName: "Sector Alpha", PosX: 100.5, PosY: 200.3, PosZ: 0},
+			{CaptureFrame: 30, Name: "contested", ObjectType: "flag", UnitName: "Flag Bravo", PosX: 300, PosY: 400, PosZ: 10},
+		},
+	}
+
+	export := Build(data)
+
+	require.Len(t, export.Events, 2)
+
+	// First sector event (internal 15 → v1 14)
+	evt0 := export.Events[0]
+	assert.Equal(t, 14, evt0[0])
+	assert.Equal(t, "captured", evt0[1])
+	payload0 := evt0[2].([]any)
+	assert.Equal(t, "sector", payload0[0])
+	assert.Equal(t, "Sector Alpha", payload0[1])
+	pos0 := payload0[2].([]float64)
+	assert.Equal(t, 100.5, pos0[0])
+	assert.Equal(t, 200.3, pos0[1])
+	assert.Equal(t, 0.0, pos0[2])
+
+	// Second sector event (internal 30 → v1 29)
+	evt1 := export.Events[1]
+	assert.Equal(t, 29, evt1[0])
+	assert.Equal(t, "contested", evt1[1])
+}
+
+func TestBuildWithEndMissionEvents(t *testing.T) {
+	data := &MissionData{
+		Mission:  &core.Mission{MissionName: "Test"},
+		World:    &core.World{WorldName: "Altis"},
+		Soldiers: make(map[uint16]*SoldierRecord),
+		Vehicles: make(map[uint16]*VehicleRecord),
+		Markers:  make(map[string]*MarkerRecord),
+		EndMissionEvents: []core.EndMissionEvent{
+			{CaptureFrame: 500, Side: "WEST", Message: "BLUFOR controlled all sectors!"},
+		},
+	}
+
+	export := Build(data)
+
+	require.Len(t, export.Events, 1)
+
+	evt := export.Events[0]
+	assert.Equal(t, 499, evt[0])            // internal 500 → v1 499
+	assert.Equal(t, "endMission", evt[1])
+	assert.Equal(t, "WEST", evt[2])
+	assert.Equal(t, "BLUFOR controlled all sectors!", evt[3])
+}
+
 func TestBuildWithHitEvents(t *testing.T) {
 	soldierVictim := uint(5)
 	soldierShooter := uint(10)

--- a/internal/storage/memory/export_test.go
+++ b/internal/storage/memory/export_test.go
@@ -76,6 +76,12 @@ func TestIntegrationFullExport(t *testing.T) {
 	require.NoError(t, b.RecordGeneralEvent(&core.GeneralEvent{
 		CaptureFrame: 15, Name: "connected", Message: "Player1 connected", ExtraData: map[string]any{"uid": "12345"},
 	}))
+	require.NoError(t, b.RecordSectorEvent(&core.SectorEvent{
+		CaptureFrame: 8, Name: "captured", ObjectType: "sector", UnitName: "Sector Alpha", PosX: 100.5, PosY: 200.3, PosZ: 0,
+	}))
+	require.NoError(t, b.RecordEndMissionEvent(&core.EndMissionEvent{
+		CaptureFrame: 25, Side: "WEST", Message: "BLUFOR wins",
+	}))
 	require.NoError(t, b.RecordTimeState(&core.TimeState{
 		CaptureFrame: 1, SystemTimeUTC: "2024-01-15T10:30:00.000", MissionDate: "2035-06-24T06:00:00", TimeMultiplier: 1.0, MissionTime: 0,
 	}))
@@ -151,11 +157,27 @@ func TestIntegrationFullExport(t *testing.T) {
 	assert.Equal(t, "car", vehicleEntity.Class)
 	require.Len(t, vehicleEntity.Positions, 1)
 
-	// Verify events (array format: [frameNum, type, message])
-	require.Len(t, export.Events, 1)
-	assert.Equal(t, "connected", export.Events[0][1])         // type
-	assert.EqualValues(t, 14, export.Events[0][0])            // frameNum (input 15 → v1 output 14)
-	assert.Equal(t, "Player1 connected", export.Events[0][2]) // message
+	// Verify events — sorted by frame number
+	require.Len(t, export.Events, 3)
+
+	// Sector event at frame 8 (v1: 7)
+	assert.EqualValues(t, 7, export.Events[0][0])
+	assert.Equal(t, "captured", export.Events[0][1])
+	sectorPayload, ok := export.Events[0][2].([]any)
+	require.True(t, ok, "sector event payload should be []any")
+	assert.Equal(t, "sector", sectorPayload[0])
+	assert.Equal(t, "Sector Alpha", sectorPayload[1])
+
+	// General event at frame 15 (v1: 14)
+	assert.EqualValues(t, 14, export.Events[1][0])
+	assert.Equal(t, "connected", export.Events[1][1])
+	assert.Equal(t, "Player1 connected", export.Events[1][2])
+
+	// EndMission event at frame 25 (v1: 24)
+	assert.EqualValues(t, 24, export.Events[2][0])
+	assert.Equal(t, "endMission", export.Events[2][1])
+	assert.Equal(t, "WEST", export.Events[2][2])
+	assert.Equal(t, "BLUFOR wins", export.Events[2][3])
 
 	// Verify markers (array format: [type, text, startFrame, endFrame, playerId, color, sideIndex, positions, size, shape, brush])
 	require.Len(t, export.Markers, 1)

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -53,6 +53,8 @@ type Backend struct {
 	placed        map[uint16]*PlacedObjectRecord  // keyed by ObjectID
 
 	generalEvents         []core.GeneralEvent
+	sectorEvents          []core.SectorEvent
+	endMissionEvents      []core.EndMissionEvent
 	hitEvents             []core.HitEvent
 	killEvents            []core.KillEvent
 	chatEvents            []core.ChatEvent
@@ -144,6 +146,8 @@ func (b *Backend) resetCollections() {
 	b.nextMarkerID = 0
 	b.placed = make(map[uint16]*PlacedObjectRecord)
 	b.generalEvents = nil
+	b.sectorEvents = nil
+	b.endMissionEvents = nil
 	b.hitEvents = nil
 	b.killEvents = nil
 	b.chatEvents = nil
@@ -303,6 +307,22 @@ func (b *Backend) RecordGeneralEvent(e *core.GeneralEvent) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.generalEvents = append(b.generalEvents, *e)
+	return nil
+}
+
+// RecordSectorEvent records a sector state change event.
+func (b *Backend) RecordSectorEvent(e *core.SectorEvent) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.sectorEvents = append(b.sectorEvents, *e)
+	return nil
+}
+
+// RecordEndMissionEvent records an end-of-mission event.
+func (b *Backend) RecordEndMissionEvent(e *core.EndMissionEvent) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.endMissionEvents = append(b.endMissionEvents, *e)
 	return nil
 }
 
@@ -531,6 +551,8 @@ func (b *Backend) buildExportUnlocked() v1.Export {
 		Markers:          make(map[string]*v1.MarkerRecord),
 		PlacedObjects:    make(map[uint16]*v1.PlacedObjectRecord),
 		GeneralEvents:    b.generalEvents,
+		SectorEvents:     b.sectorEvents,
+		EndMissionEvents: b.endMissionEvents,
 		HitEvents:        b.hitEvents,
 		KillEvents:       b.killEvents,
 		TimeStates:       b.timeStates,

--- a/internal/storage/memory/memory_test.go
+++ b/internal/storage/memory/memory_test.go
@@ -322,6 +322,41 @@ func TestRecordGeneralEvent(t *testing.T) {
 	assert.Equal(t, "connected", b.generalEvents[0].Name)
 }
 
+func TestRecordSectorEvent(t *testing.T) {
+	b := New(config.MemoryConfig{}, nil)
+
+	evt := &core.SectorEvent{
+		CaptureFrame: 200,
+		Name:         "captured",
+		ObjectType:   "sector",
+		UnitName:     "Sector Alpha",
+		PosX:         100.5,
+		PosY:         200.3,
+	}
+
+	require.NoError(t, b.RecordSectorEvent(evt))
+
+	assert.Len(t, b.sectorEvents, 1)
+	assert.Equal(t, "captured", b.sectorEvents[0].Name)
+	assert.Equal(t, "Sector Alpha", b.sectorEvents[0].UnitName)
+}
+
+func TestRecordEndMissionEvent(t *testing.T) {
+	b := New(config.MemoryConfig{}, nil)
+
+	evt := &core.EndMissionEvent{
+		CaptureFrame: 1043,
+		Side:         "WEST",
+		Message:      "BLUFOR wins",
+	}
+
+	require.NoError(t, b.RecordEndMissionEvent(evt))
+
+	assert.Len(t, b.endMissionEvents, 1)
+	assert.Equal(t, "WEST", b.endMissionEvents[0].Side)
+	assert.Equal(t, "BLUFOR wins", b.endMissionEvents[0].Message)
+}
+
 func TestRecordHitEvent(t *testing.T) {
 	b := New(config.MemoryConfig{}, nil)
 
@@ -605,6 +640,8 @@ func TestStartMissionResetsEverything(t *testing.T) {
 	_, err := b.AddMarker(&core.Marker{MarkerName: "m1"})
 	require.NoError(t, err)
 	require.NoError(t, b.RecordGeneralEvent(&core.GeneralEvent{Name: "test"}))
+	require.NoError(t, b.RecordSectorEvent(&core.SectorEvent{Name: "captured"}))
+	require.NoError(t, b.RecordEndMissionEvent(&core.EndMissionEvent{Side: "WEST"}))
 	require.NoError(t, b.RecordHitEvent(&core.HitEvent{}))
 	require.NoError(t, b.RecordKillEvent(&core.KillEvent{}))
 	require.NoError(t, b.RecordChatEvent(&core.ChatEvent{}))
@@ -626,6 +663,8 @@ func TestStartMissionResetsEverything(t *testing.T) {
 	assert.Len(t, b.vehicles, 0)
 	assert.Len(t, b.markers, 0)
 	assert.Len(t, b.generalEvents, 0)
+	assert.Len(t, b.sectorEvents, 0)
+	assert.Len(t, b.endMissionEvents, 0)
 	assert.Len(t, b.hitEvents, 0)
 	assert.Len(t, b.killEvents, 0)
 	assert.Len(t, b.chatEvents, 0)

--- a/internal/storage/postgres/postgres.go
+++ b/internal/storage/postgres/postgres.go
@@ -316,6 +316,33 @@ func (b *Backend) RecordGeneralEvent(e *core.GeneralEvent) error {
 	return nil
 }
 
+// RecordSectorEvent stores sector events as general events in postgres.
+// The structured data is flattened to the general event format for DB compatibility.
+func (b *Backend) RecordSectorEvent(e *core.SectorEvent) error {
+	gormObj := convert.CoreToGeneralEvent(core.GeneralEvent{
+		ID:           e.ID,
+		Time:         e.Time,
+		CaptureFrame: e.CaptureFrame,
+		Name:         e.Name,
+		Message:      fmt.Sprintf("%s %s", e.ObjectType, e.UnitName),
+	})
+	b.queues.GeneralEvents.Push(gormObj)
+	return nil
+}
+
+// RecordEndMissionEvent stores end mission events as general events in postgres.
+func (b *Backend) RecordEndMissionEvent(e *core.EndMissionEvent) error {
+	gormObj := convert.CoreToGeneralEvent(core.GeneralEvent{
+		ID:           e.ID,
+		Time:         e.Time,
+		CaptureFrame: e.CaptureFrame,
+		Name:         "endMission",
+		Message:      fmt.Sprintf("%s %s", e.Side, e.Message),
+	})
+	b.queues.GeneralEvents.Push(gormObj)
+	return nil
+}
+
 // RecordHitEvent is a no-op — replaced by ProjectileEvent.
 func (b *Backend) RecordHitEvent(e *core.HitEvent) error {
 	return nil

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -187,6 +187,41 @@ func TestRecordGeneralEvent_QueuesToInternalQueue(t *testing.T) {
 	assert.Equal(t, 1, b.queues.GeneralEvents.Len())
 }
 
+func TestRecordSectorEvent_QueuesToGeneralEvents(t *testing.T) {
+	b := newTestBackend()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
+
+	event := &core.SectorEvent{
+		CaptureFrame: 100,
+		Name:         "captured",
+		ObjectType:   "sector",
+		UnitName:     "Sector Alpha",
+		PosX:         100.5,
+		PosY:         200.3,
+	}
+
+	err := b.RecordSectorEvent(event)
+	require.NoError(t, err)
+	assert.Equal(t, 1, b.queues.GeneralEvents.Len())
+}
+
+func TestRecordEndMissionEvent_QueuesToGeneralEvents(t *testing.T) {
+	b := newTestBackend()
+	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing
+	defer func() { require.NoError(t, b.Close()) }()
+
+	event := &core.EndMissionEvent{
+		CaptureFrame: 500,
+		Side:         "WEST",
+		Message:      "BLUFOR wins",
+	}
+
+	err := b.RecordEndMissionEvent(event)
+	require.NoError(t, err)
+	assert.Equal(t, 1, b.queues.GeneralEvents.Len())
+}
+
 func TestRecordKillEvent_QueuesToInternalQueue(t *testing.T) {
 	b := newTestBackend()
 	b.Init() //nolint:errcheck // Init fails (no postgres) but queues are created for testing

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -30,6 +30,8 @@ type Backend interface {
 	RecordFiredEvent(e *core.FiredEvent) error
 	RecordProjectileEvent(e *core.ProjectileEvent) error
 	RecordGeneralEvent(e *core.GeneralEvent) error
+	RecordSectorEvent(e *core.SectorEvent) error
+	RecordEndMissionEvent(e *core.EndMissionEvent) error
 	RecordHitEvent(e *core.HitEvent) error
 	RecordKillEvent(e *core.KillEvent) error
 	RecordChatEvent(e *core.ChatEvent) error

--- a/internal/storage/websocket/websocket.go
+++ b/internal/storage/websocket/websocket.go
@@ -157,6 +157,14 @@ func (b *Backend) RecordGeneralEvent(e *core.GeneralEvent) error {
 	return b.sendEnvelope(streaming.TypeGeneralEvent, e)
 }
 
+func (b *Backend) RecordSectorEvent(e *core.SectorEvent) error {
+	return b.sendEnvelope(streaming.TypeSectorEvent, e)
+}
+
+func (b *Backend) RecordEndMissionEvent(e *core.EndMissionEvent) error {
+	return b.sendEnvelope(streaming.TypeEndMissionEvent, e)
+}
+
 func (b *Backend) RecordHitEvent(e *core.HitEvent) error {
 	return b.sendEnvelope(streaming.TypeHitEvent, e)
 }

--- a/internal/storage/websocket/websocket_test.go
+++ b/internal/storage/websocket/websocket_test.go
@@ -156,6 +156,8 @@ func TestAllMessageTypes(t *testing.T) {
 	require.NoError(t, b.RecordFiredEvent(&core.FiredEvent{SoldierID: 1, Weapon: "arifle_MX_F"}))
 	require.NoError(t, b.RecordProjectileEvent(&core.ProjectileEvent{FirerObjectID: 1}))
 	require.NoError(t, b.RecordGeneralEvent(&core.GeneralEvent{Name: "test"}))
+	require.NoError(t, b.RecordSectorEvent(&core.SectorEvent{Name: "captured", ObjectType: "sector", UnitName: "Alpha"}))
+	require.NoError(t, b.RecordEndMissionEvent(&core.EndMissionEvent{Side: "WEST", Message: "BLUFOR wins"}))
 	require.NoError(t, b.RecordHitEvent(&core.HitEvent{EventText: "hit"}))
 	require.NoError(t, b.RecordKillEvent(&core.KillEvent{EventText: "killed"}))
 	require.NoError(t, b.RecordChatEvent(&core.ChatEvent{Message: "hello"}))

--- a/internal/worker/dispatch.go
+++ b/internal/worker/dispatch.go
@@ -27,6 +27,8 @@ func (m *Manager) RegisterHandlers(d *dispatcher.Dispatcher) {
 
 	// General events - buffered
 	d.Register(":EVENT:GENERAL:", m.handleGeneralEvent, dispatcher.Buffered(1000), dispatcher.Logged())
+	d.Register(":EVENT:SECTOR:", m.handleSectorEvent, dispatcher.Buffered(1000), dispatcher.Logged())
+	d.Register(":EVENT:ENDMISSION:", m.handleEndMissionEvent, dispatcher.Buffered(100), dispatcher.Logged())
 	d.Register(":EVENT:CHAT:", m.handleChatEvent, dispatcher.Buffered(1000), dispatcher.Logged())
 	d.Register(":EVENT:RADIO:", m.handleRadioEvent, dispatcher.Buffered(1000), dispatcher.Logged())
 	d.Register(":TELEMETRY:FRAME:", m.handleTelemetryEvent, dispatcher.Buffered(100), dispatcher.Logged())
@@ -250,6 +252,30 @@ func (m *Manager) handleGeneralEvent(e dispatcher.Event) (any, error) {
 
 	if err := m.backend.RecordGeneralEvent(&obj); err != nil {
 		return nil, fmt.Errorf("record general event: %w", err)
+	}
+	return nil, nil
+}
+
+func (m *Manager) handleSectorEvent(e dispatcher.Event) (any, error) {
+	obj, err := m.deps.ParserService.ParseSectorEvent(e.Args)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse sector event: %w", err)
+	}
+
+	if err := m.backend.RecordSectorEvent(&obj); err != nil {
+		return nil, fmt.Errorf("record sector event: %w", err)
+	}
+	return nil, nil
+}
+
+func (m *Manager) handleEndMissionEvent(e dispatcher.Event) (any, error) {
+	obj, err := m.deps.ParserService.ParseEndMissionEvent(e.Args)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse end mission event: %w", err)
+	}
+
+	if err := m.backend.RecordEndMissionEvent(&obj); err != nil {
+		return nil, fmt.Errorf("record end mission event: %w", err)
 	}
 	return nil, nil
 }

--- a/internal/worker/dispatch_test.go
+++ b/internal/worker/dispatch_test.go
@@ -1045,6 +1045,77 @@ func TestHandleProjectile_RecordsProjectileEvent(t *testing.T) {
 	assert.Empty(t, backend.hitEvents, "dispatch should not create hit events")
 }
 
+func TestHandleSectorEvent_RecordsEvent(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{
+		sectorEvent: core.SectorEvent{
+			CaptureFrame: 200,
+			Name:         "captured",
+			ObjectType:   "sector",
+			UnitName:     "Sector Alpha",
+			PosX:         100.5,
+			PosY:         200.3,
+		},
+	}
+
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:SECTOR:", Args: []string{}})
+	require.NoError(t, err)
+
+	waitFor(t, func() bool {
+		backend.mu.Lock()
+		defer backend.mu.Unlock()
+		return len(backend.sectorEvents) > 0
+	}, "timed out waiting for sector event")
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	require.Equal(t, 1, len(backend.sectorEvents))
+	assert.Equal(t, "captured", backend.sectorEvents[0].Name)
+	assert.Equal(t, "Sector Alpha", backend.sectorEvents[0].UnitName)
+}
+
+func TestHandleEndMissionEvent_RecordsEvent(t *testing.T) {
+	d, _ := newTestDispatcher(t)
+
+	parserService := &mockParserService{
+		endMissionEvent: core.EndMissionEvent{
+			CaptureFrame: 1043,
+			Side:         "WEST",
+			Message:      "BLUFOR wins",
+		},
+	}
+
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:ENDMISSION:", Args: []string{}})
+	require.NoError(t, err)
+
+	waitFor(t, func() bool {
+		backend.mu.Lock()
+		defer backend.mu.Unlock()
+		return len(backend.endMissionEvents) > 0
+	}, "timed out waiting for end mission event")
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	require.Equal(t, 1, len(backend.endMissionEvents))
+	assert.Equal(t, "WEST", backend.endMissionEvents[0].Side)
+	assert.Equal(t, "BLUFOR wins", backend.endMissionEvents[0].Message)
+}
+
 func TestHandleMarkerMove_ResolvesMarkerName(t *testing.T) {
 	d, _ := newTestDispatcher(t)
 	markerCache := cache.NewMarkerCache()
@@ -1923,6 +1994,46 @@ func TestHandleGeneralEvent_ParserError(t *testing.T) {
 	assert.Empty(t, backend.generalEvents)
 }
 
+func TestHandleSectorEvent_ParserError(t *testing.T) {
+	d, logger := newTestDispatcher(t)
+
+	parserService := &mockParserService{returnError: true, errorMsg: "bad sector"}
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:SECTOR:", Args: []string{}})
+	require.NoError(t, err)
+
+	waitForLogMsg(t, logger, "event failed")
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.sectorEvents)
+}
+
+func TestHandleEndMissionEvent_ParserError(t *testing.T) {
+	d, logger := newTestDispatcher(t)
+
+	parserService := &mockParserService{returnError: true, errorMsg: "bad endmission"}
+	backend := &mockBackend{}
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, backend)
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:ENDMISSION:", Args: []string{}})
+	require.NoError(t, err)
+
+	waitForLogMsg(t, logger, "event failed")
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	assert.Empty(t, backend.endMissionEvents)
+}
+
 func TestHandleKillEvent_ParserError(t *testing.T) {
 	d, logger := newTestDispatcher(t)
 
@@ -2360,6 +2471,20 @@ func (b *configurableErrorBackend) RecordGeneralEvent(e *core.GeneralEvent) erro
 	return b.mockBackend.RecordGeneralEvent(e)
 }
 
+func (b *configurableErrorBackend) RecordSectorEvent(e *core.SectorEvent) error {
+	if err := b.fail("RecordSectorEvent"); err != nil {
+		return err
+	}
+	return b.mockBackend.RecordSectorEvent(e)
+}
+
+func (b *configurableErrorBackend) RecordEndMissionEvent(e *core.EndMissionEvent) error {
+	if err := b.fail("RecordEndMissionEvent"); err != nil {
+		return err
+	}
+	return b.mockBackend.RecordEndMissionEvent(e)
+}
+
 func (b *configurableErrorBackend) RecordKillEvent(e *core.KillEvent) error {
 	if err := b.fail("RecordKillEvent"); err != nil {
 		return err
@@ -2536,6 +2661,42 @@ func TestHandleGeneralEvent_BackendError(t *testing.T) {
 	manager.RegisterHandlers(d)
 
 	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:GENERAL:", Args: []string{}})
+	require.NoError(t, err)
+	waitForLogMsg(t, logger, "event failed")
+}
+
+func TestHandleSectorEvent_BackendError(t *testing.T) {
+	d, logger := newTestDispatcher(t)
+
+	parserService := &mockParserService{
+		sectorEvent: core.SectorEvent{CaptureFrame: 100, Name: "captured"},
+	}
+
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, &configurableErrorBackend{failOn: map[string]error{"RecordSectorEvent": errInjected}})
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:SECTOR:", Args: []string{}})
+	require.NoError(t, err)
+	waitForLogMsg(t, logger, "event failed")
+}
+
+func TestHandleEndMissionEvent_BackendError(t *testing.T) {
+	d, logger := newTestDispatcher(t)
+
+	parserService := &mockParserService{
+		endMissionEvent: core.EndMissionEvent{CaptureFrame: 100, Side: "WEST"},
+	}
+
+	manager := NewManager(Dependencies{
+		ParserService: parserService,
+		EntityCache:   cache.NewEntityCache(),
+	}, &configurableErrorBackend{failOn: map[string]error{"RecordEndMissionEvent": errInjected}})
+	manager.RegisterHandlers(d)
+
+	_, err := d.Dispatch(dispatcher.Event{Command: ":EVENT:ENDMISSION:", Args: []string{}})
 	require.NoError(t, err)
 	waitForLogMsg(t, logger, "event failed")
 }

--- a/internal/worker/dispatch_test.go
+++ b/internal/worker/dispatch_test.go
@@ -60,8 +60,10 @@ type mockBackend struct {
 	vehicleStates  []*core.VehicleState
 	markerStates   []*core.MarkerState
 	firedEvents    []*core.FiredEvent
-	generalEvents  []*core.GeneralEvent
-	hitEvents      []*core.HitEvent
+	generalEvents    []*core.GeneralEvent
+	sectorEvents     []*core.SectorEvent
+	endMissionEvents []*core.EndMissionEvent
+	hitEvents        []*core.HitEvent
 	killEvents     []*core.KillEvent
 	chatEvents        []*core.ChatEvent
 	radioEvents       []*core.RadioEvent
@@ -189,6 +191,20 @@ func (b *mockBackend) RecordGeneralEvent(e *core.GeneralEvent) error {
 	return nil
 }
 
+func (b *mockBackend) RecordSectorEvent(e *core.SectorEvent) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.sectorEvents = append(b.sectorEvents, e)
+	return nil
+}
+
+func (b *mockBackend) RecordEndMissionEvent(e *core.EndMissionEvent) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.endMissionEvents = append(b.endMissionEvents, e)
+	return nil
+}
+
 func (b *mockBackend) RecordHitEvent(e *core.HitEvent) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -294,8 +310,10 @@ type mockParserService struct {
 	soldierState  core.SoldierState
 	vehicleState  core.VehicleState
 	projectile    parser.ProjectileEvent
-	generalEvent  core.GeneralEvent
-	killEvent     parser.KillEvent
+	generalEvent     core.GeneralEvent
+	sectorEvent      core.SectorEvent
+	endMissionEvent  core.EndMissionEvent
+	killEvent        parser.KillEvent
 	chatEvent     core.ChatEvent
 	radioEvent    core.RadioEvent
 	telemetryEvent core.TelemetryEvent
@@ -390,6 +408,26 @@ func (h *mockParserService) ParseGeneralEvent(args []string) (core.GeneralEvent,
 		return core.GeneralEvent{}, errors.New(h.errorMsg)
 	}
 	return h.generalEvent, nil
+}
+
+func (h *mockParserService) ParseSectorEvent(args []string) (core.SectorEvent, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.calls = append(h.calls, "ParseSectorEvent")
+	if h.returnError {
+		return core.SectorEvent{}, errors.New(h.errorMsg)
+	}
+	return h.sectorEvent, nil
+}
+
+func (h *mockParserService) ParseEndMissionEvent(args []string) (core.EndMissionEvent, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.calls = append(h.calls, "ParseEndMissionEvent")
+	if h.returnError {
+		return core.EndMissionEvent{}, errors.New(h.errorMsg)
+	}
+	return h.endMissionEvent, nil
 }
 
 func (h *mockParserService) ParseKillEvent(args []string) (parser.KillEvent, error) {
@@ -610,6 +648,8 @@ func TestRegisterHandlers_RegistersAllCommands(t *testing.T) {
 		":EVENT:PROJECTILE:",
 		":EVENT:KILL:",
 		":EVENT:GENERAL:",
+		":EVENT:SECTOR:",
+		":EVENT:ENDMISSION:",
 		":EVENT:CHAT:",
 		":EVENT:RADIO:",
 		":TELEMETRY:FRAME:",

--- a/pkg/core/events.go
+++ b/pkg/core/events.go
@@ -18,7 +18,7 @@ type FiredEvent struct {
 	EndPos       Position3D
 }
 
-// GeneralEvent is a generic event
+// GeneralEvent is a generic event (connected, disconnected, generalEvent, respawnTickets, etc.)
 type GeneralEvent struct {
 	ID           uint
 	Time         time.Time
@@ -26,6 +26,28 @@ type GeneralEvent struct {
 	Name         string
 	Message      string
 	ExtraData    map[string]any
+}
+
+// SectorEvent represents a sector state change (captured, contested, capturedFlag).
+type SectorEvent struct {
+	ID           uint
+	Time         time.Time
+	CaptureFrame Frame
+	Name         string  // "captured", "contested", "capturedFlag"
+	ObjectType   string  // "sector", "flag", etc.
+	UnitName     string  // name of the sector/flag
+	PosX         float64
+	PosY         float64
+	PosZ         float64
+}
+
+// EndMissionEvent represents the end of a mission.
+type EndMissionEvent struct {
+	ID           uint
+	Time         time.Time
+	CaptureFrame Frame
+	Side         string // winning side ("WEST", "EAST", etc.) or empty
+	Message      string // victory description
 }
 
 // HitEvent represents something being hit

--- a/pkg/streaming/messages.go
+++ b/pkg/streaming/messages.go
@@ -21,8 +21,10 @@ const (
 	TypeDeleteVehicle   = "delete_vehicle"
 	TypeFiredEvent      = "fired_event"
 	TypeProjectileEvent = "projectile_event"
-	TypeGeneralEvent    = "general_event"
-	TypeHitEvent        = "hit_event"
+	TypeGeneralEvent      = "general_event"
+	TypeSectorEvent       = "sector_event"
+	TypeEndMissionEvent   = "end_mission_event"
+	TypeHitEvent          = "hit_event"
 	TypeKillEvent       = "kill_event"
 	TypeChatEvent       = "chat_event"
 	TypeRadioEvent      = "radio_event"
@@ -41,7 +43,7 @@ var AllMessageTypes = []string{
 	TypeStartMission, TypeEndMission,
 	TypeAddSoldier, TypeAddVehicle, TypeAddMarker,
 	TypeSoldierState, TypeVehicleState, TypeMarkerState, TypeDeleteMarker, TypeDeleteSoldier, TypeDeleteVehicle,
-	TypeFiredEvent, TypeProjectileEvent, TypeGeneralEvent,
+	TypeFiredEvent, TypeProjectileEvent, TypeGeneralEvent, TypeSectorEvent, TypeEndMissionEvent,
 	TypeHitEvent, TypeKillEvent, TypeChatEvent, TypeRadioEvent,
 	TypeTelemetry, TypeTimeState, TypeAce3Death, TypeAce3Unconscious,
 	TypeAddPlaced, TypePlacedEvent,


### PR DESCRIPTION
## Summary

- Splits sector events (captured/contested/capturedFlag) and endMission out of `:EVENT:GENERAL:` into dedicated commands with typed positional args
- New `core.SectorEvent` and `core.EndMissionEvent` types preserve structured data through the entire pipeline (parser → storage → export)
- V1 JSON export format is unchanged — structured fields are assembled at the export layer instead of pre-baked in the parser
- All storage backends updated: memory, websocket (streaming), postgres (stored as general events for DB compat), v1 builder

## Changes

| Layer | What changed |
|-------|-------------|
| Core types | Added `SectorEvent` and `EndMissionEvent` structs |
| Parser | New `ParseSectorEvent`/`ParseEndMissionEvent`; simplified `ParseGeneralEvent` |
| Storage interface | Added `RecordSectorEvent`/`RecordEndMissionEvent` |
| Memory backend | New event slices, passed to v1 builder |
| V1 builder | Builds `[frame, "captured", [objectType, unitName, [x,y,z]]]` and `[frame, "endMission", side, message]` |
| WebSocket | Streams new message types `sector_event`/`end_mission_event` |
| Postgres | Maps to general events for backward compatibility |
| Dispatch | Registers `:EVENT:SECTOR:` and `:EVENT:ENDMISSION:` handlers |

## Test plan

- [x] All existing tests pass (`go test ./...` — 18 packages)
- [x] New `TestParseSectorEvent` covers: position/no-position, all event names, error cases
- [x] New `TestParseEndMissionEvent` covers: normal, empty side, comma in message, error cases
- [x] `TestAllMessageTypes` updated to exercise new streaming types
- [x] `TestRegisterHandlers_RegistersAllCommands` includes new commands
- [ ] Companion addon PR updates SQF to send `:EVENT:SECTOR:` and `:EVENT:ENDMISSION:`