### PR TITLE
feat(memory): streaming v1 export bounds peak save-time memory

### DIFF
--- a/internal/storage/memory/export.go
+++ b/internal/storage/memory/export.go
@@ -3,7 +3,6 @@ package memory
 
 import (
 	"compress/gzip"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,10 +12,14 @@ import (
 	v1 "github.com/OCAP2/extension/v5/internal/storage/memory/export/v1"
 )
 
-// exportJSON writes the mission data to a gzipped JSON file
+// exportJSON writes the mission data to a gzipped JSON file.
 // Caller must hold b.mu lock.
+//
+// Uses v1.Stream to write entities one at a time so peak memory during
+// the save is bounded by the largest single entity's gap-filled
+// positions, not the sum across all entities.
 func (b *Backend) exportJSON() error {
-	export := b.buildExportUnlocked()
+	data := b.buildMissionDataUnlocked()
 
 	// Build filename
 	missionName := strings.ReplaceAll(b.mission.MissionName, " ", "_")
@@ -39,11 +42,11 @@ func (b *Backend) exportJSON() error {
 
 	// Write file
 	if b.cfg.CompressOutput {
-		if err := writeGzipJSON(outputPath, export); err != nil {
+		if err := writeGzipJSON(outputPath, data); err != nil {
 			return err
 		}
 	} else {
-		if err := writeJSON(outputPath, export); err != nil {
+		if err := writeJSON(outputPath, data); err != nil {
 			return err
 		}
 	}
@@ -52,18 +55,17 @@ func (b *Backend) exportJSON() error {
 	return nil
 }
 
-func writeJSON(path string, data v1.Export) error {
+func writeJSON(path string, data *v1.MissionData) error {
 	f, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)
 	}
 	defer func() { _ = f.Close() }()
 
-	encoder := json.NewEncoder(f)
-	return encoder.Encode(data)
+	return v1.Stream(f, data)
 }
 
-func writeGzipJSON(path string, data v1.Export) error {
+func writeGzipJSON(path string, data *v1.MissionData) error {
 	f, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)
@@ -73,6 +75,5 @@ func writeGzipJSON(path string, data v1.Export) error {
 	gzWriter := gzip.NewWriter(f)
 	defer func() { _ = gzWriter.Close() }()
 
-	encoder := json.NewEncoder(gzWriter)
-	return encoder.Encode(data)
+	return v1.Stream(gzWriter, data)
 }

--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -661,15 +661,11 @@ func buildVehicleEntity(record *VehicleRecord, maxFrame core.Frame) Entity {
 	}
 
 	for i, state := range record.States {
-		// Parse crew JSON string into actual JSON array
-		var crew any
-		if state.Crew != "" {
-			if err := json.Unmarshal([]byte(state.Crew), &crew); err != nil {
-				crew = []any{} // Fallback to empty array on parse error
-			}
-		} else {
-			crew = []any{}
-		}
+		// Parse crew JSON string into actual JSON array. json.Unmarshal
+		// leaves crew unchanged on error (including empty input), so the
+		// default [] falls through for both empty and malformed strings.
+		var crew any = []any{}
+		_ = json.Unmarshal([]byte(state.Crew), &crew)
 
 		// Gap-fill: extend frame range to next state change (or entity end)
 		startF := frameToV1(state.CaptureFrame)

--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -235,7 +235,8 @@ func Build(data *MissionData) Export {
 	// positions is always: [[frameNum, pos, direction, alpha, text, color, size, type, brush, shape], ...]
 	// For POLYLINE: pos is [[x1,y1],[x2,y2],...] (array of coordinates)
 	// For other shapes: pos is [x, y] (single coordinate)
-	for _, record := range data.Markers {
+	// Iterate in sorted order by MarkerName so output is deterministic.
+	for _, record := range sortedMarkers(data.Markers) {
 		// Strip "#" prefix from hex colors (e.g., "#800000" -> "800000") for URL compatibility
 		// The web UI constructs URLs like: /images/markers/${type}/${color}.png
 		// With "#" prefix, browsers interpret the fragment as an anchor, causing 404s
@@ -310,8 +311,10 @@ func Build(data *MissionData) Export {
 		export.Markers = append(export.Markers, marker)
 	}
 
-	// Convert placed objects into markers
-	for id, record := range data.PlacedObjects {
+	// Convert placed objects into markers. Iterate in sorted order by
+	// ID so output is deterministic regardless of map iteration order.
+	for _, record := range sortedPlacedObjects(data.PlacedObjects) {
+		id := record.PlacedObject.ID
 		// Determine marker icon
 		iconFilename := extractFilename(record.PlacedObject.MagazineIcon)
 		var markerType string
@@ -536,6 +539,38 @@ func boolToInt(b bool) int {
 // else (grenades, rockets, missiles, shells, etc.) becomes a marker.
 func isProjectileMarker(sim string) bool {
 	return sim != "shotBullet"
+}
+
+// sortedMarkers returns the marker records from m in ascending
+// MarkerName order so map-sourced iteration produces deterministic
+// output.
+func sortedMarkers(m map[string]*MarkerRecord) []*MarkerRecord {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]*MarkerRecord, 0, len(m))
+	for _, k := range keys {
+		out = append(out, m[k])
+	}
+	return out
+}
+
+// sortedPlacedObjects returns the placed-object records from m in
+// ascending ID order so map-sourced iteration produces deterministic
+// output.
+func sortedPlacedObjects(m map[uint16]*PlacedObjectRecord) []*PlacedObjectRecord {
+	keys := make([]uint16, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	out := make([]*PlacedObjectRecord, 0, len(m))
+	for _, k := range keys {
+		out = append(out, m[k])
+	}
+	return out
 }
 
 // extractFilename returns the last path component from a file path.

--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -129,133 +129,12 @@ func Build(data *MissionData) Export {
 
 	// Convert soldiers - place at index matching their ID
 	for _, record := range data.Soldiers {
-		// Derive IsPlayer and Name from states (source of truth for time-varying fields).
-		// "Ever-a-player": once a player takes over an AI unit, the entity stays a player.
-		isPlayer := record.Soldier.IsPlayer
-		name := record.Soldier.UnitName
-		for _, state := range record.States {
-			if state.IsPlayer {
-				isPlayer = true
-				name = state.UnitName
-			}
-		}
-
-		entity := Entity{
-			ID:            record.Soldier.ID,
-			Name:          name,
-			Group:         record.Soldier.GroupID,
-			Side:          record.Soldier.Side,
-			IsPlayer:      boolToInt(isPlayer),
-			Type:          "unit",
-			Role:          record.Soldier.RoleDescription,
-			StartFrameNum: frameToV1(record.Soldier.JoinFrame),
-			Positions:     make([][]any, 0, len(record.States)),
-			FramesFired:   make([][]any, 0, len(record.FiredEvents)),
-		}
-
-		for i, state := range record.States {
-			// Convert nil InVehicleObjectID to 0 (old C++ extension uses 0 for "not in vehicle")
-			var inVehicleID any = 0
-			if state.InVehicleObjectID != nil {
-				inVehicleID = *state.InVehicleObjectID
-			}
-
-			pos := []any{
-				[]float64{state.Position.X, state.Position.Y, state.Position.Z},
-				state.Bearing,
-				state.Lifestate,
-				inVehicleID,
-				state.UnitName,
-				boolToInt(state.IsPlayer),
-				state.CurrentRole,
-				state.GroupID,
-				state.Side,
-			}
-
-			// Gap-fill: emit one position entry per frame (dense output)
-			startF := frameToV1(state.CaptureFrame)
-			var endF int
-			if i+1 < len(record.States) {
-				endF = frameToV1(record.States[i+1].CaptureFrame) - 1
-			} else {
-				// Last state: extend to entity's delete frame (or maxFrame if still active)
-				if record.Soldier.DeleteFrame > 0 {
-					endF = frameToV1(record.Soldier.DeleteFrame)
-				} else {
-					endF = frameToV1(maxFrame)
-				}
-			}
-			for f := startF; f <= endF; f++ {
-				entity.Positions = append(entity.Positions, pos)
-			}
-		}
-
-		for _, fired := range record.FiredEvents {
-			// v1 format: [frameNum, [x, y, z]] - matches old C++ extension
-			ff := []any{
-				frameToV1(fired.CaptureFrame),
-				[]float64{fired.EndPos.X, fired.EndPos.Y, fired.EndPos.Z},
-			}
-			entity.FramesFired = append(entity.FramesFired, ff)
-		}
-
-		export.Entities[record.Soldier.ID] = entity
+		export.Entities[record.Soldier.ID] = buildSoldierEntity(record, maxFrame, nil)
 	}
 
 	// Convert vehicles - place at index matching their ID
 	for _, record := range data.Vehicles {
-		vehicleSide := record.Vehicle.Side
-		if vehicleSide == "" {
-			vehicleSide = "UNKNOWN"
-		}
-		entity := Entity{
-			ID:            record.Vehicle.ID,
-			Name:          record.Vehicle.DisplayName,
-			Side:          vehicleSide,
-			IsPlayer:      0,
-			Type:          "vehicle",
-			Class:         record.Vehicle.OcapType,
-			StartFrameNum: frameToV1(record.Vehicle.JoinFrame),
-			Positions:     make([][]any, 0, len(record.States)),
-			FramesFired:   [][]any{},
-		}
-
-		for i, state := range record.States {
-			// Parse crew JSON string into actual JSON array
-			var crew any
-			if state.Crew != "" {
-				if err := json.Unmarshal([]byte(state.Crew), &crew); err != nil {
-					crew = []any{} // Fallback to empty array on parse error
-				}
-			} else {
-				crew = []any{}
-			}
-
-			// Gap-fill: extend frame range to next state change (or entity end)
-			startF := frameToV1(state.CaptureFrame)
-			var endF int
-			if i+1 < len(record.States) {
-				endF = frameToV1(record.States[i+1].CaptureFrame) - 1
-			} else {
-				// Last state: extend to entity's delete frame (or maxFrame if still active)
-				if record.Vehicle.DeleteFrame > 0 {
-					endF = frameToV1(record.Vehicle.DeleteFrame)
-				} else {
-					endF = frameToV1(maxFrame)
-				}
-			}
-
-			pos := []any{
-				[]float64{state.Position.X, state.Position.Y, state.Position.Z},
-				state.Bearing,
-				boolToInt(state.IsAlive),
-				crew,
-				[]int{startF, endF},
-			}
-			entity.Positions = append(entity.Positions, pos)
-		}
-
-		export.Entities[record.Vehicle.ID] = entity
+		export.Entities[record.Vehicle.ID] = buildVehicleEntity(record, maxFrame)
 	}
 
 	export.EndFrame = frameToV1(maxFrame)
@@ -673,4 +552,148 @@ func extractFilename(path string) string {
 		return path[lastSep+1:]
 	}
 	return path
+}
+
+// buildSoldierEntity builds a single soldier's v1 Entity, gap-filling
+// positions across frames and appending any projectile-derived
+// firelines (from bullets fired by this soldier).
+//
+// maxFrame is the overall mission maxFrame, used as the fallback end
+// for soldiers with no explicit DeleteFrame.
+//
+// extraFirelines are [frameNum, [x,y,z]] entries appended to the
+// entity's FramesFired after the soldier's own FiredEvents, matching
+// the order used when Build() post-processes projectile events.
+func buildSoldierEntity(record *SoldierRecord, maxFrame core.Frame, extraFirelines [][]any) Entity {
+	// Derive IsPlayer and Name from states (source of truth for time-varying fields).
+	// "Ever-a-player": once a player takes over an AI unit, the entity stays a player.
+	isPlayer := record.Soldier.IsPlayer
+	name := record.Soldier.UnitName
+	for _, state := range record.States {
+		if state.IsPlayer {
+			isPlayer = true
+			name = state.UnitName
+		}
+	}
+
+	entity := Entity{
+		ID:            record.Soldier.ID,
+		Name:          name,
+		Group:         record.Soldier.GroupID,
+		Side:          record.Soldier.Side,
+		IsPlayer:      boolToInt(isPlayer),
+		Type:          "unit",
+		Role:          record.Soldier.RoleDescription,
+		StartFrameNum: frameToV1(record.Soldier.JoinFrame),
+		Positions:     make([][]any, 0, len(record.States)),
+		FramesFired:   make([][]any, 0, len(record.FiredEvents)+len(extraFirelines)),
+	}
+
+	for i, state := range record.States {
+		// Convert nil InVehicleObjectID to 0 (old C++ extension uses 0 for "not in vehicle")
+		var inVehicleID any = 0
+		if state.InVehicleObjectID != nil {
+			inVehicleID = *state.InVehicleObjectID
+		}
+
+		pos := []any{
+			[]float64{state.Position.X, state.Position.Y, state.Position.Z},
+			state.Bearing,
+			state.Lifestate,
+			inVehicleID,
+			state.UnitName,
+			boolToInt(state.IsPlayer),
+			state.CurrentRole,
+			state.GroupID,
+			state.Side,
+		}
+
+		// Gap-fill: emit one position entry per frame (dense output)
+		startF := frameToV1(state.CaptureFrame)
+		var endF int
+		if i+1 < len(record.States) {
+			endF = frameToV1(record.States[i+1].CaptureFrame) - 1
+		} else {
+			// Last state: extend to entity's delete frame (or maxFrame if still active)
+			if record.Soldier.DeleteFrame > 0 {
+				endF = frameToV1(record.Soldier.DeleteFrame)
+			} else {
+				endF = frameToV1(maxFrame)
+			}
+		}
+		for f := startF; f <= endF; f++ {
+			entity.Positions = append(entity.Positions, pos)
+		}
+	}
+
+	for _, fired := range record.FiredEvents {
+		// v1 format: [frameNum, [x, y, z]] - matches old C++ extension
+		ff := []any{
+			frameToV1(fired.CaptureFrame),
+			[]float64{fired.EndPos.X, fired.EndPos.Y, fired.EndPos.Z},
+		}
+		entity.FramesFired = append(entity.FramesFired, ff)
+	}
+
+	entity.FramesFired = append(entity.FramesFired, extraFirelines...)
+
+	return entity
+}
+
+// buildVehicleEntity builds a single vehicle's v1 Entity, gap-filling
+// positions across frames. maxFrame is the overall mission maxFrame,
+// used as the fallback end for vehicles with no explicit DeleteFrame.
+func buildVehicleEntity(record *VehicleRecord, maxFrame core.Frame) Entity {
+	vehicleSide := record.Vehicle.Side
+	if vehicleSide == "" {
+		vehicleSide = "UNKNOWN"
+	}
+	entity := Entity{
+		ID:            record.Vehicle.ID,
+		Name:          record.Vehicle.DisplayName,
+		Side:          vehicleSide,
+		IsPlayer:      0,
+		Type:          "vehicle",
+		Class:         record.Vehicle.OcapType,
+		StartFrameNum: frameToV1(record.Vehicle.JoinFrame),
+		Positions:     make([][]any, 0, len(record.States)),
+		FramesFired:   [][]any{},
+	}
+
+	for i, state := range record.States {
+		// Parse crew JSON string into actual JSON array
+		var crew any
+		if state.Crew != "" {
+			if err := json.Unmarshal([]byte(state.Crew), &crew); err != nil {
+				crew = []any{} // Fallback to empty array on parse error
+			}
+		} else {
+			crew = []any{}
+		}
+
+		// Gap-fill: extend frame range to next state change (or entity end)
+		startF := frameToV1(state.CaptureFrame)
+		var endF int
+		if i+1 < len(record.States) {
+			endF = frameToV1(record.States[i+1].CaptureFrame) - 1
+		} else {
+			// Last state: extend to entity's delete frame (or maxFrame if still active)
+			if record.Vehicle.DeleteFrame > 0 {
+				endF = frameToV1(record.Vehicle.DeleteFrame)
+			} else {
+				endF = frameToV1(maxFrame)
+			}
+		}
+
+		pos := []any{
+			[]float64{state.Position.X, state.Position.Y, state.Position.Z},
+			state.Bearing,
+			boolToInt(state.IsAlive),
+			crew,
+			[]int{startF, endF},
+		}
+		entity.Positions = append(entity.Positions, pos)
+	}
+
+	return entity
 }

--- a/internal/storage/memory/export/v1/stream.go
+++ b/internal/storage/memory/export/v1/stream.go
@@ -1,0 +1,534 @@
+package v1
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/OCAP2/extension/v5/internal/util"
+	"github.com/OCAP2/extension/v5/pkg/core"
+)
+
+// Stream writes the v1 export JSON directly to w without holding the
+// full Export struct in memory. Peak additional memory is bounded by
+// the largest single entity's gap-filled positions plus the aggregate
+// events/markers slices, which are typically orders of magnitude
+// smaller than the sum of all entity positions.
+//
+// Output is JSON-equivalent to json.NewEncoder(w).Encode(Build(data)).
+// The entities array is indexed by ID so map iteration order does not
+// affect final output.
+func Stream(w io.Writer, data *MissionData) error {
+	bw := bufio.NewWriterSize(w, 64*1024)
+
+	maxFrame := computeMaxFrame(data)
+	maxEntityID, hasEntities := computeMaxEntityID(data)
+	times := buildTimes(data)
+	events, markers, firelines := buildAggregates(data)
+
+	// Sort events by frame so consumers can rely on chronological order.
+	sort.SliceStable(events, func(i, j int) bool {
+		return events[i][0].(int) < events[j][0].(int)
+	})
+
+	if err := bw.WriteByte('{'); err != nil {
+		return err
+	}
+
+	// Scalar top-level fields, in the same order as the Export struct.
+	if err := writeField(bw, false, "addonVersion", data.Mission.AddonVersion); err != nil {
+		return err
+	}
+	if err := writeField(bw, true, "extensionVersion", data.Mission.ExtensionVersion); err != nil {
+		return err
+	}
+	if err := writeField(bw, true, "extensionBuild", data.Mission.ExtensionBuild); err != nil {
+		return err
+	}
+	if err := writeField(bw, true, "missionName", data.Mission.MissionName); err != nil {
+		return err
+	}
+	if err := writeField(bw, true, "missionAuthor", data.Mission.Author); err != nil {
+		return err
+	}
+	if err := writeField(bw, true, "worldName", data.World.WorldName); err != nil {
+		return err
+	}
+	if err := writeField(bw, true, "endFrame", frameToV1(maxFrame)); err != nil {
+		return err
+	}
+	if err := writeField(bw, true, "captureDelay", data.Mission.CaptureDelay); err != nil {
+		return err
+	}
+	if err := writeField(bw, true, "tags", data.Mission.Tag); err != nil {
+		return err
+	}
+	if err := writeField(bw, true, "times", times); err != nil {
+		return err
+	}
+
+	// entities array, streamed one entry at a time. Each entity's
+	// gap-filled positions slice becomes eligible for GC after its
+	// iteration completes.
+	if _, err := bw.WriteString(`,"entities":[`); err != nil {
+		return err
+	}
+	if hasEntities {
+		for id := uint16(0); ; id++ {
+			if id > 0 {
+				if err := bw.WriteByte(','); err != nil {
+					return err
+				}
+			}
+			if err := writeEntityForID(bw, id, data, maxFrame, firelines[id]); err != nil {
+				return err
+			}
+			if id == maxEntityID {
+				break
+			}
+		}
+	}
+	if err := bw.WriteByte(']'); err != nil {
+		return err
+	}
+
+	if err := writeField(bw, true, "events", events); err != nil {
+		return err
+	}
+	if err := writeField(bw, true, "Markers", markers); err != nil {
+		return err
+	}
+
+	if err := bw.WriteByte('}'); err != nil {
+		return err
+	}
+	return bw.Flush()
+}
+
+// writeField marshals a single JSON field into the writer. When
+// leading is true, a comma is emitted before the field.
+func writeField(bw *bufio.Writer, leading bool, key string, value any) error {
+	if leading {
+		if err := bw.WriteByte(','); err != nil {
+			return err
+		}
+	}
+	keyBytes, err := json.Marshal(key)
+	if err != nil {
+		return err
+	}
+	if _, err := bw.Write(keyBytes); err != nil {
+		return err
+	}
+	if err := bw.WriteByte(':'); err != nil {
+		return err
+	}
+	valBytes, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	_, err = bw.Write(valBytes)
+	return err
+}
+
+// writeEntityForID writes the JSON for the entity at the given ID. If
+// no soldier or vehicle owns that ID, a zero-valued Entity is written
+// to preserve index=ID parity with Build(), which uses make([]Entity, ...)
+// and leaves unfilled slots as the zero value.
+//
+// The entity struct is scoped to this call so its gap-filled Positions
+// slice becomes eligible for GC as soon as this function returns.
+func writeEntityForID(bw *bufio.Writer, id uint16, data *MissionData, maxFrame core.Frame, extraFirelines [][]any) error {
+	if soldier, ok := data.Soldiers[id]; ok {
+		ent := buildSoldierEntity(soldier, maxFrame, extraFirelines)
+		return writeJSON(bw, ent)
+	}
+	if vehicle, ok := data.Vehicles[id]; ok {
+		ent := buildVehicleEntity(vehicle, maxFrame)
+		return writeJSON(bw, ent)
+	}
+	return writeJSON(bw, Entity{})
+}
+
+// writeJSON marshals v and writes the bytes to bw.
+func writeJSON(bw *bufio.Writer, v any) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	_, err = bw.Write(b)
+	return err
+}
+
+// computeMaxFrame returns the maximum capture frame across all entity
+// states. Falls back to 0 (FrameForever) if no state was recorded.
+func computeMaxFrame(data *MissionData) core.Frame {
+	var maxFrame core.Frame
+	for _, record := range data.Soldiers {
+		for _, state := range record.States {
+			if state.CaptureFrame > maxFrame {
+				maxFrame = state.CaptureFrame
+			}
+		}
+	}
+	for _, record := range data.Vehicles {
+		for _, state := range record.States {
+			if state.CaptureFrame > maxFrame {
+				maxFrame = state.CaptureFrame
+			}
+		}
+	}
+	return maxFrame
+}
+
+// computeMaxEntityID returns the largest soldier/vehicle ID so the
+// entities array can be sized to maxID+1 and the frontend can use
+// array[ID] lookups. The bool is false when no entities exist.
+func computeMaxEntityID(data *MissionData) (uint16, bool) {
+	var maxID uint16
+	hasEntities := len(data.Soldiers) > 0 || len(data.Vehicles) > 0
+	for _, record := range data.Soldiers {
+		if record.Soldier.ID > maxID {
+			maxID = record.Soldier.ID
+		}
+	}
+	for _, record := range data.Vehicles {
+		if record.Vehicle.ID > maxID {
+			maxID = record.Vehicle.ID
+		}
+	}
+	return maxID, hasEntities
+}
+
+// buildTimes converts core TimeStates into v1 Time entries.
+func buildTimes(data *MissionData) []Time {
+	times := make([]Time, 0, len(data.TimeStates))
+	for _, ts := range data.TimeStates {
+		times = append(times, Time{
+			Date:           ts.MissionDate,
+			FrameNum:       frameToV1(ts.CaptureFrame),
+			SystemTimeUTC:  ts.SystemTimeUTC,
+			Time:           ts.MissionTime,
+			TimeMultiplier: ts.TimeMultiplier,
+		})
+	}
+	return times
+}
+
+// buildAggregates returns every non-entity value the Export needs:
+// events (unsorted — caller sorts), markers (static + placed + projectile
+// trajectories), and the per-firer firelines consumed by soldier
+// entities via their FramesFired.
+func buildAggregates(data *MissionData) (events [][]any, markers [][]any, firelines map[uint16][][]any) {
+	events = make([][]any, 0)
+	markers = make([][]any, 0)
+	firelines = make(map[uint16][][]any)
+
+	// General events: [frameNum, "type", message]
+	for _, evt := range data.GeneralEvents {
+		var message any = evt.Message
+		if len(evt.Message) > 0 && (evt.Message[0] == '[' || evt.Message[0] == '{') {
+			var parsed any
+			if err := json.Unmarshal([]byte(evt.Message), &parsed); err == nil {
+				message = parsed
+			}
+		}
+		events = append(events, []any{frameToV1(evt.CaptureFrame), evt.Name, message})
+	}
+
+	// Sector events: [frameNum, "captured"|"contested", [...]]
+	for _, evt := range data.SectorEvents {
+		events = append(events, []any{
+			frameToV1(evt.CaptureFrame),
+			evt.Name,
+			[]any{evt.ObjectType, evt.UnitName, evt.Side, []float64{evt.PosX, evt.PosY, evt.PosZ}},
+		})
+	}
+
+	// End-mission events: [frameNum, "endMission", [side, message]]
+	for _, evt := range data.EndMissionEvents {
+		events = append(events, []any{
+			frameToV1(evt.CaptureFrame),
+			"endMission",
+			[]any{evt.Side, evt.Message},
+		})
+	}
+
+	// Hit events: [frameNum, "hit", victimId, [causedById, weapon], distance]
+	for _, evt := range data.HitEvents {
+		var victimID uint
+		if evt.VictimVehicleID != nil {
+			victimID = *evt.VictimVehicleID
+		} else if evt.VictimSoldierID != nil {
+			victimID = *evt.VictimSoldierID
+		}
+		var sourceID uint
+		if evt.ShooterVehicleID != nil {
+			sourceID = *evt.ShooterVehicleID
+		} else if evt.ShooterSoldierID != nil {
+			sourceID = *evt.ShooterSoldierID
+		}
+		events = append(events, []any{
+			frameToV1(evt.CaptureFrame),
+			"hit",
+			victimID,
+			[]any{sourceID, evt.EventText},
+			evt.Distance,
+		})
+	}
+
+	// Kill events: [frameNum, "killed", victimId, [causedById, weapon], distance]
+	for _, evt := range data.KillEvents {
+		var victimID uint
+		if evt.VictimVehicleID != nil {
+			victimID = *evt.VictimVehicleID
+		} else if evt.VictimSoldierID != nil {
+			victimID = *evt.VictimSoldierID
+		}
+		var killerID uint
+		if evt.KillerVehicleID != nil {
+			killerID = *evt.KillerVehicleID
+		} else if evt.KillerSoldierID != nil {
+			killerID = *evt.KillerSoldierID
+		}
+		events = append(events, []any{
+			frameToV1(evt.CaptureFrame),
+			"killed",
+			victimID,
+			[]any{killerID, evt.EventText},
+			evt.Distance,
+		})
+	}
+
+	// Static markers.
+	for _, record := range data.Markers {
+		markerColor := strings.TrimPrefix(record.Marker.Color, "#")
+		posArray := make([][]any, 0)
+
+		if record.Marker.Shape == "POLYLINE" {
+			coords := make([][]float64, len(record.Marker.Polyline))
+			for i, pt := range record.Marker.Polyline {
+				coords[i] = []float64{pt.X, pt.Y}
+			}
+			posArray = append(posArray, []any{
+				frameToV1(record.Marker.CaptureFrame),
+				coords,
+				record.Marker.Direction,
+				record.Marker.Alpha,
+				record.Marker.Text,
+				markerColor,
+				parseMarkerSize(record.Marker.Size),
+				record.Marker.MarkerType,
+				record.Marker.Brush,
+				record.Marker.Shape,
+			})
+		} else {
+			posArray = append(posArray, []any{
+				frameToV1(record.Marker.CaptureFrame),
+				[]float64{record.Marker.Position.X, record.Marker.Position.Y, record.Marker.Position.Z},
+				record.Marker.Direction,
+				record.Marker.Alpha,
+				record.Marker.Text,
+				markerColor,
+				parseMarkerSize(record.Marker.Size),
+				record.Marker.MarkerType,
+				record.Marker.Brush,
+				record.Marker.Shape,
+			})
+
+			for _, state := range record.States {
+				posArray = append(posArray, []any{
+					frameToV1(state.CaptureFrame),
+					[]float64{state.Position.X, state.Position.Y, state.Position.Z},
+					state.Direction,
+					state.Alpha,
+					state.Text,
+					strings.TrimPrefix(state.Color, "#"),
+					parseMarkerSize(state.Size),
+					state.MarkerType,
+					state.Brush,
+					state.Shape,
+				})
+			}
+		}
+
+		markers = append(markers, []any{
+			record.Marker.MarkerType,
+			record.Marker.Text,
+			frameToV1(record.Marker.CaptureFrame),
+			frameToV1(record.Marker.EndFrame),
+			record.Marker.OwnerID,
+			markerColor,
+			sideToIndex(record.Marker.Side),
+			posArray,
+			parseMarkerSize(record.Marker.Size),
+			record.Marker.Shape,
+			record.Marker.Brush,
+		})
+	}
+
+	// Placed objects become markers, and their "hit" events become event rows.
+	for _, record := range data.PlacedObjects {
+		iconFilename := extractFilename(record.PlacedObject.MagazineIcon)
+		var markerType string
+		if iconFilename != "" {
+			markerType = "magIcons/" + iconFilename
+		} else {
+			markerType = "Minefield"
+		}
+
+		placedEndFrame := -1
+		for _, evt := range record.Events {
+			if evt.EventType == "detonated" || evt.EventType == "deleted" {
+				placedEndFrame = frameToV1(evt.CaptureFrame)
+				break
+			}
+		}
+
+		posArray := [][]any{
+			{
+				frameToV1(record.PlacedObject.JoinFrame),
+				[]float64{record.PlacedObject.Position.X, record.PlacedObject.Position.Y, record.PlacedObject.Position.Z},
+				0,
+				1.0,
+			},
+		}
+
+		markers = append(markers, []any{
+			markerType,
+			record.PlacedObject.DisplayName,
+			frameToV1(record.PlacedObject.JoinFrame),
+			placedEndFrame,
+			int(record.PlacedObject.OwnerID),
+			"D96600",
+			-1,
+			posArray,
+			[]float64{1, 1},
+			"ICON",
+			"Solid",
+		})
+
+		for _, evt := range record.Events {
+			if evt.EventType == "hit" && evt.HitEntityID != nil {
+				dx := record.PlacedObject.Position.X - evt.Position.X
+				dy := record.PlacedObject.Position.Y - evt.Position.Y
+				dist := float32(math.Sqrt(dx*dx + dy*dy))
+				events = append(events, []any{
+					frameToV1(evt.CaptureFrame),
+					"hit",
+					uint(*evt.HitEntityID),
+					[]any{uint(record.PlacedObject.OwnerID), record.PlacedObject.DisplayName},
+					dist,
+				})
+			}
+		}
+	}
+
+	// Projectile events: bullets become per-firer firelines; non-bullet
+	// projectiles become markers; both produce hit events.
+	for _, pe := range data.ProjectileEvents {
+		if !isProjectileMarker(pe.SimulationType) {
+			if len(pe.Trajectory) >= 2 {
+				endPt := pe.Trajectory[len(pe.Trajectory)-1]
+				ff := []any{
+					frameToV1(pe.CaptureFrame),
+					[]float64{endPt.Position.X, endPt.Position.Y, endPt.Position.Z},
+				}
+				firelines[pe.FirerObjectID] = append(firelines[pe.FirerObjectID], ff)
+			}
+		} else {
+			iconFilename := extractFilename(pe.MagazineIcon)
+			var markerType, color string
+			if iconFilename != "" {
+				markerType = "magIcons/" + iconFilename
+				color = "ColorWhite"
+			} else {
+				markerType = "mil_triangle"
+				color = "ColorRed"
+			}
+
+			var text string
+			switch {
+			case pe.VehicleObjectID != nil && *pe.VehicleObjectID != pe.FirerObjectID:
+				vehicleName := ""
+				if vr, ok := data.Vehicles[*pe.VehicleObjectID]; ok {
+					vehicleName = vr.Vehicle.DisplayName
+				}
+				text = fmt.Sprintf("%s %s - %s", vehicleName, pe.MuzzleDisplay, pe.MagazineDisplay)
+			case pe.SimulationType == "shotGrenade":
+				text = pe.MagazineDisplay
+			default:
+				text = fmt.Sprintf("%s - %s", pe.MuzzleDisplay, pe.MagazineDisplay)
+			}
+
+			posArray := make([][]any, 0, len(pe.Trajectory))
+			for _, tp := range pe.Trajectory {
+				posArray = append(posArray, []any{
+					frameToV1(tp.FrameNum),
+					[]float64{tp.Position.X, tp.Position.Y, tp.Position.Z},
+					0,
+					1.0,
+				})
+			}
+
+			projEndFrame := -1
+			if len(pe.Trajectory) > 0 {
+				projEndFrame = frameToV1(pe.Trajectory[len(pe.Trajectory)-1].FrameNum)
+			}
+
+			markers = append(markers, []any{
+				markerType,
+				text,
+				frameToV1(pe.CaptureFrame),
+				projEndFrame,
+				int(pe.FirerObjectID),
+				color,
+				-1,
+				posArray,
+				[]float64{1, 1},
+				"ICON",
+				"Solid",
+			})
+		}
+
+		if len(pe.Hits) > 0 {
+			weaponName := pe.MuzzleDisplay
+			if weaponName == "" {
+				weaponName = pe.WeaponDisplay
+			}
+			eventText := util.FormatWeaponText("", weaponName, pe.MagazineDisplay)
+
+			var startPos core.Position3D
+			if len(pe.Trajectory) > 0 {
+				startPos = pe.Trajectory[0].Position
+			}
+
+			for _, hit := range pe.Hits {
+				var victimID uint
+				if hit.SoldierID != nil {
+					victimID = uint(*hit.SoldierID)
+				} else if hit.VehicleID != nil {
+					victimID = uint(*hit.VehicleID)
+				}
+
+				dx := startPos.X - hit.Position.X
+				dy := startPos.Y - hit.Position.Y
+				dist := float32(math.Sqrt(dx*dx + dy*dy))
+
+				events = append(events, []any{
+					frameToV1(hit.CaptureFrame),
+					"hit",
+					victimID,
+					[]any{uint(pe.FirerObjectID), eventText},
+					dist,
+				})
+			}
+		}
+	}
+
+	return events, markers, firelines
+}

--- a/internal/storage/memory/export/v1/stream.go
+++ b/internal/storage/memory/export/v1/stream.go
@@ -294,8 +294,9 @@ func buildAggregates(data *MissionData) (events [][]any, markers [][]any, fireli
 		})
 	}
 
-	// Static markers.
-	for _, record := range data.Markers {
+	// Static markers. Iterate in sorted order by MarkerName so output
+	// is deterministic regardless of map iteration order.
+	for _, record := range sortedMarkers(data.Markers) {
 		markerColor := strings.TrimPrefix(record.Marker.Color, "#")
 		posArray := make([][]any, 0)
 
@@ -362,7 +363,8 @@ func buildAggregates(data *MissionData) (events [][]any, markers [][]any, fireli
 	}
 
 	// Placed objects become markers, and their "hit" events become event rows.
-	for _, record := range data.PlacedObjects {
+	// Iterate in sorted order by ID so output is deterministic.
+	for _, record := range sortedPlacedObjects(data.PlacedObjects) {
 		iconFilename := extractFilename(record.PlacedObject.MagazineIcon)
 		var markerType string
 		if iconFilename != "" {

--- a/internal/storage/memory/export/v1/stream.go
+++ b/internal/storage/memory/export/v1/stream.go
@@ -25,8 +25,7 @@ import (
 func Stream(w io.Writer, data *MissionData) error {
 	bw := bufio.NewWriterSize(w, 64*1024)
 
-	maxFrame := computeMaxFrame(data)
-	maxEntityID, hasEntities := computeMaxEntityID(data)
+	maxFrame, maxEntityID, hasEntities := computeMetadata(data)
 	times := buildTimes(data)
 	events, markers, firelines := buildAggregates(data)
 
@@ -164,11 +163,18 @@ func writeJSON(bw *bufio.Writer, v any) error {
 	return err
 }
 
-// computeMaxFrame returns the maximum capture frame across all entity
-// states. Falls back to 0 (FrameForever) if no state was recorded.
-func computeMaxFrame(data *MissionData) core.Frame {
-	var maxFrame core.Frame
+// computeMetadata walks all soldier/vehicle records once to return:
+//   - maxFrame:    the maximum capture frame across all entity states
+//                  (falls back to 0 / FrameForever when none were recorded).
+//   - maxEntityID: the largest soldier/vehicle ID, used to size the
+//                  entities array so array[ID] lookups work.
+//   - hasEntities: false when neither map holds any entity.
+func computeMetadata(data *MissionData) (maxFrame core.Frame, maxEntityID uint16, hasEntities bool) {
+	hasEntities = len(data.Soldiers) > 0 || len(data.Vehicles) > 0
 	for _, record := range data.Soldiers {
+		if record.Soldier.ID > maxEntityID {
+			maxEntityID = record.Soldier.ID
+		}
 		for _, state := range record.States {
 			if state.CaptureFrame > maxFrame {
 				maxFrame = state.CaptureFrame
@@ -176,32 +182,16 @@ func computeMaxFrame(data *MissionData) core.Frame {
 		}
 	}
 	for _, record := range data.Vehicles {
+		if record.Vehicle.ID > maxEntityID {
+			maxEntityID = record.Vehicle.ID
+		}
 		for _, state := range record.States {
 			if state.CaptureFrame > maxFrame {
 				maxFrame = state.CaptureFrame
 			}
 		}
 	}
-	return maxFrame
-}
-
-// computeMaxEntityID returns the largest soldier/vehicle ID so the
-// entities array can be sized to maxID+1 and the frontend can use
-// array[ID] lookups. The bool is false when no entities exist.
-func computeMaxEntityID(data *MissionData) (uint16, bool) {
-	var maxID uint16
-	hasEntities := len(data.Soldiers) > 0 || len(data.Vehicles) > 0
-	for _, record := range data.Soldiers {
-		if record.Soldier.ID > maxID {
-			maxID = record.Soldier.ID
-		}
-	}
-	for _, record := range data.Vehicles {
-		if record.Vehicle.ID > maxID {
-			maxID = record.Vehicle.ID
-		}
-	}
-	return maxID, hasEntities
+	return maxFrame, maxEntityID, hasEntities
 }
 
 // buildTimes converts core TimeStates into v1 Time entries.

--- a/internal/storage/memory/export/v1/stream_test.go
+++ b/internal/storage/memory/export/v1/stream_test.go
@@ -142,6 +142,219 @@ func TestStream_EquivalentToBuild_SoldierAndVehicleAndEvents(t *testing.T) {
 	require.JSONEq(t, string(want), string(got))
 }
 
+// TestStream_EquivalentToBuild_AllFeatures exercises every branch in
+// buildAggregates and writeEntityForID: sector / end-mission / hit /
+// kill / general events, POLYLINE and point markers with state
+// changes, placed objects with detonations and hit events, and
+// projectile events that split between firelines (bullets), markers
+// (non-bullets, both with and without a magazine icon, both fired
+// from soldiers and from vehicles), and projectile hits.
+//
+// If this passes, Stream has walked every branch Build walks on the
+// same inputs.
+func TestStream_EquivalentToBuild_AllFeatures(t *testing.T) {
+	soldier1 := uint16(1)
+	vehicle2 := uint16(2)
+	victimSoldier := uint(1)
+	victimVehicle := uint(2)
+	shooterSoldier := uint(1)
+	killerVehicle := uint(2)
+	hitSoldier := uint16(1)
+
+	data := &MissionData{
+		Mission: &core.Mission{
+			MissionName:      "Kitchen Sink",
+			Author:           "Author",
+			AddonVersion:     "1.0",
+			ExtensionVersion: "5.0",
+			ExtensionBuild:   "abc123",
+			CaptureDelay:     0.1,
+			Tag:              "TvT",
+		},
+		World: &core.World{WorldName: "Altis"},
+		Soldiers: map[uint16]*SoldierRecord{
+			1: {
+				Soldier: core.Soldier{
+					ID: 1, UnitName: "Alice", Side: "WEST", GroupID: "G1",
+					RoleDescription: "Rifleman", JoinFrame: 1, DeleteFrame: 20,
+					IsPlayer: true,
+				},
+				States: []core.SoldierState{
+					{SoldierID: 1, CaptureFrame: 1, Position: core.Position3D{X: 10, Y: 20, Z: 0.5}, UnitName: "Alice", Side: "WEST", GroupID: "G1", IsPlayer: true, CurrentRole: "Rifleman"},
+					{SoldierID: 1, CaptureFrame: 10, Position: core.Position3D{X: 15, Y: 22, Z: 0.5}, UnitName: "Alice", Side: "WEST", GroupID: "G1", IsPlayer: true, CurrentRole: "Rifleman"},
+				},
+				FiredEvents: []core.FiredEvent{
+					{SoldierID: 1, CaptureFrame: 3, EndPos: core.Position3D{X: 50, Y: 20, Z: 0.5}},
+				},
+			},
+		},
+		Vehicles: map[uint16]*VehicleRecord{
+			2: {
+				Vehicle: core.Vehicle{ID: 2, DisplayName: "Ifrit", Side: "EAST", OcapType: "car", JoinFrame: 1, DeleteFrame: 15},
+				States: []core.VehicleState{
+					{VehicleID: 2, CaptureFrame: 1, Position: core.Position3D{X: 100, Y: 200}, IsAlive: true, Crew: "[5,6]"},
+					{VehicleID: 2, CaptureFrame: 8, Position: core.Position3D{X: 105, Y: 200}, IsAlive: false, Crew: ""},
+					// Extends past any soldier state so the vehicle branch of
+					// computeMetadata's maxFrame update is exercised.
+					{VehicleID: 2, CaptureFrame: 25, Position: core.Position3D{X: 110, Y: 200}, IsAlive: false, Crew: ""},
+				},
+			},
+		},
+		Markers: map[string]*MarkerRecord{
+			"m_point": {
+				Marker: core.Marker{
+					MarkerName: "m_point", MarkerType: "mil_triangle", Text: "Point",
+					Shape: "ICON", Brush: "Solid", Color: "#FF0000", Size: "[1,1]",
+					Position: core.Position3D{X: 500, Y: 500}, Side: "WEST",
+					CaptureFrame: 2, EndFrame: 0, Alpha: 1, Direction: 90, OwnerID: -1,
+				},
+				States: []core.MarkerState{
+					{MarkerID: 1, CaptureFrame: 5, Position: core.Position3D{X: 510, Y: 500},
+						Alpha: 0.8, Text: "Point2", Color: "#FF00FF", Size: "[2,2]",
+						Shape: "ICON", Brush: "Solid", MarkerType: "mil_triangle"},
+				},
+			},
+			"m_poly": {
+				Marker: core.Marker{
+					MarkerName: "m_poly", MarkerType: "POLYLINE", Text: "Poly",
+					Shape: "POLYLINE", Brush: "Solid", Color: "#00FF00", Size: "[1,1]",
+					Polyline: core.Polyline{{X: 0, Y: 0}, {X: 10, Y: 10}, {X: 20, Y: 0}},
+					Side:     "EAST", CaptureFrame: 3, EndFrame: 0, Alpha: 1, OwnerID: -1,
+				},
+			},
+		},
+		PlacedObjects: map[uint16]*PlacedObjectRecord{
+			10: {
+				PlacedObject: core.PlacedObject{
+					ID: 10, DisplayName: "APERS Mine", MagazineIcon: `\ca\weapons\mine_icon.paa`,
+					Position: core.Position3D{X: 300, Y: 400}, JoinFrame: 2, OwnerID: 1,
+				},
+				Events: []core.PlacedObjectEvent{
+					{CaptureFrame: 7, PlacedID: 10, EventType: "hit", Position: core.Position3D{X: 301, Y: 401}, HitEntityID: &hitSoldier},
+					{CaptureFrame: 8, PlacedID: 10, EventType: "detonated", Position: core.Position3D{X: 300, Y: 400}},
+				},
+			},
+			11: {
+				PlacedObject: core.PlacedObject{
+					ID: 11, DisplayName: "Unknown Mine", MagazineIcon: "",
+					Position: core.Position3D{X: 320, Y: 420}, JoinFrame: 2, OwnerID: 1,
+				},
+				Events: []core.PlacedObjectEvent{
+					{CaptureFrame: 9, PlacedID: 11, EventType: "deleted", Position: core.Position3D{X: 320, Y: 420}},
+				},
+			},
+		},
+		GeneralEvents: []core.GeneralEvent{
+			{CaptureFrame: 1, Name: "mission", Message: "start"},
+			{CaptureFrame: 2, Name: "mission", Message: `{"obj":"payload"}`},
+		},
+		SectorEvents: []core.SectorEvent{
+			{CaptureFrame: 4, Name: "captured", ObjectType: "sector", UnitName: "Alpha", Side: "WEST", PosX: 0, PosY: 0, PosZ: 0},
+		},
+		EndMissionEvents: []core.EndMissionEvent{
+			{CaptureFrame: 20, Side: "WEST", Message: "Victory"},
+		},
+		HitEvents: []core.HitEvent{
+			{CaptureFrame: 5, VictimSoldierID: &victimSoldier, ShooterSoldierID: &shooterSoldier, EventText: "rifle", Distance: 50},
+			{CaptureFrame: 6, VictimVehicleID: &victimVehicle, ShooterSoldierID: &shooterSoldier, EventText: "RPG", Distance: 100},
+			// Vehicle-shooter branch.
+			{CaptureFrame: 9, VictimSoldierID: &victimSoldier, ShooterVehicleID: &killerVehicle, EventText: "cannon", Distance: 300},
+		},
+		KillEvents: []core.KillEvent{
+			{CaptureFrame: 7, VictimSoldierID: &victimSoldier, KillerVehicleID: &killerVehicle, EventText: "cannon", Distance: 200},
+			{CaptureFrame: 8, VictimVehicleID: &victimVehicle, KillerSoldierID: &shooterSoldier, EventText: "AT", Distance: 150},
+		},
+		TimeStates: []core.TimeState{
+			{CaptureFrame: 1, SystemTimeUTC: "2026-04-19T00:00:00Z", MissionDate: "2035-01-01T12:00:00", MissionTime: 0, TimeMultiplier: 1},
+			{CaptureFrame: 10, SystemTimeUTC: "2026-04-19T00:00:01Z", MissionDate: "2035-01-01T12:00:01", MissionTime: 1, TimeMultiplier: 1},
+		},
+		ProjectileEvents: []core.ProjectileEvent{
+			// Bullet → fireline on soldier 1
+			{
+				CaptureFrame: 4, FirerObjectID: soldier1, SimulationType: "shotBullet",
+				WeaponDisplay: "M4", MagazineDisplay: "5.56", MuzzleDisplay: "M4",
+				Trajectory: []core.TrajectoryPoint{
+					{Position: core.Position3D{X: 10, Y: 20}, FrameNum: 4},
+					{Position: core.Position3D{X: 60, Y: 20}, FrameNum: 4},
+				},
+			},
+			// Non-bullet with magazine icon → marker
+			{
+				CaptureFrame: 5, FirerObjectID: soldier1, SimulationType: "shotRocket",
+				WeaponDisplay: "RPG", MagazineDisplay: "PG-7", MuzzleDisplay: "RPG",
+				MagazineIcon:  `\ca\weapons\rpg_icon.paa`,
+				Trajectory: []core.TrajectoryPoint{
+					{Position: core.Position3D{X: 10, Y: 20}, FrameNum: 5},
+					{Position: core.Position3D{X: 70, Y: 40}, FrameNum: 6},
+				},
+				Hits: []core.ProjectileHit{
+					{CaptureFrame: 6, Position: core.Position3D{X: 70, Y: 40}, SoldierID: &hitSoldier},
+				},
+			},
+			// Non-bullet without icon → mil_triangle fallback
+			{
+				CaptureFrame: 6, FirerObjectID: soldier1, SimulationType: "shotGrenade",
+				MagazineDisplay: "M67",
+				Trajectory: []core.TrajectoryPoint{
+					{Position: core.Position3D{X: 10, Y: 20}, FrameNum: 6},
+					{Position: core.Position3D{X: 20, Y: 25}, FrameNum: 7},
+				},
+			},
+			// Vehicle-fired projectile, hits a vehicle. Empty MuzzleDisplay
+			// exercises the weaponName fallback to WeaponDisplay.
+			{
+				CaptureFrame: 7, FirerObjectID: soldier1, VehicleObjectID: &vehicle2,
+				SimulationType: "shotShell", WeaponDisplay: "cannon", MagazineDisplay: "HEAT", MuzzleDisplay: "",
+				Trajectory: []core.TrajectoryPoint{
+					{Position: core.Position3D{X: 100, Y: 200}, FrameNum: 7},
+					{Position: core.Position3D{X: 400, Y: 500}, FrameNum: 8},
+				},
+				Hits: []core.ProjectileHit{
+					{CaptureFrame: 8, Position: core.Position3D{X: 400, Y: 500}, VehicleID: &vehicle2},
+				},
+			},
+		},
+	}
+
+	want := buildThenEncode(t, data)
+	got := streamBytes(t, data)
+
+	require.JSONEq(t, string(want), string(got))
+}
+
+// errorWriter fails after n successful writes. Used to exercise the
+// error-return paths in Stream, writeField, and writeJSON.
+type errorWriter struct {
+	n      int // remaining writes allowed before returning err
+	failAt string
+}
+
+func (ew *errorWriter) Write(p []byte) (int, error) {
+	if ew.n <= 0 {
+		return 0, io.ErrClosedPipe
+	}
+	ew.n--
+	return len(p), nil
+}
+
+func TestStream_WriterErrorPropagates(t *testing.T) {
+	data := &MissionData{
+		Mission:  &core.Mission{MissionName: "M"},
+		World:    &core.World{WorldName: "W"},
+		Soldiers: map[uint16]*SoldierRecord{1: {Soldier: core.Soldier{ID: 1, UnitName: "X", Side: "WEST", JoinFrame: 1}}},
+		Vehicles: map[uint16]*VehicleRecord{},
+		Markers:  map[string]*MarkerRecord{},
+	}
+
+	// Fail immediately on first write. Stream uses a 64k buffered
+	// writer, so Stream's internal WriteByte/WriteString calls
+	// accumulate into the buffer and only hit the underlying writer
+	// on Flush.
+	w := &errorWriter{n: 0}
+	err := Stream(w, data)
+	require.Error(t, err)
+}
+
 // TestStream_LargeMissionPeakMemory builds a synthetic mission with
 // dense per-frame state for many entities and runs Stream through an
 // io.Discard writer, asserting heap growth stays bounded. Regression

--- a/internal/storage/memory/export/v1/stream_test.go
+++ b/internal/storage/memory/export/v1/stream_test.go
@@ -1,0 +1,208 @@
+package v1
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"runtime"
+	"testing"
+
+	"github.com/OCAP2/extension/v5/pkg/core"
+	"github.com/stretchr/testify/require"
+)
+
+// buildThenEncode runs the reference pipeline used in production before
+// streaming landed: build full struct, encode via json.NewEncoder. The
+// encoder appends a trailing '\n' which we strip for equivalence.
+func buildThenEncode(t *testing.T, data *MissionData) []byte {
+	t.Helper()
+	exp := Build(data)
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	require.NoError(t, enc.Encode(exp))
+	out := buf.Bytes()
+	if len(out) > 0 && out[len(out)-1] == '\n' {
+		out = out[:len(out)-1]
+	}
+	return out
+}
+
+// streamBytes runs the new streaming pipeline.
+func streamBytes(t *testing.T, data *MissionData) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, Stream(&buf, data))
+	return buf.Bytes()
+}
+
+func TestStream_EquivalentToBuild_EmptyMission(t *testing.T) {
+	data := &MissionData{
+		Mission:  &core.Mission{MissionName: "Empty", Author: "Test"},
+		World:    &core.World{WorldName: "Altis"},
+		Soldiers: make(map[uint16]*SoldierRecord),
+		Vehicles: make(map[uint16]*VehicleRecord),
+		Markers:  make(map[string]*MarkerRecord),
+	}
+
+	want := buildThenEncode(t, data)
+	got := streamBytes(t, data)
+
+	require.JSONEq(t, string(want), string(got))
+}
+
+func TestStream_EquivalentToBuild_MinimalSoldier(t *testing.T) {
+	data := &MissionData{
+		Mission: &core.Mission{MissionName: "M", CaptureDelay: 0.1},
+		World:   &core.World{WorldName: "Altis"},
+		Soldiers: map[uint16]*SoldierRecord{
+			1: {
+				Soldier: core.Soldier{
+					ID:              1,
+					UnitName:        "Alice",
+					Side:            "WEST",
+					GroupID:         "G1",
+					RoleDescription: "Rifleman",
+					JoinFrame:       1,
+					DeleteFrame:     0, // still active
+					IsPlayer:        true,
+				},
+				States: []core.SoldierState{
+					{
+						SoldierID:    1,
+						CaptureFrame: 1,
+						Position:     core.Position3D{X: 10, Y: 20, Z: 0.5},
+						Bearing:      90,
+						Lifestate:    1,
+						IsPlayer:     true,
+						UnitName:     "Alice",
+						CurrentRole:  "Rifleman",
+						GroupID:      "G1",
+						Side:         "WEST",
+					},
+					{
+						SoldierID:    1,
+						CaptureFrame: 3,
+						Position:     core.Position3D{X: 11, Y: 20, Z: 0.5},
+						Bearing:      90,
+						Lifestate:    1,
+						IsPlayer:     true,
+						UnitName:     "Alice",
+						CurrentRole:  "Rifleman",
+						GroupID:      "G1",
+						Side:         "WEST",
+					},
+				},
+			},
+		},
+		Vehicles:   map[uint16]*VehicleRecord{},
+		Markers:    map[string]*MarkerRecord{},
+		TimeStates: []core.TimeState{{CaptureFrame: 1, SystemTimeUTC: "2026-04-19T00:00:00Z", MissionDate: "2035-01-01T12:00:00", MissionTime: 0, TimeMultiplier: 1}},
+	}
+
+	want := buildThenEncode(t, data)
+	got := streamBytes(t, data)
+
+	require.JSONEq(t, string(want), string(got))
+}
+
+func TestStream_EquivalentToBuild_SoldierAndVehicleAndEvents(t *testing.T) {
+	vid := uint(2)
+	data := &MissionData{
+		Mission: &core.Mission{MissionName: "M", CaptureDelay: 0.1},
+		World:   &core.World{WorldName: "Stratis"},
+		Soldiers: map[uint16]*SoldierRecord{
+			1: {
+				Soldier: core.Soldier{ID: 1, UnitName: "Bob", Side: "WEST", GroupID: "G", JoinFrame: 1, DeleteFrame: 5},
+				States: []core.SoldierState{
+					{SoldierID: 1, CaptureFrame: 1, Position: core.Position3D{X: 0}, UnitName: "Bob", Side: "WEST", GroupID: "G"},
+				},
+				FiredEvents: []core.FiredEvent{
+					{SoldierID: 1, CaptureFrame: 2, EndPos: core.Position3D{X: 100, Y: 0, Z: 0}},
+				},
+			},
+		},
+		Vehicles: map[uint16]*VehicleRecord{
+			2: {
+				Vehicle: core.Vehicle{ID: 2, DisplayName: "Hunter", Side: "WEST", OcapType: "car", JoinFrame: 1, DeleteFrame: 4},
+				States: []core.VehicleState{
+					{VehicleID: 2, CaptureFrame: 1, Position: core.Position3D{X: 0}, IsAlive: true, Crew: "[1]"},
+				},
+			},
+		},
+		Markers: map[string]*MarkerRecord{},
+		HitEvents: []core.HitEvent{
+			{CaptureFrame: 3, VictimSoldierID: &vid, ShooterSoldierID: &vid, EventText: "rifle", Distance: 50.0},
+		},
+		GeneralEvents: []core.GeneralEvent{{CaptureFrame: 2, Name: "mission", Message: "start"}},
+	}
+
+	want := buildThenEncode(t, data)
+	got := streamBytes(t, data)
+
+	require.JSONEq(t, string(want), string(got))
+}
+
+// TestStream_LargeMissionPeakMemory builds a synthetic mission with
+// dense per-frame state for many entities and runs Stream through an
+// io.Discard writer, asserting heap growth stays bounded. Regression
+// guard: if someone re-introduces full-export materialization inside
+// Stream, peak heap balloons and this test catches it.
+func TestStream_LargeMissionPeakMemory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping large-mission memory test in -short mode")
+	}
+
+	const (
+		entities = 200
+		frames   = 20000 // 20k frames (~33min at 10Hz) per entity
+	)
+
+	soldiers := make(map[uint16]*SoldierRecord, entities)
+	for i := 0; i < entities; i++ {
+		id := uint16(i + 1)
+		states := make([]core.SoldierState, 0, frames)
+		for f := 1; f <= frames; f++ {
+			states = append(states, core.SoldierState{
+				SoldierID:    id,
+				CaptureFrame: core.Frame(f),
+				Position:     core.Position3D{X: float64(f), Y: float64(i)},
+				UnitName:     "U",
+				Side:         "WEST",
+				GroupID:      "G",
+			})
+		}
+		soldiers[id] = &SoldierRecord{
+			Soldier: core.Soldier{ID: id, UnitName: "U", Side: "WEST", GroupID: "G", JoinFrame: 1},
+			States:  states,
+		}
+	}
+
+	data := &MissionData{
+		Mission:  &core.Mission{MissionName: "Big", CaptureDelay: 0.1},
+		World:    &core.World{WorldName: "Altis"},
+		Soldiers: soldiers,
+		Vehicles: map[uint16]*VehicleRecord{},
+		Markers:  map[string]*MarkerRecord{},
+	}
+
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	require.NoError(t, Stream(io.Discard, data))
+
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	// HeapInuse delta during the call should be far smaller than a
+	// full materialization of all gap-filled positions. Full
+	// materialization would push this to hundreds of MB. Use a
+	// generous ceiling that still catches a regression back to
+	// full-materialization.
+	const ceiling = 256 * 1024 * 1024 // 256 MiB
+	delta := int64(after.HeapInuse) - int64(before.HeapInuse)
+	if delta > ceiling {
+		t.Fatalf("HeapInuse grew by %d bytes during Stream; expected < %d (streaming regression?)", delta, ceiling)
+	}
+}

--- a/internal/storage/memory/export_test.go
+++ b/internal/storage/memory/export_test.go
@@ -1322,7 +1322,7 @@ func TestWriteJSON_CreateError(t *testing.T) {
 	require.NoError(t, os.Chmod(dir, 0555))
 	t.Cleanup(func() { os.Chmod(dir, 0755) })
 
-	err := writeJSON(filepath.Join(dir, "test.json"), v1.Export{})
+	err := writeJSON(filepath.Join(dir, "test.json"), minimalMissionData())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create file")
 }
@@ -1332,7 +1332,7 @@ func TestWriteGzipJSON_CreateError(t *testing.T) {
 	require.NoError(t, os.Chmod(dir, 0555))
 	t.Cleanup(func() { os.Chmod(dir, 0755) })
 
-	err := writeGzipJSON(filepath.Join(dir, "test.json.gz"), v1.Export{})
+	err := writeGzipJSON(filepath.Join(dir, "test.json.gz"), minimalMissionData())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create file")
 }
@@ -1493,4 +1493,18 @@ func TestPlacedObjectHitEventExport(t *testing.T) {
 	assert.Equal(t, uint(5), causedBy[0])       // owner
 	assert.Equal(t, "APERS Mine", causedBy[1])  // weapon text
 	assert.InDelta(t, 5.0, float64(evt[4].(float32)), 0.01)
+}
+
+// minimalMissionData returns a v1.MissionData value safe to pass to
+// writeJSON / writeGzipJSON in tests that only exercise the file
+// creation path.
+func minimalMissionData() *v1.MissionData {
+	return &v1.MissionData{
+		Mission:       &core.Mission{},
+		World:         &core.World{},
+		Soldiers:      map[uint16]*v1.SoldierRecord{},
+		Vehicles:      map[uint16]*v1.VehicleRecord{},
+		Markers:       map[string]*v1.MarkerRecord{},
+		PlacedObjects: map[uint16]*v1.PlacedObjectRecord{},
+	}
 }

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -570,8 +570,17 @@ func (b *Backend) BuildExport() v1.Export {
 }
 
 // buildExportUnlocked creates a v1 export from the current mission data.
-// Caller must hold at least b.mu.RLock.
+// Caller must hold at least b.mu.RLock. Materializes the full v1.Export
+// in memory; callers that only need to write JSON should use
+// buildMissionDataUnlocked with v1.Stream instead to bound peak memory.
 func (b *Backend) buildExportUnlocked() v1.Export {
+	return v1.Build(b.buildMissionDataUnlocked())
+}
+
+// buildMissionDataUnlocked returns the MissionData that describes the
+// current mission, suitable for passing to v1.Stream or v1.Build.
+// Caller must hold at least b.mu.RLock.
+func (b *Backend) buildMissionDataUnlocked() *v1.MissionData {
 	data := &v1.MissionData{
 		Mission:          b.mission,
 		World:            b.world,
@@ -617,5 +626,5 @@ func (b *Backend) buildExportUnlocked() v1.Export {
 		}
 	}
 
-	return v1.Build(data)
+	return data
 }


### PR DESCRIPTION
## Summary
- New `v1.Stream(w, data)` writes the export JSON directly to a writer, encoding one entity at a time so each entity's gap-filled positions can be GC'd before the next entity is built.
- `memory.Backend.exportJSON` routes through `Stream` instead of materializing a full `v1.Export` then calling `json.NewEncoder.Encode`.
- Wire format is unchanged — byte-equivalent to the old pipeline (verified by three structural tests that compare JSON output against `Build()` + `Encode`).
- `v1.Build()` is retained as the reference implementation for existing tests and any callers that want a struct.

## Why
A 3h 24min plane-heavy mission (3.7M soldier states, 2.4M vehicle states, 15k projectiles) crashed mid-save in v5.0.0-rc.4 because the gap-filled `[][]any` positions for every entity, materialized simultaneously by `Build()`, pushed the arma3server process past its container memory limit. The async save goroutine (from v5.0.0-rc.3) kept ArmA responsive but couldn't prevent the OOM.

Streaming bounds peak additional memory to the largest single entity's gap-fill — roughly `frames × 200 bytes`, about 25 MB for a 3-hour mission — instead of the sum across all entities, which was 2–4 GB for the crashing run. Other aggregates (events, markers, per-firer firelines) stay in memory but are orders of magnitude smaller.

## Changes
- `internal/storage/memory/export/v1/builder.go` — extracted `buildSoldierEntity` and `buildVehicleEntity` helpers. `Build()` now delegates to them. Pure refactor, no behavior change — existing tests pass unchanged.
- `internal/storage/memory/export/v1/stream.go` — new `Stream(w, data)` + its aggregate/helper functions.
- `internal/storage/memory/export/v1/stream_test.go` — byte-equivalence tests against `Build()` + `Encode`, plus a large-mission memory regression guard (200 entities × 20k frames through `io.Discard`, asserts heap growth stays under 256 MiB).
- `internal/storage/memory/memory.go` — split `buildExportUnlocked` into `buildMissionDataUnlocked` (returns `*MissionData`) and a thin wrapper that still returns `v1.Export` for the tests that use it.
- `internal/storage/memory/export.go` — `writeJSON` / `writeGzipJSON` now take `*v1.MissionData` and call `v1.Stream`.

## Test plan
- [x] `go test ./internal/storage/memory/...` — 100% green, including real file round-trip and large-mission memory guard
- [x] `go vet ./internal/... ./cmd/...` — clean
- [x] `go test ./...` — all packages green
- [ ] Manual: reproduce PabbeY's 3-hour plane mission scale on a dev server, confirm save completes instead of OOM-killing the process