### PR TITLE
fix(runtime): use automaxprocs for cgroup-aware GOMAXPROCS

### DIFF
--- a/cmd/ocap_recorder/main.go
+++ b/cmd/ocap_recorder/main.go
@@ -228,7 +228,25 @@ func init() {
 	}
 	_ = undo // ArmA unloads the DLL at process exit; restoring GOMAXPROCS is not needed.
 
-	Logger.Debug("GOMAXPROCS after automaxprocs", "gomaxprocs", runtime.GOMAXPROCS(0), "numCPUs", runtime.NumCPU())
+	// On hosts with plenty of CPUs available to Go (bare-metal or a generous
+	// container), reserve 2 cores for the ArmA main thread and the host OS so
+	// a CPU-heavy burst in the extension (e.g. mission save) cannot starve the
+	// game. On constrained environments (containers with a small CPU quota),
+	// trust whatever automaxprocs gave us and don't subtract — halving the
+	// allowance on a 2-core container would make the save unusably slow.
+	const hostCoreReserve = 2
+	const minCoresBeforeReserve = hostCoreReserve + 3 // only subtract when >= 5 cores
+	if current := runtime.GOMAXPROCS(0); current >= minCoresBeforeReserve {
+		adjusted := current - hostCoreReserve
+		runtime.GOMAXPROCS(adjusted)
+		Logger.Info("reserved CPU cores for host",
+			"gomaxprocs", adjusted,
+			"reserved", hostCoreReserve,
+			"previous", current,
+		)
+	}
+
+	Logger.Debug("Final GOMAXPROCS", "gomaxprocs", runtime.GOMAXPROCS(0), "numCPUs", runtime.NumCPU())
 
 	// Initialize parser (no DB dependency)
 	parserService = parser.NewParser(Logger)

--- a/cmd/ocap_recorder/main.go
+++ b/cmd/ocap_recorder/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/OCAP2/extension/v5/pkg/a3interface"
 
 	"github.com/spf13/viper"
+	"go.uber.org/automaxprocs/maxprocs"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 )
 
@@ -215,16 +216,19 @@ func init() {
 		Logger.Info("Set up a3interfaces")
 	}
 
-	// get count of cpus available
-	// set GOMAXPROCS to n - 2, minimum 2
-	// this is to ensure we're using all available cores
+	// Respect cgroup CPU quotas so GOMAXPROCS matches the container's
+	// actual CPU allowance instead of the host's total core count.
+	// Falls back to runtime.NumCPU() when there is no cgroup quota
+	// (bare-metal, macOS, Windows).
+	undo, err := maxprocs.Set(maxprocs.Logger(func(format string, args ...any) {
+		Logger.Info(fmt.Sprintf("automaxprocs: "+format, args...))
+	}))
+	if err != nil {
+		Logger.Warn("automaxprocs failed, falling back to default GOMAXPROCS", "error", err)
+	}
+	_ = undo // ArmA unloads the DLL at process exit; restoring GOMAXPROCS is not needed.
 
-	// get number of CPUs
-	numCPUs := runtime.NumCPU()
-	Logger.Debug("Number of CPUs", "numCPUs", numCPUs)
-
-	// set GOMAXPROCS
-	runtime.GOMAXPROCS(max(numCPUs-2, 1))
+	Logger.Debug("GOMAXPROCS after automaxprocs", "gomaxprocs", runtime.GOMAXPROCS(0), "numCPUs", runtime.NumCPU())
 
 	// Initialize parser (no DB dependency)
 	parserService = parser.NewParser(Logger)

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.40.0
 	go.opentelemetry.io/otel/sdk v1.40.0
 	go.opentelemetry.io/otel/sdk/log v0.16.0
+	go.uber.org/automaxprocs v1.6.0
 	gorm.io/datatypes v1.2.7
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/peterstace/simplefeatures v0.58.0 h1:dTY/+HejhbamHps4hx4eXx5tgXkX5TAM
 github.com/peterstace/simplefeatures v0.58.0/go.mod h1:0QH884YeU4jOeM6Bh7EDdDFyYU1L0I0QONxwwFiknqc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
+github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
@@ -120,6 +122,8 @@ go.opentelemetry.io/otel/trace v1.40.0 h1:WA4etStDttCSYuhwvEa8OP8I5EWu24lkOzp+ZY
 go.opentelemetry.io/otel/trace v1.40.0/go.mod h1:zeAhriXecNGP/s2SEG3+Y8X9ujcJOTqQ5RgdEJcawiA=
 go.opentelemetry.io/proto/otlp v1.9.0 h1:l706jCMITVouPOqEnii2fIAuO3IVGBRPV5ICjceRb/A=
 go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
+go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
+go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=


### PR DESCRIPTION
## Summary
- Add `go.uber.org/automaxprocs` and call `maxprocs.Set` in `init()` instead of the old `GOMAXPROCS(numCPUs - 2)` math.
- `runtime.NumCPU()` returns the host count, not the cgroup quota — on a 24-core host with a 200% Docker CPU limit the old code had Go scheduling 22 OS threads against a 2-core budget, producing exactly the "0 fps for 5-10s" stalls that motivate this PR.

## Why
A user running Pelican (Docker) reported their ArmA server hanging during `:MISSION:SAVE:`. Raising the container CPU limit from 200% to 400% made a 30-minute test pass where 200% had reliably stalled — a textbook CFS-quota oversubscription symptom. The extension's log showed `numCPUs=24` even inside the container, confirming that `runtime.NumCPU()` was returning the host count and that GOMAXPROCS was set to 22. `automaxprocs` reads `/sys/fs/cgroup/cpu.max` (cgroup v2) or the v1 equivalents and sets `GOMAXPROCS` to the actual CPU allowance.

On bare metal / macOS / Windows where there's no cgroup quota, `maxprocs.Set` falls through to `runtime.NumCPU()`, so nothing changes.

## Test plan
- [x] `go build ./cmd/ocap_recorder`
- [x] `go test ./...`
- [ ] Manual (optional): run the binary inside a container with \`--cpus=2\` and confirm the startup log shows \`GOMAXPROCS=2\`