### PR TITLE
fix: make :MISSION:SAVE: async to stop blocking ArmA main thread

### DIFF
--- a/cmd/ocap_recorder/main.go
+++ b/cmd/ocap_recorder/main.go
@@ -8,7 +8,6 @@ package main
 import "C" // This is required to import the C code
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -375,35 +374,7 @@ func registerLifecycleHandlers(d *dispatcher.Dispatcher) {
 	d.Register(":MISSION:START:", handleNewMission, dispatcher.Buffered(1), dispatcher.Blocking(), dispatcher.Gated(storageReady))
 
 	d.Register(":MISSION:SAVE:", func(e dispatcher.Event) (any, error) {
-		Logger.Info("Received :MISSION:SAVE: command, ending mission recording")
-		if storageBackend != nil {
-			if err := storageBackend.EndMission(); err != nil {
-				Logger.Error("Failed to end mission in storage backend", "error", err)
-				return nil, err
-			}
-			Logger.Info("Mission recording saved to storage backend")
-
-			// Upload if backend supports it and API client is configured
-			if u, ok := storageBackend.(storage.Uploadable); ok && apiClient != nil {
-				if path := u.GetExportedFilePath(); path != "" {
-					meta := u.GetExportMetadata()
-					if err := apiClient.Upload(path, meta); err != nil {
-						Logger.Error("Failed to upload to OCAP web", "error", err, "path", path)
-						// Don't return error - file is saved locally
-					} else {
-						Logger.Info("Mission uploaded to OCAP web", "path", path)
-					}
-				}
-			}
-		}
-		// Flush OTel data if provider is available
-		if OTelProvider != nil {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			if err := OTelProvider.Flush(ctx); err != nil {
-				Logger.Warn("Failed to flush OTel data", "error", err)
-			}
-		}
-		return nil, nil
+		Logger.Info("Received :MISSION:SAVE: command, queuing async save")
+		return triggerMissionSave(saveState, storageBackend, apiClient)
 	})
 }

--- a/cmd/ocap_recorder/mission_save.go
+++ b/cmd/ocap_recorder/mission_save.go
@@ -112,10 +112,10 @@ func runMissionSaveWorker(state *missionSaveState, backend storage.Backend, clie
 	// Flush OTel data if provider is available.
 	if OTelProvider != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
 		if err := OTelProvider.Flush(ctx); err != nil && Logger != nil {
 			Logger.Warn("Failed to flush OTel data", "error", err)
 		}
-		cancel()
 	}
 
 	// Build callback payload.

--- a/cmd/ocap_recorder/mission_save.go
+++ b/cmd/ocap_recorder/mission_save.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+	"sync/atomic"
+	"time"
+
+	"github.com/OCAP2/extension/v5/internal/api"
+	"github.com/OCAP2/extension/v5/internal/storage"
+	"github.com/OCAP2/extension/v5/pkg/a3interface"
+)
+
+// missionSaveState holds the cross-call state for the async save worker.
+// There is exactly one instance, owned by the package-level saveState variable.
+type missionSaveState struct {
+	inFlight atomic.Bool
+}
+
+// saveState is the package-level state used by the :MISSION:SAVE: handler.
+var saveState = &missionSaveState{}
+
+// triggerMissionSave is the logic behind the :MISSION:SAVE: dispatcher handler,
+// extracted so it can be exercised in tests with a fake backend and a fake
+// api client.
+//
+// Contract:
+//   - Returns "queued" + nil error when a goroutine was spawned.
+//   - Returns a non-nil error if another save is already in progress.
+//   - Never blocks on the save itself. The save runs asynchronously and
+//     reports completion via a3interface.WriteArmaCallback with function
+//     name ":MISSION:SAVED:".
+func triggerMissionSave(state *missionSaveState, backend storage.Backend, client *api.Client) (any, error) {
+	if backend == nil {
+		return nil, fmt.Errorf("no storage backend configured")
+	}
+	if !state.inFlight.CompareAndSwap(false, true) {
+		return nil, fmt.Errorf("save already in progress")
+	}
+
+	go runMissionSaveWorker(state, backend, client)
+	return "queued", nil
+}
+
+// runMissionSaveWorker performs EndMission + optional upload, recovers from
+// panics, flushes OTel, and dispatches the :MISSION:SAVED: callback.
+func runMissionSaveWorker(state *missionSaveState, backend storage.Backend, client *api.Client) {
+	// Always clear the in-flight flag before returning.
+	defer state.inFlight.Store(false)
+
+	start := time.Now()
+
+	var (
+		savedPath string
+		endErr    error
+		uploadErr error
+		panicInfo string
+	)
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicInfo = fmt.Sprintf("panic during mission save: %v", r)
+				if Logger != nil {
+					Logger.Error("panic during mission save",
+						"panic", r,
+						"stack", string(debug.Stack()),
+					)
+				}
+			}
+		}()
+
+		if err := backend.EndMission(); err != nil {
+			endErr = err
+			if Logger != nil {
+				Logger.Error("Failed to end mission in storage backend", "error", err)
+			}
+			return
+		}
+		if Logger != nil {
+			Logger.Info("Mission recording saved to storage backend",
+				"duration", time.Since(start),
+			)
+		}
+
+		if u, ok := backend.(storage.Uploadable); ok && client != nil {
+			if path := u.GetExportedFilePath(); path != "" {
+				savedPath = path
+				meta := u.GetExportMetadata()
+				if err := client.Upload(path, meta); err != nil {
+					uploadErr = err
+					if Logger != nil {
+						Logger.Error("Failed to upload to OCAP web",
+							"error", err,
+							"path", path,
+						)
+					}
+				} else if Logger != nil {
+					Logger.Info("Mission uploaded to OCAP web",
+						"path", path,
+						"duration", time.Since(start),
+					)
+				}
+			}
+		} else if u, ok := backend.(storage.Uploadable); ok {
+			// Client not configured — still report the path so the addon can inform players.
+			savedPath = u.GetExportedFilePath()
+		}
+	}()
+
+	// Flush OTel data if provider is available.
+	if OTelProvider != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := OTelProvider.Flush(ctx); err != nil && Logger != nil {
+			Logger.Warn("Failed to flush OTel data", "error", err)
+		}
+		cancel()
+	}
+
+	// Build callback payload.
+	switch {
+	case panicInfo != "":
+		_ = a3interface.WriteArmaCallback(ExtensionName, ":MISSION:SAVED:", "error", panicInfo)
+	case endErr != nil:
+		_ = a3interface.WriteArmaCallback(ExtensionName, ":MISSION:SAVED:", "error", endErr.Error())
+	case uploadErr != nil:
+		_ = a3interface.WriteArmaCallback(ExtensionName, ":MISSION:SAVED:", "partial", savedPath, uploadErr.Error())
+	default:
+		_ = a3interface.WriteArmaCallback(ExtensionName, ":MISSION:SAVED:", "ok", savedPath)
+	}
+}

--- a/cmd/ocap_recorder/mission_save_test.go
+++ b/cmd/ocap_recorder/mission_save_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/OCAP2/extension/v5/internal/storage"
+	"github.com/OCAP2/extension/v5/pkg/a3interface"
+	"github.com/OCAP2/extension/v5/pkg/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeBackend is a minimal storage.Backend + storage.Uploadable implementation
+// that only implements what the save path actually touches. Every other
+// Backend method is a panic — if the test triggers one of those, the save
+// path is doing something it shouldn't.
+type fakeBackend struct {
+	endErr      error
+	endDuration time.Duration
+	path        string
+	meta        core.UploadMetadata
+}
+
+func (f *fakeBackend) Init() error  { return nil }
+func (f *fakeBackend) Close() error { return nil }
+func (f *fakeBackend) StartMission(*core.Mission, *core.World) error {
+	panic("unexpected StartMission")
+}
+func (f *fakeBackend) EndMission() error {
+	if f.endDuration > 0 {
+		time.Sleep(f.endDuration)
+	}
+	return f.endErr
+}
+func (f *fakeBackend) AddSoldier(*core.Soldier) error              { panic("no") }
+func (f *fakeBackend) AddVehicle(*core.Vehicle) error              { panic("no") }
+func (f *fakeBackend) AddMarker(*core.Marker) (uint, error)        { panic("no") }
+func (f *fakeBackend) DeleteSoldier(uint16, core.Frame) error      { panic("no") }
+func (f *fakeBackend) DeleteVehicle(uint16, core.Frame) error      { panic("no") }
+func (f *fakeBackend) RecordSoldierState(*core.SoldierState) error { panic("no") }
+func (f *fakeBackend) RecordVehicleState(*core.VehicleState) error { panic("no") }
+func (f *fakeBackend) RecordMarkerState(*core.MarkerState) error   { panic("no") }
+func (f *fakeBackend) DeleteMarker(*core.DeleteMarker) error       { panic("no") }
+func (f *fakeBackend) RecordFiredEvent(*core.FiredEvent) error     { panic("no") }
+func (f *fakeBackend) RecordProjectileEvent(*core.ProjectileEvent) error {
+	panic("no")
+}
+func (f *fakeBackend) RecordGeneralEvent(*core.GeneralEvent) error { panic("no") }
+func (f *fakeBackend) RecordSectorEvent(*core.SectorEvent) error   { panic("no") }
+func (f *fakeBackend) RecordEndMissionEvent(*core.EndMissionEvent) error {
+	panic("no")
+}
+func (f *fakeBackend) RecordHitEvent(*core.HitEvent) error     { panic("no") }
+func (f *fakeBackend) RecordKillEvent(*core.KillEvent) error   { panic("no") }
+func (f *fakeBackend) RecordChatEvent(*core.ChatEvent) error   { panic("no") }
+func (f *fakeBackend) RecordRadioEvent(*core.RadioEvent) error { panic("no") }
+func (f *fakeBackend) RecordTelemetryEvent(*core.TelemetryEvent) error {
+	panic("no")
+}
+func (f *fakeBackend) RecordTimeState(*core.TimeState) error { panic("no") }
+func (f *fakeBackend) RecordAce3DeathEvent(*core.Ace3DeathEvent) error {
+	panic("no")
+}
+func (f *fakeBackend) RecordAce3UnconsciousEvent(*core.Ace3UnconsciousEvent) error {
+	panic("no")
+}
+func (f *fakeBackend) AddPlacedObject(*core.PlacedObject) error { panic("no") }
+func (f *fakeBackend) RecordPlacedObjectEvent(*core.PlacedObjectEvent) error {
+	panic("no")
+}
+func (f *fakeBackend) SetFocusStart(core.Frame) error { panic("no") }
+func (f *fakeBackend) SetFocusEnd(core.Frame) error   { panic("no") }
+
+// Uploadable
+func (f *fakeBackend) GetExportedFilePath() string            { return f.path }
+func (f *fakeBackend) GetExportMetadata() core.UploadMetadata { return f.meta }
+
+var (
+	_ storage.Backend    = (*fakeBackend)(nil)
+	_ storage.Uploadable = (*fakeBackend)(nil)
+)
+
+type recordedCallback struct {
+	function string
+	data     []string
+}
+
+type callbackRecorder struct {
+	mu    sync.Mutex
+	calls []recordedCallback
+}
+
+func (r *callbackRecorder) sink(name, function string, data ...string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, recordedCallback{function: function, data: append([]string(nil), data...)})
+}
+
+func (r *callbackRecorder) wait(t *testing.T, fn string) recordedCallback {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		r.mu.Lock()
+		for _, c := range r.calls {
+			if c.function == fn {
+				r.mu.Unlock()
+				return c
+			}
+		}
+		r.mu.Unlock()
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for callback %s", fn)
+	return recordedCallback{}
+}
+
+// newTestSaveState returns a fresh missionSaveState suitable for tests.
+func newTestSaveState() *missionSaveState {
+	return &missionSaveState{}
+}
+
+func TestRunMissionSave_SuccessWithoutUpload(t *testing.T) {
+	rec := &callbackRecorder{}
+	a3interface.SetCallbackSinkForTest(rec.sink)
+	t.Cleanup(func() { a3interface.SetCallbackSinkForTest(nil) })
+
+	state := newTestSaveState()
+	backend := &fakeBackend{path: "recordings/test.json.gz"}
+
+	// apiClient = nil → no upload
+	result, err := triggerMissionSave(state, backend, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "queued", result)
+
+	cb := rec.wait(t, ":MISSION:SAVED:")
+	require.Len(t, cb.data, 2)
+	assert.Equal(t, `"ok"`, cb.data[0])
+	assert.Equal(t, `"recordings/test.json.gz"`, cb.data[1])
+	assert.False(t, state.inFlight.Load())
+}
+
+func TestRunMissionSave_EndMissionError(t *testing.T) {
+	rec := &callbackRecorder{}
+	a3interface.SetCallbackSinkForTest(rec.sink)
+	t.Cleanup(func() { a3interface.SetCallbackSinkForTest(nil) })
+
+	state := newTestSaveState()
+	backend := &fakeBackend{endErr: errors.New("disk full")}
+
+	result, err := triggerMissionSave(state, backend, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "queued", result)
+
+	cb := rec.wait(t, ":MISSION:SAVED:")
+	require.Len(t, cb.data, 2)
+	assert.Equal(t, `"error"`, cb.data[0])
+	assert.Contains(t, cb.data[1], "disk full")
+}
+
+func TestRunMissionSave_RejectsConcurrent(t *testing.T) {
+	rec := &callbackRecorder{}
+	a3interface.SetCallbackSinkForTest(rec.sink)
+	t.Cleanup(func() { a3interface.SetCallbackSinkForTest(nil) })
+
+	state := newTestSaveState()
+	// Make the first save slow so the second call lands while it's still running.
+	backend := &fakeBackend{endDuration: 200 * time.Millisecond, path: "r.json.gz"}
+
+	result1, err1 := triggerMissionSave(state, backend, nil)
+	require.NoError(t, err1)
+	assert.Equal(t, "queued", result1)
+
+	_, err2 := triggerMissionSave(state, backend, nil)
+	require.Error(t, err2)
+	assert.Contains(t, err2.Error(), "save already in progress")
+
+	rec.wait(t, ":MISSION:SAVED:")
+}
+
+func TestRunMissionSave_PanicIsRecovered(t *testing.T) {
+	rec := &callbackRecorder{}
+	a3interface.SetCallbackSinkForTest(rec.sink)
+	t.Cleanup(func() { a3interface.SetCallbackSinkForTest(nil) })
+
+	state := newTestSaveState()
+	// A backend whose EndMission panics.
+	panicBackend := &panickingBackend{fakeBackend: fakeBackend{path: "r.json.gz"}}
+
+	result, err := triggerMissionSave(state, panicBackend, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "queued", result)
+
+	cb := rec.wait(t, ":MISSION:SAVED:")
+	require.Len(t, cb.data, 2)
+	assert.Equal(t, `"error"`, cb.data[0])
+	assert.Contains(t, cb.data[1], "panic")
+	assert.False(t, state.inFlight.Load(), "inFlight must be cleared even after panic")
+}
+
+type panickingBackend struct{ fakeBackend }
+
+func (p *panickingBackend) EndMission() error {
+	panic(fmt.Errorf("boom"))
+}

--- a/pkg/a3interface/extensioncallback.go
+++ b/pkg/a3interface/extensioncallback.go
@@ -16,10 +16,28 @@ import "C"
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"unsafe"
 )
 
 var extensionCallbackFnc C.extensionCallback
+
+// callbackSink is an optional hook used by tests. When non-nil,
+// WriteArmaCallback diverts its output here instead of invoking the
+// real C callback function. Protected by callbackSinkMu.
+var (
+	callbackSinkMu sync.Mutex
+	callbackSink   func(name, function string, data ...string)
+)
+
+// SetCallbackSinkForTest installs a hook that receives WriteArmaCallback
+// invocations instead of forwarding them to the registered C callback.
+// Pass nil to restore the C callback path. Intended for tests only.
+func SetCallbackSinkForTest(sink func(name, function string, data ...string)) {
+	callbackSinkMu.Lock()
+	defer callbackSinkMu.Unlock()
+	callbackSink = sink
+}
 
 // RVExtensionRegisterCallback registers the callback function that will be called when WriteArmaCallback is called
 //
@@ -56,6 +74,15 @@ func WriteArmaCallback(
 	}
 	// format the data into a string
 	a3Message := fmt.Sprintf(`[%s]`, strings.Join(data, ","))
+
+	// Test hook: divert to an in-process sink if one was installed.
+	callbackSinkMu.Lock()
+	sink := callbackSink
+	callbackSinkMu.Unlock()
+	if sink != nil {
+		sink(extensionName, functionName, data...)
+		return nil
+	}
 
 	// check if the callback function is set
 	if extensionCallbackFnc != nil {

--- a/pkg/a3interface/extensioncallback_test.go
+++ b/pkg/a3interface/extensioncallback_test.go
@@ -1,0 +1,46 @@
+package a3interface
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriteArmaCallback_DivertsToSink(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		gotName string
+		gotFunc string
+		gotData []string
+	)
+
+	SetCallbackSinkForTest(func(name, function string, data ...string) {
+		mu.Lock()
+		defer mu.Unlock()
+		gotName = name
+		gotFunc = function
+		gotData = append(gotData, data...)
+	})
+	t.Cleanup(func() { SetCallbackSinkForTest(nil) })
+
+	err := WriteArmaCallback("ocap_recorder", ":MISSION:SAVED:", "ok", "foo.json.gz")
+	assert.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, "ocap_recorder", gotName)
+	assert.Equal(t, ":MISSION:SAVED:", gotFunc)
+	assert.Len(t, gotData, 2)
+	// data is pre-escaped and wrapped in quotes by WriteArmaCallback
+	assert.Equal(t, `"ok"`, gotData[0])
+	assert.Equal(t, `"foo.json.gz"`, gotData[1])
+}
+
+func TestWriteArmaCallback_NoSinkNoCallback(t *testing.T) {
+	// No sink, no C callback registered → error
+	SetCallbackSinkForTest(nil)
+	extensionCallbackFnc = nil
+	err := WriteArmaCallback("ocap_recorder", ":FOO:", "bar")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- `:MISSION:SAVE:` now returns immediately with `queued` and runs the export + upload in a goroutine.
- A single flag prevents concurrent saves.
- Completion is reported via a new `:MISSION:SAVED:` extension callback: `[ok|partial|error, path, errorDetail]`.
- Panics in `EndMission` / encoding / upload are recovered; the ArmA host stays alive.
- Matching addon changes land in a parallel PR on `OCAP2/addon` (`fix/async-mission-saved-callback`).

## Why
Investigation of a user crash showed `:MISSION:SAVE:` blocks the ArmA main thread for 13-30+s while `EndMission` builds and serializes the v1 export. On larger missions this is long enough for the OS OOM killer or a watchdog to terminate the server, leaving a 0-byte recording. Making the handler async is the minimum fix that prevents any save-duration from being a crash trigger.

Investigation details: a 2.5hr / 22-player successful run produced an 834 MB uncompressed JSON with 11.45 million position entries; save held the dispatcher for 13s and upload held it for another 19s. A 30-player / 2hr Zeus session with 10Hz capture scales this up and has been crashing the host with a 0-byte output file — consistent with the process being killed between `os.Create` and the first gzip flush.

## Test plan
- [x] `go test ./...` - all green
- [ ] Manual: start a short mission on a dev server, call save, observe ArmA remains responsive and `:MISSION:SAVED:` fires in the logs
- [ ] Manual: point the addon at a dead `api.serverUrl`, confirm save still completes locally and a `partial` callback is emitted