### PR TITLE
fix(memory): recover from panics during mission export

### DIFF
--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -117,10 +117,24 @@ func (b *Backend) StartMission(mission *core.Mission, world *core.World) error {
 // Recovers from panics in the builder or encoder and converts them
 // into an error return so the calling save worker can report them
 // via :MISSION:SAVED: instead of crashing the host process.
+//
+// Regardless of outcome (success, error return, or recovered panic),
+// the backend state is always reset so the next mission starts fresh
+// and poisoned data from a failed export cannot cause a repeat panic
+// on a subsequent call.
 func (b *Backend) EndMission() (retErr error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	// Guard against "no mission" case up front so we don't run cleanup
+	// when the caller hasn't started anything yet.
+	if b.mission == nil {
+		return fmt.Errorf("no mission to end: mission was never started")
+	}
+
+	// Single defer handles both panic recovery and state cleanup. The
+	// cleanup runs unconditionally (success, error, or panic) so the
+	// backend is always ready for the next mission.
 	defer func() {
 		if r := recover(); r != nil {
 			stack := debug.Stack()
@@ -132,11 +146,14 @@ func (b *Backend) EndMission() (retErr error) {
 			}
 			retErr = fmt.Errorf("panic during mission export: %v", r)
 		}
-	}()
 
-	if b.mission == nil {
-		return fmt.Errorf("no mission to end: mission was never started")
-	}
+		// Clear all recorded data so subsequent recordings within the same
+		// mission start fresh (e.g. manual start/stop recording in Liberation),
+		// and so poisoned data from a panic is not retained for the next call.
+		b.mission = nil
+		b.world = nil
+		b.resetCollections()
+	}()
 
 	// Cache export metadata before clearing data (needed for upload after export)
 	b.lastExportMetadata = b.computeExportMetadata()
@@ -144,12 +161,6 @@ func (b *Backend) EndMission() (retErr error) {
 	if err := b.exportJSON(); err != nil {
 		return err
 	}
-
-	// Clear all recorded data so subsequent recordings within the same
-	// mission start fresh (e.g. manual start/stop recording in Liberation).
-	b.mission = nil
-	b.world = nil
-	b.resetCollections()
 
 	return nil
 }

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -4,6 +4,7 @@ package memory
 import (
 	"fmt"
 	"log/slog"
+	"runtime/debug"
 	"sync"
 
 	"github.com/OCAP2/extension/v5/internal/config"
@@ -111,10 +112,27 @@ func (b *Backend) StartMission(mission *core.Mission, world *core.World) error {
 	return nil
 }
 
-// EndMission finalizes and exports the mission data
-func (b *Backend) EndMission() error {
+// EndMission finalizes and exports the mission data.
+//
+// Recovers from panics in the builder or encoder and converts them
+// into an error return so the calling save worker can report them
+// via :MISSION:SAVED: instead of crashing the host process.
+func (b *Backend) EndMission() (retErr error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	defer func() {
+		if r := recover(); r != nil {
+			stack := debug.Stack()
+			if b.logger != nil {
+				b.logger.Error("panic during mission export (recovered)",
+					"panic", r,
+					"stack", string(stack),
+				)
+			}
+			retErr = fmt.Errorf("panic during mission export: %v", r)
+		}
+	}()
 
 	if b.mission == nil {
 		return fmt.Errorf("no mission to end: mission was never started")

--- a/internal/storage/memory/memory_test.go
+++ b/internal/storage/memory/memory_test.go
@@ -1126,3 +1126,29 @@ func TestFocusRange_UserScenario(t *testing.T) {
 	assert.Equal(t, core.Frame(100), meta.FocusRanges[2].Start)
 	assert.Equal(t, core.Frame(200), meta.FocusRanges[2].End)
 }
+
+// TestEndMission_RecoversFromBuildPanic verifies that a panic during
+// the export build/encode is converted to an error rather than
+// propagating out of EndMission. This protects the async save worker
+// (and, historically, the ArmA host) from recoverable panics.
+func TestEndMission_RecoversFromBuildPanic(t *testing.T) {
+	tmpDir := t.TempDir()
+	b := New(config.MemoryConfig{OutputDir: tmpDir, CompressOutput: true}, nil)
+
+	// Start a minimal mission so EndMission has something to export.
+	mission := &core.Mission{MissionName: "PanicMission", CaptureDelay: 0.1}
+	world := &core.World{WorldName: "Altis"}
+	require.NoError(t, b.StartMission(mission, world))
+
+	// Poison a soldier record so the builder panics when it walks it.
+	// Inject a nil record directly into the internal map — the builder
+	// unconditionally dereferences record fields when iterating, which
+	// makes a nil entry guaranteed to panic.
+	b.mu.Lock()
+	b.soldiers[1] = nil // nil record — builder will panic on access
+	b.mu.Unlock()
+
+	err := b.EndMission()
+	require.Error(t, err, "expected EndMission to return an error, not panic")
+	assert.Contains(t, err.Error(), "panic")
+}

--- a/internal/storage/memory/memory_test.go
+++ b/internal/storage/memory/memory_test.go
@@ -1131,6 +1131,9 @@ func TestFocusRange_UserScenario(t *testing.T) {
 // the export build/encode is converted to an error rather than
 // propagating out of EndMission. This protects the async save worker
 // (and, historically, the ArmA host) from recoverable panics.
+//
+// Also verifies that the backend state is reset after a panic so the
+// poisoned data cannot cause a repeat panic on a subsequent call.
 func TestEndMission_RecoversFromBuildPanic(t *testing.T) {
 	tmpDir := t.TempDir()
 	b := New(config.MemoryConfig{OutputDir: tmpDir, CompressOutput: true}, nil)
@@ -1151,4 +1154,12 @@ func TestEndMission_RecoversFromBuildPanic(t *testing.T) {
 	err := b.EndMission()
 	require.Error(t, err, "expected EndMission to return an error, not panic")
 	assert.Contains(t, err.Error(), "panic")
+
+	// State must be reset after the panic so the poisoned data is gone
+	// and the backend is ready for the next mission.
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	assert.Nil(t, b.mission, "mission should be cleared after panic")
+	assert.Nil(t, b.world, "world should be cleared after panic")
+	assert.Empty(t, b.soldiers, "soldiers should be cleared after panic")
 }


### PR DESCRIPTION
## Summary
- `memory.Backend.EndMission` now catches panics from the builder or gzip encoder and converts them to a returned error.
- Logs the stack trace at ERROR level so a panic still leaves a forensic trail.
- Does not attempt to catch `runtime.throw` / OOM — those are a kernel/container problem, not a panic.

## Why
Previously any recoverable panic during `buildExportUnlocked` or `writeGzipJSON` would propagate straight out of the sync `:MISSION:SAVE:` handler and kill the ArmA host. Even once the handler is async (see #159), the worker goroutine still needs a clean error return instead of an unrecovered panic — the new `:MISSION:SAVED:` callback path relies on `EndMission` returning an error rather than panicking.

## Test plan
- [x] `go test ./internal/storage/memory/...`
- [x] New test `TestEndMission_RecoversFromBuildPanic` exercises the recover path — verified to panic before the fix and return a descriptive error after.