### PR TITLE
feat(api): configurable upload timeout, default 10m

### DIFF
--- a/cmd/ocap_recorder/main.go
+++ b/cmd/ocap_recorder/main.go
@@ -289,14 +289,15 @@ func loadConfig() (err error) {
 }
 
 func initAPIClient() {
-	serverURL := viper.GetString("api.serverUrl")
-	if serverURL == "" {
+	apiCfg := config.GetAPIConfig()
+	if apiCfg.ServerURL == "" {
 		Logger.Info("API server URL not configured, upload disabled")
 		return
 	}
 
-	apiKey := viper.GetString("api.apiKey")
-	apiClient = api.New(serverURL, apiKey)
+	apiClient = api.NewWithConfig(apiCfg.ServerURL, apiCfg.APIKey, api.ClientConfig{
+		UploadTimeout: apiCfg.UploadTimeout,
+	})
 
 	if err := apiClient.Healthcheck(); err != nil {
 		Logger.Info("OCAP Frontend is offline", "error", err)

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -18,6 +18,20 @@ import (
 // PathPrefix is the API path prefix appended to the base server URL.
 const PathPrefix = "/api"
 
+// DefaultUploadTimeout is the default upload timeout when the caller
+// does not provide one. It covers the full request (including body
+// streaming), so it must be generous enough for tens-of-MB uploads
+// across a slow reverse proxy.
+const DefaultUploadTimeout = 10 * time.Minute
+
+// ClientConfig configures the API client. All fields are optional —
+// zero values resolve to sensible defaults.
+type ClientConfig struct {
+	// UploadTimeout is the maximum duration for the total upload request
+	// (including streaming the body). Defaults to DefaultUploadTimeout.
+	UploadTimeout time.Duration
+}
+
 // Client handles communication with the OCAP web frontend.
 type Client struct {
 	baseURL    string
@@ -25,12 +39,21 @@ type Client struct {
 	httpClient *http.Client
 }
 
-// New creates a new API client.
+// New creates a new API client with default configuration.
 func New(baseURL, apiKey string) *Client {
+	return NewWithConfig(baseURL, apiKey, ClientConfig{})
+}
+
+// NewWithConfig creates a new API client with custom configuration.
+func NewWithConfig(baseURL, apiKey string, cfg ClientConfig) *Client {
+	timeout := cfg.UploadTimeout
+	if timeout <= 0 {
+		timeout = DefaultUploadTimeout
+	}
 	return &Client{
 		baseURL:    strings.TrimRight(baseURL, "/") + PathPrefix,
 		apiKey:     apiKey,
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: &http.Client{Timeout: timeout},
 	}
 }
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/OCAP2/extension/v5/pkg/core"
 	"github.com/stretchr/testify/assert"
@@ -191,6 +192,27 @@ func TestUpload_InvalidURL(t *testing.T) {
 	err := c.Upload(testFile, core.UploadMetadata{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create request")
+}
+
+func TestNew_DefaultTimeouts(t *testing.T) {
+	c := New("http://localhost:5000", "secret")
+	require.NotNil(t, c)
+	assert.NotNil(t, c.httpClient)
+	// Backwards-compat default preserved: 10 minutes.
+	assert.Equal(t, 10*time.Minute, c.httpClient.Timeout)
+}
+
+func TestNewWithConfig_CustomTimeout(t *testing.T) {
+	c := NewWithConfig("http://localhost:5000", "secret", ClientConfig{
+		UploadTimeout: 2 * time.Minute,
+	})
+	require.NotNil(t, c)
+	assert.Equal(t, 2*time.Minute, c.httpClient.Timeout)
+}
+
+func TestNewWithConfig_ZeroTimeoutUsesDefault(t *testing.T) {
+	c := NewWithConfig("http://localhost:5000", "secret", ClientConfig{UploadTimeout: 0})
+	assert.Equal(t, 10*time.Minute, c.httpClient.Timeout)
 }
 
 func writeTestFile(path string, content []byte) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,10 @@ func Load(configDir string) error {
 
 	viper.SetDefault("api.serverUrl", "http://localhost:5000")
 	viper.SetDefault("api.apiKey", "")
+	// 10 minute default — generous enough for multi-hundred-MB uploads across
+	// a reverse proxy without being so long that a dead backend hangs the save
+	// worker forever.
+	viper.SetDefault("api.uploadTimeout", "10m")
 
 	viper.SetDefault("db.host", "localhost")
 	viper.SetDefault("db.port", "5432")
@@ -111,5 +115,19 @@ type OTelConfig struct {
 func GetOTelConfig() OTelConfig {
 	var cfg OTelConfig
 	_ = viper.UnmarshalKey("otel", &cfg)
+	return cfg
+}
+
+// APIConfig holds HTTP client configuration for the OCAP web API.
+type APIConfig struct {
+	ServerURL     string        `json:"serverUrl" mapstructure:"serverUrl"`
+	APIKey        string        `json:"apiKey" mapstructure:"apiKey"`
+	UploadTimeout time.Duration `json:"uploadTimeout" mapstructure:"uploadTimeout"`
+}
+
+// GetAPIConfig returns the HTTP API client configuration.
+func GetAPIConfig() APIConfig {
+	var cfg APIConfig
+	_ = viper.UnmarshalKey("api", &cfg)
 	return cfg
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -45,6 +45,7 @@ func TestLoad_DefaultValues(t *testing.T) {
 	assert.Equal(t, "./ocaplogs", viper.GetString("logsDir"))
 	assert.Equal(t, "http://localhost:5000", viper.GetString("api.serverUrl"))
 	assert.Equal(t, "", viper.GetString("api.apiKey"))
+	assert.Equal(t, "10m", viper.GetString("api.uploadTimeout"))
 	assert.Equal(t, "localhost", viper.GetString("db.host"))
 	assert.Equal(t, "5432", viper.GetString("db.port"))
 	assert.Equal(t, "postgres", viper.GetString("db.username"))
@@ -125,6 +126,39 @@ func TestGetStorageConfig_Override(t *testing.T) {
 	assert.Equal(t, "/tmp/out", sc.Memory.OutputDir)
 	assert.Equal(t, false, sc.Memory.CompressOutput)
 	assert.Equal(t, 10*time.Minute, sc.SQLite.DumpInterval)
+}
+
+func TestGetAPIConfig_Defaults(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ocap_recorder.cfg.json"), []byte(`{}`), 0644))
+	require.NoError(t, Load(dir))
+
+	cfg := GetAPIConfig()
+	assert.Equal(t, "http://localhost:5000", cfg.ServerURL)
+	assert.Equal(t, "", cfg.APIKey)
+	assert.Equal(t, 10*time.Minute, cfg.UploadTimeout)
+}
+
+func TestGetAPIConfig_Override(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	dir := t.TempDir()
+	cfgJSON := `{
+		"api": {
+			"serverUrl": "http://example.com:8080",
+			"apiKey": "mykey",
+			"uploadTimeout": "5m"
+		}
+	}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ocap_recorder.cfg.json"), []byte(cfgJSON), 0644))
+	require.NoError(t, Load(dir))
+
+	cfg := GetAPIConfig()
+	assert.Equal(t, "http://example.com:8080", cfg.ServerURL)
+	assert.Equal(t, "mykey", cfg.APIKey)
+	assert.Equal(t, 5*time.Minute, cfg.UploadTimeout)
 }
 
 func TestGetOTelConfig_Defaults(t *testing.T) {

--- a/ocap_recorder.cfg.json.example
+++ b/ocap_recorder.cfg.json.example
@@ -4,7 +4,8 @@
   "defaultTag": "TvT",
   "api": {
     "serverUrl": "http://127.0.0.1:5000",
-    "apiKey": "same-secret"
+    "apiKey": "same-secret",
+    "uploadTimeout": "10m"
   },
   "db": {
     "host": "127.0.0.1",


### PR DESCRIPTION
## Summary
- Introduces `api.ClientConfig` and `api.NewWithConfig`, leaving `api.New` as a thin back-compat shim.
- New config key `api.uploadTimeout` (default `10m`) controls the total HTTP request timeout for mission uploads.
- The old hard-coded 30-second timeout was too tight for real-world recordings behind a reverse proxy and was an invisible ArmA-hang contributor when paired with the sync save path.

## Why
Investigation of a user report showed the existing 30-second `http.Client.Timeout` covers the **entire** request (including streaming the body). At the ~1.3 MB/s observed upload speed, a 25 MB file needs 19s, a 50 MB file would need 38s and already exceeds the timeout. Because the current `:MISSION:SAVE:` handler is synchronous (see companion PR #159), every extra second the upload takes is a second ArmA is blocked. Moving the default to 10m buys headroom for multi-hundred-MB recordings behind slow reverse proxies, and making it configurable lets operators tune per deployment.

## Test plan
- [x] `go test ./internal/api/... ./internal/config/...`
- [ ] Manual: set `api.uploadTimeout` to `2s`, confirm a long upload is aborted with a timeout error
- [ ] Manual: leave it unset, confirm the default `10m` applies