### PR TITLE
fix: sector event side field and capturedFlag cleanup

### DIFF
--- a/internal/parser/parse_events.go
+++ b/internal/parser/parse_events.go
@@ -184,7 +184,7 @@ func (p *Parser) ParseGeneralEvent(data []string) (core.GeneralEvent, error) {
 }
 
 // ParseSectorEvent parses sector state change events.
-// Handles: captured, contested, capturedFlag.
+// Handles: captured, contested.
 // Args: [frame, type, objectType, unitName, side, posX?, posY?, posZ?]
 func (p *Parser) ParseSectorEvent(data []string) (core.SectorEvent, error) {
 	var event core.SectorEvent

--- a/internal/parser/parse_events.go
+++ b/internal/parser/parse_events.go
@@ -185,7 +185,7 @@ func (p *Parser) ParseGeneralEvent(data []string) (core.GeneralEvent, error) {
 
 // ParseSectorEvent parses sector state change events.
 // Handles: captured, contested, capturedFlag.
-// Args: [frame, type, objectType, unitName, posX?, posY?, posZ?]
+// Args: [frame, type, objectType, unitName, side, posX?, posY?, posZ?]
 func (p *Parser) ParseSectorEvent(data []string) (core.SectorEvent, error) {
 	var event core.SectorEvent
 
@@ -208,16 +208,20 @@ func (p *Parser) ParseSectorEvent(data []string) (core.SectorEvent, error) {
 	event.ObjectType = data[2]
 	event.UnitName = data[3]
 
-	if len(data) >= 7 {
-		event.PosX, err = strconv.ParseFloat(data[4], 64)
+	if len(data) >= 5 {
+		event.Side = data[4]
+	}
+
+	if len(data) >= 8 {
+		event.PosX, err = strconv.ParseFloat(data[5], 64)
 		if err != nil {
 			return event, fmt.Errorf("invalid position X for sector event: %w", err)
 		}
-		event.PosY, err = strconv.ParseFloat(data[5], 64)
+		event.PosY, err = strconv.ParseFloat(data[6], 64)
 		if err != nil {
 			return event, fmt.Errorf("invalid position Y for sector event: %w", err)
 		}
-		event.PosZ, err = strconv.ParseFloat(data[6], 64)
+		event.PosZ, err = strconv.ParseFloat(data[7], 64)
 		if err != nil {
 			return event, fmt.Errorf("invalid position Z for sector event: %w", err)
 		}

--- a/internal/parser/parse_events_test.go
+++ b/internal/parser/parse_events_test.go
@@ -560,19 +560,6 @@ func TestParseSectorEvent(t *testing.T) {
 			},
 		},
 		{
-			name:  "capturedFlag",
-			input: []string{"150", "capturedFlag", "flag", "Player One", "EAST", "300", "400", "5"},
-			check: func(t *testing.T, e core.SectorEvent) {
-				assert.Equal(t, "capturedFlag", e.Name)
-				assert.Equal(t, "flag", e.ObjectType)
-				assert.Equal(t, "Player One", e.UnitName)
-				assert.Equal(t, "EAST", e.Side)
-				assert.InDelta(t, 300.0, e.PosX, 0.001)
-				assert.InDelta(t, 400.0, e.PosY, 0.001)
-				assert.InDelta(t, 5.0, e.PosZ, 0.001)
-			},
-		},
-		{
 			name:  "captured without position",
 			input: []string{"200", "captured", "sector", "Sector Alpha", "WEST"},
 			check: func(t *testing.T, e core.SectorEvent) {

--- a/internal/parser/parse_events_test.go
+++ b/internal/parser/parse_events_test.go
@@ -537,33 +537,36 @@ func TestParseSectorEvent(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:  "captured with position",
-			input: []string{"200", "captured", "sector", "Sector Alpha", "100.5", "200.3", "0"},
+			name:  "captured with side and position",
+			input: []string{"200", "captured", "sector", "Sector Alpha", "WEST", "100.5", "200.3", "0"},
 			check: func(t *testing.T, e core.SectorEvent) {
 				assert.Equal(t, core.Frame(200), e.CaptureFrame)
 				assert.Equal(t, "captured", e.Name)
 				assert.Equal(t, "sector", e.ObjectType)
 				assert.Equal(t, "Sector Alpha", e.UnitName)
+				assert.Equal(t, "WEST", e.Side)
 				assert.InDelta(t, 100.5, e.PosX, 0.001)
 				assert.InDelta(t, 200.3, e.PosY, 0.001)
 				assert.InDelta(t, 0.0, e.PosZ, 0.001)
 			},
 		},
 		{
-			name:  "contested",
-			input: []string{"300", "contested", "sector", "Sector,With,Commas", "50", "60", "0"},
+			name:  "contested with empty side",
+			input: []string{"300", "contested", "sector", "Sector,With,Commas", "", "50", "60", "0"},
 			check: func(t *testing.T, e core.SectorEvent) {
 				assert.Equal(t, "contested", e.Name)
 				assert.Equal(t, "Sector,With,Commas", e.UnitName)
+				assert.Equal(t, "", e.Side)
 			},
 		},
 		{
 			name:  "capturedFlag",
-			input: []string{"150", "capturedFlag", "flag", "Player One", "300", "400", "5"},
+			input: []string{"150", "capturedFlag", "flag", "Player One", "EAST", "300", "400", "5"},
 			check: func(t *testing.T, e core.SectorEvent) {
 				assert.Equal(t, "capturedFlag", e.Name)
 				assert.Equal(t, "flag", e.ObjectType)
 				assert.Equal(t, "Player One", e.UnitName)
+				assert.Equal(t, "EAST", e.Side)
 				assert.InDelta(t, 300.0, e.PosX, 0.001)
 				assert.InDelta(t, 400.0, e.PosY, 0.001)
 				assert.InDelta(t, 5.0, e.PosZ, 0.001)
@@ -571,13 +574,22 @@ func TestParseSectorEvent(t *testing.T) {
 		},
 		{
 			name:  "captured without position",
-			input: []string{"200", "captured", "sector", "Sector Alpha"},
+			input: []string{"200", "captured", "sector", "Sector Alpha", "WEST"},
 			check: func(t *testing.T, e core.SectorEvent) {
 				assert.Equal(t, "captured", e.Name)
 				assert.Equal(t, "Sector Alpha", e.UnitName)
+				assert.Equal(t, "WEST", e.Side)
 				assert.Equal(t, 0.0, e.PosX)
 				assert.Equal(t, 0.0, e.PosY)
 				assert.Equal(t, 0.0, e.PosZ)
+			},
+		},
+		{
+			name:  "minimal without side or position",
+			input: []string{"200", "captured", "sector", "Alpha"},
+			check: func(t *testing.T, e core.SectorEvent) {
+				assert.Equal(t, "captured", e.Name)
+				assert.Equal(t, "", e.Side)
 			},
 		},
 		{
@@ -592,17 +604,17 @@ func TestParseSectorEvent(t *testing.T) {
 		},
 		{
 			name:    "error: bad position X",
-			input:   []string{"200", "captured", "sector", "Alpha", "not_a_number", "200", "0"},
+			input:   []string{"200", "captured", "sector", "Alpha", "WEST", "not_a_number", "200", "0"},
 			wantErr: true,
 		},
 		{
 			name:    "error: bad position Y",
-			input:   []string{"200", "captured", "sector", "Alpha", "100", "not_a_number", "0"},
+			input:   []string{"200", "captured", "sector", "Alpha", "WEST", "100", "not_a_number", "0"},
 			wantErr: true,
 		},
 		{
 			name:    "error: bad position Z",
-			input:   []string{"200", "captured", "sector", "Alpha", "100", "200", "not_a_number"},
+			input:   []string{"200", "captured", "sector", "Alpha", "WEST", "100", "200", "not_a_number"},
 			wantErr: true,
 		},
 	}

--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -290,13 +290,12 @@ func Build(data *MissionData) Export {
 	}
 
 	// Convert end mission events
-	// Format: [frameNum, "endMission", side, message]
+	// Format: [frameNum, "endMission", [side, message]]
 	for _, evt := range data.EndMissionEvents {
 		export.Events = append(export.Events, []any{
 			frameToV1(evt.CaptureFrame),
 			"endMission",
-			evt.Side,
-			evt.Message,
+			[]any{evt.Side, evt.Message},
 		})
 	}
 

--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -280,7 +280,7 @@ func Build(data *MissionData) Export {
 	}
 
 	// Convert sector events
-	// Format: [frameNum, "captured"|"contested"|"capturedFlag", [objectType, unitName, side, [x, y, z]]]
+	// Format: [frameNum, "captured"|"contested", [objectType, unitName, side, [x, y, z]]]
 	for _, evt := range data.SectorEvents {
 		export.Events = append(export.Events, []any{
 			frameToV1(evt.CaptureFrame),

--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -280,12 +280,12 @@ func Build(data *MissionData) Export {
 	}
 
 	// Convert sector events
-	// Format: [frameNum, "captured"|"contested"|"capturedFlag", [objectType, unitName, [x, y, z]]]
+	// Format: [frameNum, "captured"|"contested"|"capturedFlag", [objectType, unitName, side, [x, y, z]]]
 	for _, evt := range data.SectorEvents {
 		export.Events = append(export.Events, []any{
 			frameToV1(evt.CaptureFrame),
 			evt.Name,
-			[]any{evt.ObjectType, evt.UnitName, []float64{evt.PosX, evt.PosY, evt.PosZ}},
+			[]any{evt.ObjectType, evt.UnitName, evt.Side, []float64{evt.PosX, evt.PosY, evt.PosZ}},
 		})
 	}
 

--- a/internal/storage/memory/export/v1/builder_test.go
+++ b/internal/storage/memory/export/v1/builder_test.go
@@ -490,8 +490,8 @@ func TestBuildWithSectorEvents(t *testing.T) {
 		Vehicles: make(map[uint16]*VehicleRecord),
 		Markers:  make(map[string]*MarkerRecord),
 		SectorEvents: []core.SectorEvent{
-			{CaptureFrame: 15, Name: "captured", ObjectType: "sector", UnitName: "Sector Alpha", PosX: 100.5, PosY: 200.3, PosZ: 0},
-			{CaptureFrame: 30, Name: "contested", ObjectType: "flag", UnitName: "Flag Bravo", PosX: 300, PosY: 400, PosZ: 10},
+			{CaptureFrame: 15, Name: "captured", ObjectType: "sector", UnitName: "Sector Alpha", Side: "WEST", PosX: 100.5, PosY: 200.3, PosZ: 0},
+			{CaptureFrame: 30, Name: "contested", ObjectType: "flag", UnitName: "Flag Bravo", Side: "", PosX: 300, PosY: 400, PosZ: 10},
 		},
 	}
 
@@ -506,7 +506,8 @@ func TestBuildWithSectorEvents(t *testing.T) {
 	payload0 := evt0[2].([]any)
 	assert.Equal(t, "sector", payload0[0])
 	assert.Equal(t, "Sector Alpha", payload0[1])
-	pos0 := payload0[2].([]float64)
+	assert.Equal(t, "WEST", payload0[2])
+	pos0 := payload0[3].([]float64)
 	assert.Equal(t, 100.5, pos0[0])
 	assert.Equal(t, 200.3, pos0[1])
 	assert.Equal(t, 0.0, pos0[2])

--- a/internal/storage/memory/export/v1/builder_test.go
+++ b/internal/storage/memory/export/v1/builder_test.go
@@ -537,8 +537,10 @@ func TestBuildWithEndMissionEvents(t *testing.T) {
 	evt := export.Events[0]
 	assert.Equal(t, 499, evt[0])            // internal 500 → v1 499
 	assert.Equal(t, "endMission", evt[1])
-	assert.Equal(t, "WEST", evt[2])
-	assert.Equal(t, "BLUFOR controlled all sectors!", evt[3])
+	inner, ok := evt[2].([]any)
+	require.True(t, ok, "endMission data should be inner array")
+	assert.Equal(t, "WEST", inner[0])
+	assert.Equal(t, "BLUFOR controlled all sectors!", inner[1])
 }
 
 func TestBuildEventsSortedByFrame(t *testing.T) {

--- a/internal/storage/memory/export_test.go
+++ b/internal/storage/memory/export_test.go
@@ -77,7 +77,7 @@ func TestIntegrationFullExport(t *testing.T) {
 		CaptureFrame: 15, Name: "connected", Message: "Player1 connected", ExtraData: map[string]any{"uid": "12345"},
 	}))
 	require.NoError(t, b.RecordSectorEvent(&core.SectorEvent{
-		CaptureFrame: 8, Name: "captured", ObjectType: "sector", UnitName: "Sector Alpha", PosX: 100.5, PosY: 200.3, PosZ: 0,
+		CaptureFrame: 8, Name: "captured", ObjectType: "sector", UnitName: "Sector Alpha", Side: "WEST", PosX: 100.5, PosY: 200.3, PosZ: 0,
 	}))
 	require.NoError(t, b.RecordEndMissionEvent(&core.EndMissionEvent{
 		CaptureFrame: 25, Side: "WEST", Message: "BLUFOR wins",
@@ -167,6 +167,7 @@ func TestIntegrationFullExport(t *testing.T) {
 	require.True(t, ok, "sector event payload should be []any")
 	assert.Equal(t, "sector", sectorPayload[0])
 	assert.Equal(t, "Sector Alpha", sectorPayload[1])
+	assert.Equal(t, "WEST", sectorPayload[2])
 
 	// General event at frame 15 (v1: 14)
 	assert.EqualValues(t, 14, export.Events[1][0])

--- a/internal/storage/memory/export_test.go
+++ b/internal/storage/memory/export_test.go
@@ -177,8 +177,10 @@ func TestIntegrationFullExport(t *testing.T) {
 	// EndMission event at frame 25 (v1: 24)
 	assert.EqualValues(t, 24, export.Events[2][0])
 	assert.Equal(t, "endMission", export.Events[2][1])
-	assert.Equal(t, "WEST", export.Events[2][2])
-	assert.Equal(t, "BLUFOR wins", export.Events[2][3])
+	endInner, ok := export.Events[2][2].([]any)
+	require.True(t, ok, "endMission data should be inner array")
+	assert.Equal(t, "WEST", endInner[0])
+	assert.Equal(t, "BLUFOR wins", endInner[1])
 
 	// Verify markers (array format: [type, text, startFrame, endFrame, playerId, color, sideIndex, positions, size, shape, brush])
 	require.Len(t, export.Markers, 1)

--- a/internal/storage/memory/memory_test.go
+++ b/internal/storage/memory/memory_test.go
@@ -330,6 +330,7 @@ func TestRecordSectorEvent(t *testing.T) {
 		Name:         "captured",
 		ObjectType:   "sector",
 		UnitName:     "Sector Alpha",
+		Side:         "WEST",
 		PosX:         100.5,
 		PosY:         200.3,
 	}
@@ -339,6 +340,7 @@ func TestRecordSectorEvent(t *testing.T) {
 	assert.Len(t, b.sectorEvents, 1)
 	assert.Equal(t, "captured", b.sectorEvents[0].Name)
 	assert.Equal(t, "Sector Alpha", b.sectorEvents[0].UnitName)
+	assert.Equal(t, "WEST", b.sectorEvents[0].Side)
 }
 
 func TestRecordEndMissionEvent(t *testing.T) {

--- a/internal/storage/postgres/postgres.go
+++ b/internal/storage/postgres/postgres.go
@@ -324,7 +324,7 @@ func (b *Backend) RecordSectorEvent(e *core.SectorEvent) error {
 		Time:         e.Time,
 		CaptureFrame: e.CaptureFrame,
 		Name:         e.Name,
-		Message:      fmt.Sprintf("%s %s", e.ObjectType, e.UnitName),
+		Message:      fmt.Sprintf("%s,%s,%s", e.ObjectType, e.UnitName, e.Side),
 	})
 	b.queues.GeneralEvents.Push(gormObj)
 	return nil

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -197,6 +197,7 @@ func TestRecordSectorEvent_QueuesToGeneralEvents(t *testing.T) {
 		Name:         "captured",
 		ObjectType:   "sector",
 		UnitName:     "Sector Alpha",
+		Side:         "WEST",
 		PosX:         100.5,
 		PosY:         200.3,
 	}

--- a/internal/worker/dispatch_test.go
+++ b/internal/worker/dispatch_test.go
@@ -1054,6 +1054,7 @@ func TestHandleSectorEvent_RecordsEvent(t *testing.T) {
 			Name:         "captured",
 			ObjectType:   "sector",
 			UnitName:     "Sector Alpha",
+			Side:         "WEST",
 			PosX:         100.5,
 			PosY:         200.3,
 		},
@@ -1080,6 +1081,7 @@ func TestHandleSectorEvent_RecordsEvent(t *testing.T) {
 	require.Equal(t, 1, len(backend.sectorEvents))
 	assert.Equal(t, "captured", backend.sectorEvents[0].Name)
 	assert.Equal(t, "Sector Alpha", backend.sectorEvents[0].UnitName)
+	assert.Equal(t, "WEST", backend.sectorEvents[0].Side)
 }
 
 func TestHandleEndMissionEvent_RecordsEvent(t *testing.T) {

--- a/pkg/core/events.go
+++ b/pkg/core/events.go
@@ -28,14 +28,14 @@ type GeneralEvent struct {
 	ExtraData    map[string]any
 }
 
-// SectorEvent represents a sector state change (captured, contested, capturedFlag).
+// SectorEvent represents a sector state change (captured, contested).
 type SectorEvent struct {
 	ID           uint
 	Time         time.Time
 	CaptureFrame Frame
-	Name         string  // "captured", "contested", "capturedFlag"
-	ObjectType   string  // "sector", "flag", etc.
-	UnitName     string  // name of the sector/flag
+	Name         string  // "captured", "contested"
+	ObjectType   string  // "sector", etc.
+	UnitName     string  // name of the sector
 	Side         string  // capturing side ("WEST", "EAST", etc.) or empty
 	PosX         float64
 	PosY         float64

--- a/pkg/core/events.go
+++ b/pkg/core/events.go
@@ -36,6 +36,7 @@ type SectorEvent struct {
 	Name         string  // "captured", "contested", "capturedFlag"
 	ObjectType   string  // "sector", "flag", etc.
 	UnitName     string  // name of the sector/flag
+	Side         string  // capturing side ("WEST", "EAST", etc.) or empty
 	PosX         float64
 	PosY         float64
 	PosZ         float64


### PR DESCRIPTION
## Summary

- Preserve the `Side` field in `SectorEvent` through all storage backends (memory, postgres, websocket) and v1 JSON export
- Remove `capturedFlag` references from sector event parser comments, test cases, and v1 builder format docs — `capturedFlag` is no longer routed through `:EVENT:SECTOR:` by the addon

## Test plan

- [x] `TestParseSectorEvent` passes (capturedFlag test case removed)
- [x] `TestBuildWithSectorEvents` passes with side field in v1 JSON output
- [x] All storage backend tests pass with side field