### PR TITLE
fix(parser): handle ACRE multi-knob radio channels and empty frequencies

### DIFF
--- a/internal/parser/parse_chat.go
+++ b/internal/parser/parse_chat.go
@@ -99,7 +99,7 @@ func (p *Parser) ParseRadioEvent(data []string) (core.RadioEvent, error) {
 	radioEvent.RadioType = data[3]
 	radioEvent.StartEnd = data[4]
 
-	channelInt, err := parseIntFromFloat(data[5])
+	channelInt, err := parseRadioChannel(data[5])
 	if err != nil {
 		return radioEvent, fmt.Errorf("error converting channel to int: %w", err)
 	}
@@ -111,9 +111,14 @@ func (p *Parser) ParseRadioEvent(data []string) (core.RadioEvent, error) {
 	}
 	radioEvent.IsAdditional = isAddtl
 
-	freq, err := strconv.ParseFloat(data[7], 64)
-	if err != nil {
-		return radioEvent, fmt.Errorf("error converting freq to float: %w", err)
+	// ACRE multi-knob radios (e.g. AN/PRC-77) may send an empty frequency
+	// when the channel is an array that getPresetChannelField can't resolve.
+	var freq float64
+	if data[7] != "" {
+		freq, err = strconv.ParseFloat(data[7], 64)
+		if err != nil {
+			return radioEvent, fmt.Errorf("error converting freq to float: %w", err)
+		}
 	}
 	radioEvent.Frequency = float32(freq)
 

--- a/internal/parser/parse_chat_test.go
+++ b/internal/parser/parse_chat_test.go
@@ -179,6 +179,28 @@ func TestParseRadioEvent(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:  "ACRE array channel [0,11]",
+			input: []string{"50", "33", "AN/PRC-77", "LR", "Start", "[0,11]", "false", "30.000", "0"},
+			check: func(t *testing.T, e core.RadioEvent) {
+				assert.Equal(t, int8(11), e.Channel, "should extract last element from array channel")
+				assert.Equal(t, "AN/PRC-77", e.Radio)
+			},
+		},
+		{
+			name:  "ACRE single-element array channel [5]",
+			input: []string{"50", "10", "ACRE_PRC343", "SR", "Start", "[5]", "false", "61.500", "0"},
+			check: func(t *testing.T, e core.RadioEvent) {
+				assert.Equal(t, int8(5), e.Channel)
+			},
+		},
+		{
+			name:  "empty frequency defaults to 0",
+			input: []string{"50", "33", "AN/PRC-77", "LR", "Start", "1", "false", "", "0"},
+			check: func(t *testing.T, e core.RadioEvent) {
+				assert.InDelta(t, float32(0), e.Frequency, 0.01)
+			},
+		},
+		{
 			name:    "error: bad channel",
 			input:   []string{"50", "5", "radio", "LR", "START", "abc", "false", "87.5", "code"},
 			wantErr: true,

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -46,21 +46,20 @@ func parseIntFromFloat(s string) (int64, error) {
 // AN/PRC-77 send the channel as [knobA, knobB]; we take the last element as
 // the channel number since it typically represents the selected channel.
 func parseRadioChannel(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+
 	// Fast path: plain scalar
 	if v, err := parseIntFromFloat(s); err == nil {
 		return v, nil
 	}
 
 	// Slow path: SQF array "[0,11]"
-	s = strings.TrimSpace(s)
-	if len(s) >= 2 && s[0] == '[' && s[len(s)-1] == ']' {
+	if strings.HasPrefix(s, "[") && strings.HasSuffix(s, "]") {
 		inner := s[1 : len(s)-1]
 		parts := strings.Split(inner, ",")
-		if len(parts) > 0 {
-			last := strings.TrimSpace(parts[len(parts)-1])
-			if v, err := parseIntFromFloat(last); err == nil {
-				return v, nil
-			}
+		last := strings.TrimSpace(parts[len(parts)-1])
+		if v, err := parseIntFromFloat(last); err == nil {
+			return v, nil
 		}
 	}
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"strings"
 
 	"github.com/OCAP2/extension/v5/pkg/core"
 )
@@ -39,6 +40,32 @@ func parseIntFromFloat(s string) (int64, error) {
 	return int64(f), nil
 }
 
+
+// parseRadioChannel parses a radio channel value that may be either a plain
+// number ("1") or an SQF array ("[0,11]"). ACRE multi-knob radios like the
+// AN/PRC-77 send the channel as [knobA, knobB]; we take the last element as
+// the channel number since it typically represents the selected channel.
+func parseRadioChannel(s string) (int64, error) {
+	// Fast path: plain scalar
+	if v, err := parseIntFromFloat(s); err == nil {
+		return v, nil
+	}
+
+	// Slow path: SQF array "[0,11]"
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 && s[0] == '[' && s[len(s)-1] == ']' {
+		inner := s[1 : len(s)-1]
+		parts := strings.Split(inner, ",")
+		if len(parts) > 0 {
+			last := strings.TrimSpace(parts[len(parts)-1])
+			if v, err := parseIntFromFloat(last); err == nil {
+				return v, nil
+			}
+		}
+	}
+
+	return 0, fmt.Errorf("parseRadioChannel: %q is not a valid channel (expected int or [int,...,int])", s)
+}
 
 // ChatChannels maps ArmA 3 channel numbers to human-readable names.
 var ChatChannels = map[int]string{

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -80,3 +80,45 @@ func TestParseIntFromFloat(t *testing.T) {
 	}
 }
 
+func TestParseRadioChannel(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    int64
+		wantErr bool
+	}{
+		// Scalar values (fast path)
+		{"plain int", "1", 1, false},
+		{"plain zero", "0", 0, false},
+		{"plain float", "5.00", 5, false},
+		{"negative", "-1", -1, false},
+
+		// SQF arrays (slow path) — ACRE multi-knob radios
+		{"array two elements", "[0,11]", 11, false},
+		{"array single element", "[5]", 5, false},
+		{"array three elements", "[1,2,3]", 3, false},
+		{"array with spaces", "[ 0, 11 ]", 11, false},
+		{"array with float", "[0,7.00]", 7, false},
+
+		// Error cases
+		{"non-numeric string", "abc", 0, true},
+		{"array with bad element", "[abc]", 0, true},
+		{"array all bad", "[foo,bar]", 0, true},
+		{"empty string", "", 0, true},
+		{"empty array", "[]", 0, true},
+		{"unclosed bracket", "[1,2", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseRadioChannel(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
## Summary
- `parseRadioChannel` tries scalar parse first, falls back to extracting the last element from an SQF array like `[0,11]`.
- Empty frequency strings (caused by ACRE when the channel is an array) now default to 0 instead of returning a parse error.

## Why
PabbeY's session 2 log (Apr 14, 2.6hr mission with ACRE mod) had **1,332 `:EVENT:RADIO:` errors**, all from the same root cause:

```
error converting channel to int: strconv.ParseFloat: parsing "[0,11]": invalid syntax
```

ACRE's `acre_api_fnc_getRadioChannel` returns `[knobA, knobB]` for multi-knob radios (AN/PRC-77) instead of a plain int. The addon passes this through to the extension unchanged. When that array is also fed to `acre_api_fnc_getPresetChannelField` to resolve the frequency, ACRE returns nil, which becomes an empty string — a second parse failure.

Working event (vanilla radio): `["SEM 52 SL", "LR", "Start", 1, false, "0.000", 0]`
Failing event (ACRE radio):   `["AN/PRC-77", "LR", "Start", [0,11], false, "", 0]`

## Test plan
- [x] `go test ./internal/parser/ -run TestParseRadioEvent` — 11/11 pass
- [x] 3 new test cases: `ACRE array channel [0,11]`, `ACRE single-element array [5]`, `empty frequency defaults to 0`
- [x] `go vet` + full `go test ./internal/...` clean