### PR TITLE
fix: update entities with only non-empty names

### DIFF
--- a/internal/storage/memory/export/v1/builder.go
+++ b/internal/storage/memory/export/v1/builder.go
@@ -295,17 +295,17 @@ func Build(data *MissionData) Export {
 		}
 
 		marker := []any{
-			record.Marker.MarkerType,               // [0] type
-			record.Marker.Text,                     // [1] text
-			frameToV1(record.Marker.CaptureFrame),  // [2] startFrame
-			frameToV1(record.Marker.EndFrame),      // [3] endFrame (FrameForever(0) → -1, otherwise 0-based frame)
-			record.Marker.OwnerID,               // [4] playerId (entity ID of creating player, -1 for system markers)
-			markerColor,                         // [5] color (# prefix stripped for URL compatibility)
-			sideToIndex(record.Marker.Side),     // [6] sideIndex
-			posArray,                            // [7] positions
-			parseMarkerSize(record.Marker.Size), // [8] size
-			record.Marker.Shape,                 // [9] shape
-			record.Marker.Brush,                 // [10] brush
+			record.Marker.MarkerType,              // [0] type
+			record.Marker.Text,                    // [1] text
+			frameToV1(record.Marker.CaptureFrame), // [2] startFrame
+			frameToV1(record.Marker.EndFrame),     // [3] endFrame (FrameForever(0) → -1, otherwise 0-based frame)
+			record.Marker.OwnerID,                 // [4] playerId (entity ID of creating player, -1 for system markers)
+			markerColor,                           // [5] color (# prefix stripped for URL compatibility)
+			sideToIndex(record.Marker.Side),       // [6] sideIndex
+			posArray,                              // [7] positions
+			parseMarkerSize(record.Marker.Size),   // [8] size
+			record.Marker.Shape,                   // [9] shape
+			record.Marker.Brush,                   // [10] brush
 		}
 
 		export.Markers = append(export.Markers, marker)
@@ -343,17 +343,17 @@ func Build(data *MissionData) Export {
 		}
 
 		marker := []any{
-			markerType,                                  // [0] type
-			record.PlacedObject.DisplayName,             // [1] text
-			frameToV1(record.PlacedObject.JoinFrame),    // [2] startFrame
-			placedEndFrame,                         // [3] endFrame
-			int(record.PlacedObject.OwnerID),       // [4] playerId
-			"D96600",                               // [5] color (orange hex)
-			-1,                                     // [6] sideIndex (GLOBAL — visible to all sides)
-			posArray,                               // [7] positions
-			[]float64{1, 1},                        // [8] size
-			"ICON",                                 // [9] shape
-			"Solid",                                // [10] brush
+			markerType,                               // [0] type
+			record.PlacedObject.DisplayName,          // [1] text
+			frameToV1(record.PlacedObject.JoinFrame), // [2] startFrame
+			placedEndFrame,                           // [3] endFrame
+			int(record.PlacedObject.OwnerID),         // [4] playerId
+			"D96600",                                 // [5] color (orange hex)
+			-1,                                       // [6] sideIndex (GLOBAL — visible to all sides)
+			posArray,                                 // [7] positions
+			[]float64{1, 1},                          // [8] size
+			"ICON",                                   // [9] shape
+			"Solid",                                  // [10] brush
 		}
 
 		_ = id // keyed by ID in the map, used for uniqueness
@@ -437,17 +437,17 @@ func Build(data *MissionData) Export {
 			}
 
 			marker := []any{
-				markerType,                   // [0] type
-				text,                         // [1] text
-				frameToV1(pe.CaptureFrame),   // [2] startFrame
-				projEndFrame,                 // [3] endFrame
-				int(pe.FirerObjectID),        // [4] playerId
-				color,                        // [5] color
-				-1,                           // [6] sideIndex (GLOBAL)
-				posArray,                     // [7] positions
-				[]float64{1, 1},              // [8] size
-				"ICON",                       // [9] shape
-				"Solid",                      // [10] brush
+				markerType,                 // [0] type
+				text,                       // [1] text
+				frameToV1(pe.CaptureFrame), // [2] startFrame
+				projEndFrame,               // [3] endFrame
+				int(pe.FirerObjectID),      // [4] playerId
+				color,                      // [5] color
+				-1,                         // [6] sideIndex (GLOBAL)
+				posArray,                   // [7] positions
+				[]float64{1, 1},            // [8] size
+				"ICON",                     // [9] shape
+				"Solid",                    // [10] brush
 			}
 
 			export.Markers = append(export.Markers, marker)
@@ -607,7 +607,9 @@ func buildSoldierEntity(record *SoldierRecord, maxFrame core.Frame, extraFirelin
 	for _, state := range record.States {
 		if state.IsPlayer {
 			isPlayer = true
-			name = state.UnitName
+			if state.UnitName != "" {
+				name = state.UnitName
+			}
 		}
 	}
 

--- a/internal/storage/memory/export_test.go
+++ b/internal/storage/memory/export_test.go
@@ -1303,6 +1303,62 @@ func TestPlayerTakeoverUpdatesEntityMetadata(t *testing.T) {
 	assert.Equal(t, 1, entity.Positions[19][5])
 }
 
+func TestPlayerTakeoverIgnoresMissingNameEntityMetadata(t *testing.T) {
+	b := New(config.MemoryConfig{}, nil)
+
+	require.NoError(t, b.StartMission(&core.Mission{MissionName: "Test", StartTime: time.Now()}, &core.World{WorldName: "Test"}))
+
+	// Register as AI unit initially
+	require.NoError(t, b.AddSoldier(&core.Soldier{
+		ID: 5, UnitName: "Habibzai", GroupID: "Alpha", Side: "EAST", IsPlayer: false, JoinFrame: 1,
+	}))
+
+	// First few frames: AI walking around
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{
+		SoldierID: 5, CaptureFrame: 1, Position: core.Position3D{X: 100, Y: 200, Z: 10},
+		Bearing: 45, Lifestate: 1, UnitName: "Habibzai", IsPlayer: false, CurrentRole: "Rifleman",
+		GroupID: "Alpha", Side: "EAST",
+	}))
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{
+		SoldierID: 5, CaptureFrame: 10, Position: core.Position3D{X: 110, Y: 210, Z: 10},
+		Bearing: 50, Lifestate: 1, UnitName: "Habibzai", IsPlayer: false, CurrentRole: "Rifleman",
+		GroupID: "Alpha", Side: "EAST",
+	}))
+
+	// Player takes over the AI unit mid-game and latest state without name (player died)
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{
+		SoldierID: 5, CaptureFrame: 20, Position: core.Position3D{X: 120, Y: 220, Z: 10},
+		Bearing: 55, Lifestate: 1, UnitName: "zigster", IsPlayer: true, CurrentRole: "Rifleman",
+		GroupID: "Alpha", Side: "EAST",
+	}))
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{
+		SoldierID: 5, CaptureFrame: 30, Position: core.Position3D{X: 130, Y: 230, Z: 10},
+		Bearing: 60, Lifestate: 0, UnitName: "", IsPlayer: true, CurrentRole: "Rifleman",
+		GroupID: "Alpha", Side: "EAST",
+	}))
+
+	export := b.BuildExport()
+
+	// Entity metadata should reflect the player takeover
+	require.Len(t, export.Entities, 6) // indices 0-5
+	entity := export.Entities[5]
+
+	assert.Equal(t, 1, entity.IsPlayer, "entity should be marked as player after takeover")
+	assert.Equal(t, "zigster", entity.Name, "entity name should be the player's name")
+
+	// Per-frame data should still be correct (dense gap-fill: 30 entries total)
+	require.Len(t, entity.Positions, 30)
+	// Frame 0: AI (state@1, covers v1 0-8)
+	assert.Equal(t, "Habibzai", entity.Positions[0][4])
+	assert.Equal(t, 0, entity.Positions[0][5])
+	// Frame 19: player took over (state@20, covers v1 19-28)
+	assert.Equal(t, "zigster", entity.Positions[19][4])
+	assert.Equal(t, 1, entity.Positions[19][5])
+	// Frame 29
+	assert.Equal(t, "", entity.Positions[29][4])
+	assert.Equal(t, 1, entity.Positions[29][5])
+}
+
 func TestExportJSON_MkdirAllError(t *testing.T) {
 	// /dev/null is a file, not a directory — MkdirAll for a subdir will fail
 	b := New(config.MemoryConfig{

--- a/internal/worker/dispatch.go
+++ b/internal/worker/dispatch.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/OCAP2/extension/v5/internal/dispatcher"
-	"github.com/OCAP2/extension/v5/pkg/core"
 	"github.com/OCAP2/extension/v5/internal/parser"
+	"github.com/OCAP2/extension/v5/pkg/core"
 )
 
 // RegisterHandlers registers all event handlers with the dispatcher.
@@ -136,10 +136,12 @@ func (m *Manager) handleSoldierState(e dispatcher.Event) (any, error) {
 		obj.Side = soldier.Side
 	}
 
-	// Player takeover: update cached entity when isPlayer escalates or player name changes
+	// Player takeover: update cached entity when isPlayer escalates or player name changes and non-empty
 	if obj.IsPlayer && (!soldier.IsPlayer || soldier.UnitName != obj.UnitName) {
 		soldier.IsPlayer = true
-		soldier.UnitName = obj.UnitName
+		if obj.UnitName != "" {
+			soldier.UnitName = obj.UnitName
+		}
 		m.deps.EntityCache.UpdateSoldier(soldier)
 	}
 

--- a/internal/worker/dispatch.go
+++ b/internal/worker/dispatch.go
@@ -137,7 +137,7 @@ func (m *Manager) handleSoldierState(e dispatcher.Event) (any, error) {
 	}
 
 	// Player takeover: update cached entity when isPlayer escalates or player name changes and non-empty
-	if obj.IsPlayer && (!soldier.IsPlayer || soldier.UnitName != obj.UnitName) {
+	if obj.IsPlayer && (!soldier.IsPlayer || (obj.UnitName != "" && soldier.UnitName != obj.UnitName)) {
 		soldier.IsPlayer = true
 		if obj.UnitName != "" {
 			soldier.UnitName = obj.UnitName


### PR DESCRIPTION
The problem with empty names can be appear when player died and after that all states contain no name (just empty string), so old logic updates entity's correct name with just empty string, and new one checks if the state name is not empty.

Why empty string as name received:
_addons\recorder\fnc_captureLoop.sqf
lines 163-181_
```sqf
private _unitData = [
  (_x getVariable QGVARMAIN(id)), //1
  _pos, //2
  round getDir _x, //3
  _lifeState, //4
  BOOL((vehicle _x) isNotEqualTo _x),  //5
  if (alive _x) then {name _x} else {""}, //6
  BOOL(isPlayer _x), //7
  _unitRole, //8
  0, // frame placeholder for comparison (set before sending) 9
  if (GVAR(hasACEStableVitals)) then {BOOL([_x] call ace_medical_status_fnc_hasStableVitals)} else {true}, // 10
  if (GVAR(hasACEIsBeingDragged)) then {BOOL([_x] call ace_medical_status_fnc_isBeingDragged)} else {false}, // 11
  _scoresStr, // scores 12
  _x call CBA_fnc_vehicleRole, // vehicle role 13
  if (!isNull _parent) then {_parent getVariable [QGVARMAIN(id), -1]} else {-1}, // 14
  stance _x, // 15
  groupID _unitGroup, // 16 group name (dynamic)
  str side _unitGroup // 17 side (dynamic)
];
```
Especially, the next line:
```sqf
if (alive _x) then {name _x} else {""}
```