### PR TITLE
fix: report recording duration in seconds, not milliseconds

### DIFF
--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -535,7 +535,8 @@ func (b *Backend) computeExportMetadata() core.UploadMetadata {
 		}
 	}
 
-	duration := float64(endFrame) * float64(b.mission.CaptureDelay) / 1000.0
+	// CaptureDelay is the per-frame interval in seconds, not milliseconds.
+	duration := float64(endFrame) * float64(b.mission.CaptureDelay)
 
 	meta := core.UploadMetadata{
 		WorldName:       b.world.WorldName,

--- a/internal/storage/memory/memory_test.go
+++ b/internal/storage/memory/memory_test.go
@@ -760,8 +760,51 @@ func TestGetExportMetadata(t *testing.T) {
 	assert.Equal(t, "Altis", meta.WorldName)
 	assert.Equal(t, "Test Mission", meta.MissionName)
 	assert.Equal(t, "TvT", meta.Tag)
-	// Duration = endFrame * captureDelay / 1000 = 100 * 1.0 / 1000 = 0.1
-	assert.Equal(t, 0.1, meta.MissionDuration)
+	assert.Equal(t, 100.0, meta.MissionDuration)
+}
+
+// Regression: captureDelay is in seconds, so a short recording must not
+// report a near-zero duration ("0m 0s" in the web viewer).
+func TestGetExportMetadata_DurationUsesCaptureDelaySeconds(t *testing.T) {
+	b := New(config.MemoryConfig{}, nil)
+
+	require.NoError(t, b.StartMission(&core.Mission{
+		MissionName:  "Short Recording",
+		CaptureDelay: 1.0, // seconds per frame
+	}, &core.World{WorldName: "Altis"}))
+
+	s := &core.Soldier{ID: 1}
+	require.NoError(t, b.AddSoldier(s))
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{
+		SoldierID:    s.ID,
+		CaptureFrame: 71,
+	}))
+
+	meta := b.GetExportMetadata()
+
+	assert.Equal(t, 71.0, meta.MissionDuration)
+}
+
+// Sub-second capture intervals (e.g. 10 fps) must scale correctly.
+func TestGetExportMetadata_DurationFractionalCaptureDelay(t *testing.T) {
+	b := New(config.MemoryConfig{}, nil)
+
+	require.NoError(t, b.StartMission(&core.Mission{
+		MissionName:  "High Frequency",
+		CaptureDelay: 0.1, // 10 frames per second
+	}, &core.World{WorldName: "Altis"}))
+
+	s := &core.Soldier{ID: 1}
+	require.NoError(t, b.AddSoldier(s))
+	require.NoError(t, b.RecordSoldierState(&core.SoldierState{
+		SoldierID:    s.ID,
+		CaptureFrame: 3937,
+	}))
+
+	meta := b.GetExportMetadata()
+
+	// 3937 × 0.1s = 393.7s; InDelta absorbs float32 rounding.
+	assert.InDelta(t, 393.7, meta.MissionDuration, 0.001)
 }
 
 func TestGetExportMetadata_VehicleEndFrame(t *testing.T) {
@@ -794,8 +837,8 @@ func TestGetExportMetadata_VehicleEndFrame(t *testing.T) {
 
 	meta := b.GetExportMetadata()
 
-	// Duration should be based on vehicle's higher frame: 200 * 1.0 / 1000 = 0.2
-	assert.Equal(t, 0.2, meta.MissionDuration)
+	// endFrame is the highest frame across entities: the vehicle's 200, not the soldier's 50.
+	assert.Equal(t, 200.0, meta.MissionDuration)
 }
 
 func TestGetExportMetadata_EmptyMission(t *testing.T) {
@@ -895,8 +938,8 @@ func TestGetExportMetadata_PlacedEventEndFrame(t *testing.T) {
 
 	meta := b.GetExportMetadata()
 
-	// Duration should be based on placed event's higher frame: 300 * 1.0 / 1000 = 0.3
-	assert.Equal(t, 0.3, meta.MissionDuration)
+	// endFrame is the highest frame across entities: the placed object's event at 300.
+	assert.Equal(t, 300.0, meta.MissionDuration)
 }
 
 func TestComputeExportMetadata_NilMission(t *testing.T) {


### PR DESCRIPTION
## Problem

Community reports that **all newly uploaded/recorded missions show `0m 0s`** duration in the web viewer (a 14-minute recording showed `0m 1s`).

Root cause is in `computeExportMetadata` (`internal/storage/memory/memory.go`):

```go
duration := float64(endFrame) * float64(b.mission.CaptureDelay) / 1000.0
```

`CaptureDelay` is the interval between captured frames **in seconds** (default `1.0`; parsed straight from the addon's `captureDelay` in `parse_mission.go` and written verbatim to the JSON manifest's `captureDelay` field). The `/1000.0` treats it as milliseconds, so the `missionDuration` uploaded to the web is **~1000× too small**:

- 72 frames @ 1.0s → `0.072s` → rounds to **`0m 0s`**
- ~840 frames @ 1.0s (14 min) → `0.84s` → **`0m 1s`**

This matches the community diagnosis pointing at the `/1000` line.

## Why it isn't seen everywhere

The web recomputes duration from the manifest during its **conversion** step, where `captureDelay` is correctly in seconds — so recordings that go through conversion display correctly and **mask** this bug. Only **direct / no-conversion uploads** (which trust the extension-supplied `missionDuration` header) show the bad value. That's why "recordings using conversion are fine" but manual/in-game uploads are not.

## Fix

Remove the erroneous `/1000.0`. Duration is simply `frameCount × captureDelay` (seconds). Added regression tests for 1.0s and 0.1s capture intervals.

Verified against real recording files:

| Recording | endFrame | captureDelay | Before (`/1000`) | After |
|---|---|---|---|---|
| short training | 71 | 1.0 | 0.071s → `0m 0s` | 71s → `1m 11s` |
| high-frequency | 3937 | 0.1 | 0.39s → `0m 0s` | 393.7s → `6m 34s` |

## Notes for reviewers

- **One-frame discrepancy (deferred, separate call):** the web's conversion-path recompute uses `(endFrame+1) × captureDelay`, while this fix keeps the extension's long-standing `endFrame × captureDelay`. So the same recording can differ by one frame between the conversion path and the header path. The extension never had the `+1` (it predates this bug), so I did **not** add it here to avoid coupling the extension to a web implementation detail. For reference, a real `29th-Training` recording (`endFrame=71`, `captureDelay=1`) spanned ~72.86s by its in-game `times` array — i.e. `endFrame+1`=72s is marginally closer than 71s. Aligning the two paths is worth a follow-up decision but is out of scope here.
- The separate `ocap_version "0.0.0"` report is a build-ldflags issue, **not** addressed by this PR.

## Test plan

- [x] `go test ./...` — full suite green
- [x] `go vet ./internal/...` — clean
- [x] New regression tests fail before the fix (`0.071`, `0.39`) and pass after (`71`, `393.7`)